### PR TITLE
Add filtering to monitoring APIs

### DIFF
--- a/api/src/monitoring/monitoring.controller.ts
+++ b/api/src/monitoring/monitoring.controller.ts
@@ -4,11 +4,13 @@ import {
   Get,
   Query,
   UseGuards,
+  Req,
 } from "@nestjs/common";
 import { MonitoringService } from "./monitoring.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
 import { Roles } from "../common/guards/roles.decorator";
+import { Request } from "express";
 
 @Controller("monitoring")
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -16,29 +18,56 @@ export class MonitoringController {
   constructor(private readonly monitoringService: MonitoringService) {}
 
   @Get("harian")
-  @Roles("ketua", "pimpinan", "admin")
-  harian(@Query("tanggal") tanggal?: string) {
+  @Roles("ketua", "pimpinan", "admin", "anggota")
+  harian(
+    @Query("tanggal") tanggal?: string,
+    @Req() req?: Request,
+    @Query("teamId") teamId?: string,
+    @Query("userId") userId?: string,
+  ) {
     if (!tanggal) {
       throw new BadRequestException("query 'tanggal' diperlukan");
     }
-    return this.monitoringService.harian(tanggal);
+    const role = (req?.user as any)?.role;
+    let tId = teamId ? parseInt(teamId, 10) : undefined;
+    let uId = userId ? parseInt(userId, 10) : undefined;
+    if (role === "anggota") uId = (req?.user as any).userId;
+    return this.monitoringService.harian(tanggal, tId, uId);
   }
 
   @Get("mingguan")
-  @Roles("ketua", "pimpinan", "admin")
-  mingguan(@Query("minggu") minggu?: string) {
+  @Roles("ketua", "pimpinan", "admin", "anggota")
+  mingguan(
+    @Query("minggu") minggu?: string,
+    @Req() req?: Request,
+    @Query("teamId") teamId?: string,
+    @Query("userId") userId?: string,
+  ) {
     if (!minggu) {
       throw new BadRequestException("query 'minggu' diperlukan");
     }
-    return this.monitoringService.mingguan(minggu);
+    const role = (req?.user as any)?.role;
+    let tId = teamId ? parseInt(teamId, 10) : undefined;
+    let uId = userId ? parseInt(userId, 10) : undefined;
+    if (role === "anggota") uId = (req?.user as any).userId;
+    return this.monitoringService.mingguan(minggu, tId, uId);
   }
 
   @Get("bulanan")
-  @Roles("ketua", "pimpinan", "admin")
-  bulanan(@Query("bulan") bulan?: string) {
+  @Roles("ketua", "pimpinan", "admin", "anggota")
+  bulanan(
+    @Query("bulan") bulan?: string,
+    @Req() req?: Request,
+    @Query("teamId") teamId?: string,
+    @Query("userId") userId?: string,
+  ) {
     if (!bulan) {
       throw new BadRequestException("query 'bulan' diperlukan");
     }
-    return this.monitoringService.bulanan(bulan);
+    const role = (req?.user as any)?.role;
+    let tId = teamId ? parseInt(teamId, 10) : undefined;
+    let uId = userId ? parseInt(userId, 10) : undefined;
+    if (role === "anggota") uId = (req?.user as any).userId;
+    return this.monitoringService.bulanan(bulan, tId, uId);
   }
 }

--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -22,10 +22,18 @@ const Dashboard = () => {
       const bulan = today.toISOString().slice(0, 7);
 
       try {
+        const filters = {};
+        if (user?.role === "anggota") {
+          filters.userId = user.id;
+        }
+        if (user?.role === "ketua" && user?.teamId) {
+          filters.teamId = user.teamId;
+        }
+
         const [dailyRes, weeklyRes, monthlyRes] = await Promise.all([
-          axios.get("/monitoring/harian", { params: { tanggal } }),
-          axios.get("/monitoring/mingguan", { params: { minggu } }),
-          axios.get("/monitoring/bulanan", { params: { bulan } }),
+          axios.get("/monitoring/harian", { params: { tanggal, ...filters } }),
+          axios.get("/monitoring/mingguan", { params: { minggu, ...filters } }),
+          axios.get("/monitoring/bulanan", { params: { bulan, ...filters } }),
         ]);
 
         setDailyData(dailyRes.data);


### PR DESCRIPTION
## Summary
- allow optional `teamId`/`userId` filters in MonitoringService
- update MonitoringController to forward filters based on login role
- send new params from dashboard page when requesting monitoring data

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in api *(fails: missing eslint config)*
- `npm run lint` in web *(fails: cannot find '@eslint/js')*
- `npm test` in web *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68713dc52614832ba3ce85c59044aaf4