### PR TITLE
Add web env example and doc

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000

--- a/web/README.md
+++ b/web/README.md
@@ -10,3 +10,19 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Environment Variables
+
+Create a `.env` file based on `.env.example` and set the API base URL used by axios:
+
+```bash
+cp .env.example .env
+```
+
+The variable is accessed via `import.meta.env`:
+
+```
+VITE_API_URL=http://localhost:3000
+```
+
+Adjust the URL if your backend runs on a different host/port.


### PR DESCRIPTION
## Summary
- add a sample env file for the web project
- document how to use the `.env` file

## Testing
- `npm run lint` in `web` *(fails: Cannot find package '@eslint/js')*
- `npm test` in `api` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_687130a73354832b94295e5089a91eef