### PR TITLE
Verify team leader before task creation

### DIFF
--- a/api/src/kegiatan/master-kegiatan.controller.ts
+++ b/api/src/kegiatan/master-kegiatan.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Post, Get, Body, UseGuards } from "@nestjs/common";
+import { Controller, Post, Get, Body, UseGuards, Req } from "@nestjs/common";
+import { Request } from "express";
 import { MasterKegiatanService } from "./master-kegiatan.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
@@ -11,8 +12,8 @@ export class MasterKegiatanController {
 
   @Post()
   @Roles("ketua")
-  create(@Body() body: any) {
-    return this.masterService.create(body);
+  create(@Body() body: any, @Req() req: Request) {
+    return this.masterService.create(body, (req.user as any).userId);
   }
 
   @Get()

--- a/api/src/kegiatan/master-kegiatan.service.ts
+++ b/api/src/kegiatan/master-kegiatan.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, ForbiddenException } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 
 @Injectable()
@@ -8,7 +8,13 @@ export class MasterKegiatanService {
     return this.prisma.masterKegiatan.findMany();
   }
 
-  create(data: any) {
+  async create(data: any, userId: number) {
+    const leader = await this.prisma.member.findFirst({
+      where: { teamId: data.teamId, userId, is_leader: true },
+    });
+    if (!leader) {
+      throw new ForbiddenException("bukan ketua tim kegiatan ini");
+    }
     return this.prisma.masterKegiatan.create({ data });
   }
 }

--- a/api/src/kegiatan/penugasan.controller.ts
+++ b/api/src/kegiatan/penugasan.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Post, Get, Body, UseGuards } from "@nestjs/common";
+import { Controller, Post, Get, Body, UseGuards, Req } from "@nestjs/common";
+import { Request } from "express";
 import { PenugasanService } from "./penugasan.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
@@ -12,8 +13,8 @@ export class PenugasanController {
 
   @Post()
   @Roles("ketua")
-  assign(@Body() body: AssignPenugasanDto) {
-    return this.penugasanService.assign(body);
+  assign(@Body() body: AssignPenugasanDto, @Req() req: Request) {
+    return this.penugasanService.assign(body, (req.user as any).userId);
   }
 
   @Get()

--- a/api/src/kegiatan/penugasan.service.ts
+++ b/api/src/kegiatan/penugasan.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, ForbiddenException, BadRequestException } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 
 @Injectable()
@@ -8,7 +8,19 @@ export class PenugasanService {
     return this.prisma.penugasan.findMany();
   }
 
-  assign(data: any) {
+  async assign(data: any, userId: number) {
+    const master = await this.prisma.masterKegiatan.findUnique({
+      where: { id: data.kegiatanId },
+    });
+    if (!master) {
+      throw new BadRequestException("master kegiatan tidak ditemukan");
+    }
+    const leader = await this.prisma.member.findFirst({
+      where: { teamId: master.teamId, userId, is_leader: true },
+    });
+    if (!leader) {
+      throw new ForbiddenException("bukan ketua tim kegiatan ini");
+    }
     return this.prisma.penugasan.create({ data });
   }
 }


### PR DESCRIPTION
## Summary
- check team leadership in MasterKegiatanService before creating a master activity
- check team leadership in PenugasanService before assigning a task
- pass current user ID from controllers to services

## Testing
- `npm ci`
- `npx tsc --noEmit`
- `npm run build`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68713bb22d98832bb5786f05949ff1be