### PR TITLE
Hash passwords before saving

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,10 +1,10 @@
 import { PrismaClient } from "@prisma/client";
-import * as bcrypt from "bcrypt";
+import { hashPassword } from "../src/common/hash";
 
 const prisma = new PrismaClient();
 
 async function main() {
-  const hash = (pwd: string) => bcrypt.hash(pwd, 10);
+  const hash = hashPassword;
 
   // Buat user satu per satu agar dapat userId
   const admin = await prisma.user.create({

--- a/api/src/common/hash.ts
+++ b/api/src/common/hash.ts
@@ -1,0 +1,7 @@
+import * as bcrypt from "bcrypt";
+
+export const SALT_ROUNDS = 10;
+
+export function hashPassword(password: string) {
+  return bcrypt.hash(password, SALT_ROUNDS);
+}

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
+import { hashPassword } from "../common/hash";
 
 @Injectable()
 export class UsersService {
@@ -12,11 +13,17 @@ export class UsersService {
     return this.prisma.user.findUnique({ where: { id } });
   }
 
-  create(data: any) {
+  async create(data: any) {
+    if (data.password) {
+      data.password = await hashPassword(data.password);
+    }
     return this.prisma.user.create({ data });
   }
 
-  update(id: number, data: any) {
+  async update(id: number, data: any) {
+    if (data.password) {
+      data.password = await hashPassword(data.password);
+    }
     return this.prisma.user.update({ where: { id }, data });
   }
 


### PR DESCRIPTION
## Summary
- hash passwords consistently via new `hashPassword` utility
- use hashing in `UsersService` create and update
- reuse the same hashing helper in the seed script

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `api` *(fails: jest not found)*
- `npm run build` in `api` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_b_687134ebfdd8832bb151e6a8ebba4046