### PR TITLE
Add Master Task List feature

### DIFF
--- a/api/src/kegiatan/master-kegiatan.controller.ts
+++ b/api/src/kegiatan/master-kegiatan.controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Post, Get, Body, UseGuards, Req } from "@nestjs/common";
+import {
+  Controller,
+  Post,
+  Get,
+  Put,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+  Req,
+  ParseIntPipe,
+} from "@nestjs/common";
 import { Request } from "express";
 import { MasterKegiatanService } from "./master-kegiatan.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
@@ -18,5 +29,19 @@ export class MasterKegiatanController {
   @Get()
   findAll() {
     return this.masterService.findAll();
+  }
+
+  @Put(":id")
+  update(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() body: any,
+    @Req() req: Request,
+  ) {
+    return this.masterService.update(id, body, (req.user as any).userId);
+  }
+
+  @Delete(":id")
+  remove(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
+    return this.masterService.remove(id, (req.user as any).userId);
   }
 }

--- a/api/src/kegiatan/master-kegiatan.service.ts
+++ b/api/src/kegiatan/master-kegiatan.service.ts
@@ -4,8 +4,9 @@ import { PrismaService } from "../prisma.service";
 @Injectable()
 export class MasterKegiatanService {
   constructor(private prisma: PrismaService) {}
+
   findAll() {
-    return this.prisma.masterKegiatan.findMany();
+    return this.prisma.masterKegiatan.findMany({ include: { team: true } });
   }
 
   async create(data: any, userId: number) {
@@ -15,6 +16,32 @@ export class MasterKegiatanService {
     if (!leader) {
       throw new ForbiddenException("bukan ketua tim kegiatan ini");
     }
-    return this.prisma.masterKegiatan.create({ data });
+    return this.prisma.masterKegiatan.create({ data, include: { team: true } });
+  }
+
+  async update(id: number, data: any, userId: number) {
+    const existing = await this.prisma.masterKegiatan.findUnique({
+      where: { id },
+    });
+    if (!existing) throw new Error("not found");
+    const leader = await this.prisma.member.findFirst({
+      where: { teamId: existing.teamId, userId, is_leader: true },
+    });
+    if (!leader) throw new ForbiddenException("bukan ketua tim kegiatan ini");
+    return this.prisma.masterKegiatan.update({
+      where: { id },
+      data,
+      include: { team: true },
+    });
+  }
+
+  async remove(id: number, userId: number) {
+    const existing = await this.prisma.masterKegiatan.findUnique({ where: { id } });
+    if (!existing) throw new Error("not found");
+    const leader = await this.prisma.member.findFirst({
+      where: { teamId: existing.teamId, userId, is_leader: true },
+    });
+    if (!leader) throw new ForbiddenException("bukan ketua tim kegiatan ini");
+    return this.prisma.masterKegiatan.delete({ where: { id } });
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.10.0",
+        "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -3276,6 +3277,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.10.0",
+    "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -14,9 +14,11 @@ export default function Sidebar({ mobileOpen, setMobileOpen }) {
     links.push({ to: "/teams", label: "Kelola Tim" });
   }
 
-  if (user?.role === "ketua") {
+  if (user?.role === "ketua" || user?.role === "admin") {
     links.push({ to: "/master-kegiatan", label: "Master Kegiatan" });
-    links.push({ to: "/penugasan", label: "Penugasan Mingguan" });
+    if (user?.role === "ketua") {
+      links.push({ to: "/penugasan", label: "Penugasan Mingguan" });
+    }
   }
 
   if (user?.role === "anggota" || user?.role === "ketua") {

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import Swal from "sweetalert2";
+import { useAuth } from "../auth/useAuth";
+
+export default function MasterKegiatanPage() {
+  const { user } = useAuth();
+  const [items, setItems] = useState([]);
+  const [teams, setTeams] = useState([]);
+  const [form, setForm] = useState({ teamId: "", nama_kegiatan: "" });
+  const [editing, setEditing] = useState(null);
+  const [showForm, setShowForm] = useState(false);
+
+  useEffect(() => {
+    fetchItems();
+    fetchTeams();
+  }, []);
+
+  const fetchItems = async () => {
+    try {
+      const res = await axios.get("/master-kegiatan");
+      setItems(res.data);
+    } catch (err) {
+      console.error("Gagal mengambil master kegiatan", err);
+    }
+  };
+
+  const fetchTeams = async () => {
+    try {
+      const res = await axios.get("/teams");
+      setTeams(res.data);
+    } catch (err) {
+      console.error("Gagal mengambil tim", err);
+    }
+  };
+
+  const openCreate = () => {
+    setEditing(null);
+    setForm({ teamId: "", nama_kegiatan: "" });
+    setShowForm(true);
+  };
+
+  const openEdit = (item) => {
+    setEditing(item);
+    setForm({ teamId: item.teamId, nama_kegiatan: item.nama_kegiatan });
+    setShowForm(true);
+  };
+
+  const saveItem = async () => {
+    try {
+      if (editing) {
+        await axios.put(`/master-kegiatan/${editing.id}`, form);
+      } else {
+        await axios.post("/master-kegiatan", form);
+      }
+      setShowForm(false);
+      setEditing(null);
+      fetchItems();
+      Swal.fire("Berhasil", "Kegiatan disimpan", "success");
+    } catch (err) {
+      console.error("Gagal menyimpan kegiatan", err);
+    }
+  };
+
+  const deleteItem = async (item) => {
+    const r = await Swal.fire({
+      title: "Hapus kegiatan ini?",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonText: "Hapus",
+    });
+    if (!r.isConfirmed) return;
+    try {
+      await axios.delete(`/master-kegiatan/${item.id}`);
+      fetchItems();
+      Swal.fire("Dihapus", "Kegiatan berhasil dihapus", "success");
+    } catch (err) {
+      console.error("Gagal menghapus kegiatan", err);
+    }
+  };
+
+  if (!["ketua", "admin"].includes(user?.role)) {
+    return (
+      <div className="p-6 text-center">Anda tidak memiliki akses ke halaman ini.</div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Master Kegiatan</h1>
+        <button
+          onClick={openCreate}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
+        >
+          Tambah Kegiatan
+        </button>
+      </div>
+
+      <table className="min-w-full bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow">
+        <thead>
+          <tr className="bg-gray-200 dark:bg-gray-700 text-left text-sm uppercase">
+            <th className="px-4 py-2">ID</th>
+            <th className="px-4 py-2">Tim</th>
+            <th className="px-4 py-2">Nama Kegiatan</th>
+            <th className="px-4 py-2">Aksi</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.id} className="border-t dark:border-gray-700">
+              <td className="px-4 py-2">{item.id}</td>
+              <td className="px-4 py-2">{item.team?.nama_tim || item.teamId}</td>
+              <td className="px-4 py-2">{item.nama_kegiatan}</td>
+              <td className="px-4 py-2 space-x-2">
+                <button
+                  onClick={() => openEdit(item)}
+                  className="px-3 py-1 text-sm bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => deleteItem(item)}
+                  className="px-3 py-1 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                >
+                  Hapus
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {showForm && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md space-y-4 shadow-xl">
+            <h2 className="text-xl font-semibold mb-2">
+              {editing ? "Edit Kegiatan" : "Tambah Kegiatan"}
+            </h2>
+            <div className="space-y-2">
+              <div>
+                <label className="block text-sm mb-1">Tim</label>
+                <select
+                  value={form.teamId}
+                  onChange={(e) => setForm({ ...form, teamId: parseInt(e.target.value, 10) })}
+                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                >
+                  <option value="">Pilih tim</option>
+                  {teams.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {t.nama_tim}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm mb-1">Nama Kegiatan</label>
+                <input
+                  type="text"
+                  value={form.nama_kegiatan}
+                  onChange={(e) => setForm({ ...form, nama_kegiatan: e.target.value })}
+                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                />
+              </div>
+            </div>
+            <div className="flex justify-end space-x-2 pt-2">
+              <button
+                onClick={() => {
+                  setShowForm(false);
+                  setEditing(null);
+                }}
+                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
+              >
+                Batal
+              </button>
+              <button
+                onClick={saveItem}
+                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+              >
+                Simpan
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/routes/AppRoutes.jsx
+++ b/web/src/routes/AppRoutes.jsx
@@ -4,6 +4,7 @@ import Dashboard from "../pages/dashboard/Dashboard";
 import Layout from "../pages/layout/Layout";
 import { useAuth } from "../pages/auth/useAuth";
 import UsersPage from "../pages/users/UsersPage";
+import MasterKegiatanPage from "../pages/master/MasterKegiatanPage";
 
 function PrivateRoute({ children }) {
   const { token, user } = useAuth();
@@ -35,6 +36,7 @@ export default function AppRoutes() {
       >
         <Route index element={<Dashboard />} />
         <Route path="users" element={<UsersPage />} />
+        <Route path="master-kegiatan" element={<MasterKegiatanPage />} />
         {/* Tambahkan rute lainnya nanti di sini */}
       </Route>
     </Routes>


### PR DESCRIPTION
## Summary
- implement CRUD API for MasterKegiatan
- show `Master Kegiatan` menu for admin and team leads
- allow editing and deleting master kegiatan from the UI
- modernize modal design and display team names

## Testing
- `npm run lint` *(fails: 1 warning)*
- `npm run build`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68720dfa3edc832bb55c6904b3aa020c