### PR TITLE
Use user from request in laporan

### DIFF
--- a/api/src/laporan/dto/add-tambahan.dto.ts
+++ b/api/src/laporan/dto/add-tambahan.dto.ts
@@ -14,6 +14,7 @@ export class AddTambahanDto {
   @IsString()
   bukti_link?: string;
 
+  @IsOptional()
   @IsInt()
-  userId!: number;
+  userId?: number;
 }

--- a/api/src/laporan/dto/submit-laporan.dto.ts
+++ b/api/src/laporan/dto/submit-laporan.dto.ts
@@ -18,6 +18,7 @@ export class SubmitLaporanDto {
   @IsString()
   catatan?: string;
 
+  @IsOptional()
   @IsInt()
-  pegawaiId!: number;
+  pegawaiId?: number;
 }

--- a/api/src/laporan/kegiatan-tambahan.controller.ts
+++ b/api/src/laporan/kegiatan-tambahan.controller.ts
@@ -3,10 +3,10 @@ import {
   Post,
   Get,
   Body,
-  Query,
   UseGuards,
-  ParseIntPipe,
+  Req,
 } from "@nestjs/common";
+import { Request } from "express";
 import { TambahanService } from "./kegiatan-tambahan.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { AddTambahanDto } from "./dto/add-tambahan.dto";
@@ -17,12 +17,14 @@ export class TambahanController {
   constructor(private readonly tambahanService: TambahanService) {}
 
   @Post()
-  add(@Body() body: AddTambahanDto) {
-    return this.tambahanService.add(body);
+  add(@Body() body: AddTambahanDto, @Req() req: Request) {
+    const userId = (req.user as any).userId;
+    return this.tambahanService.add({ ...body, userId });
   }
 
   @Get()
-  getByUser(@Query("user_id", ParseIntPipe) userId: number) {
+  getByUser(@Req() req: Request) {
+    const userId = (req.user as any).userId;
     return this.tambahanService.getByUser(userId);
   }
 }

--- a/api/src/laporan/laporan.controller.ts
+++ b/api/src/laporan/laporan.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Post, Get, Body, Query, UseGuards } from "@nestjs/common";
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Query,
+  UseGuards,
+  Req,
+} from "@nestjs/common";
+import { Request } from "express";
 import { LaporanService } from "./laporan.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { SubmitLaporanDto } from "./dto/submit-laporan.dto";
@@ -9,8 +18,9 @@ export class LaporanController {
   constructor(private readonly laporanService: LaporanService) {}
 
   @Post()
-  submit(@Body() body: SubmitLaporanDto) {
-    return this.laporanService.submit(body);
+  submit(@Body() body: SubmitLaporanDto, @Req() req: Request) {
+    const userId = (req.user as any).userId;
+    return this.laporanService.submit({ ...body, pegawaiId: userId });
   }
 
   @Get()


### PR DESCRIPTION
## Summary
- allow optional userId/pegawaiId fields
- attach authenticated userId when creating laporan harian or kegiatan tambahan
- fetch kegiatan tambahan for the logged-in user

## Testing
- `npm run build`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68713cb98220832bbeb071990931bffd