### PR TITLE
Fix master kegiatan permissions and team fetch

### DIFF
--- a/api/src/kegiatan/master-kegiatan.controller.ts
+++ b/api/src/kegiatan/master-kegiatan.controller.ts
@@ -23,7 +23,8 @@ export class MasterKegiatanController {
 
   @Post()
   create(@Body() body: any, @Req() req: Request) {
-    return this.masterService.create(body, (req.user as any).userId);
+    const u = req.user as any;
+    return this.masterService.create(body, u.userId, u.role);
   }
 
   @Get()
@@ -43,11 +44,13 @@ export class MasterKegiatanController {
     @Body() body: any,
     @Req() req: Request,
   ) {
-    return this.masterService.update(id, body, (req.user as any).userId);
+    const u = req.user as any;
+    return this.masterService.update(id, body, u.userId, u.role);
   }
 
   @Delete(":id")
   remove(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
-    return this.masterService.remove(id, (req.user as any).userId);
+    const u = req.user as any;
+    return this.masterService.remove(id, u.userId, u.role);
   }
 }

--- a/api/src/kegiatan/master-kegiatan.service.ts
+++ b/api/src/kegiatan/master-kegiatan.service.ts
@@ -36,25 +36,29 @@ export class MasterKegiatanService {
     };
   }
 
-  async create(data: any, userId: number) {
-    const leader = await this.prisma.member.findFirst({
-      where: { teamId: data.teamId, userId, is_leader: true },
-    });
-    if (!leader) {
-      throw new ForbiddenException("bukan ketua tim kegiatan ini");
+  async create(data: any, userId: number, role: string) {
+    if (role !== "admin") {
+      const leader = await this.prisma.member.findFirst({
+        where: { teamId: data.teamId, userId, is_leader: true },
+      });
+      if (!leader) {
+        throw new ForbiddenException("bukan ketua tim kegiatan ini");
+      }
     }
     return this.prisma.masterKegiatan.create({ data, include: { team: true } });
   }
 
-  async update(id: number, data: any, userId: number) {
+  async update(id: number, data: any, userId: number, role: string) {
     const existing = await this.prisma.masterKegiatan.findUnique({
       where: { id },
     });
     if (!existing) throw new Error("not found");
-    const leader = await this.prisma.member.findFirst({
-      where: { teamId: existing.teamId, userId, is_leader: true },
-    });
-    if (!leader) throw new ForbiddenException("bukan ketua tim kegiatan ini");
+    if (role !== "admin") {
+      const leader = await this.prisma.member.findFirst({
+        where: { teamId: existing.teamId, userId, is_leader: true },
+      });
+      if (!leader) throw new ForbiddenException("bukan ketua tim kegiatan ini");
+    }
     return this.prisma.masterKegiatan.update({
       where: { id },
       data,
@@ -62,13 +66,15 @@ export class MasterKegiatanService {
     });
   }
 
-  async remove(id: number, userId: number) {
+  async remove(id: number, userId: number, role: string) {
     const existing = await this.prisma.masterKegiatan.findUnique({ where: { id } });
     if (!existing) throw new Error("not found");
-    const leader = await this.prisma.member.findFirst({
-      where: { teamId: existing.teamId, userId, is_leader: true },
-    });
-    if (!leader) throw new ForbiddenException("bukan ketua tim kegiatan ini");
+    if (role !== "admin") {
+      const leader = await this.prisma.member.findFirst({
+        where: { teamId: existing.teamId, userId, is_leader: true },
+      });
+      if (!leader) throw new ForbiddenException("bukan ketua tim kegiatan ini");
+    }
     return this.prisma.masterKegiatan.delete({ where: { id } });
   }
 }

--- a/api/src/teams/teams.controller.ts
+++ b/api/src/teams/teams.controller.ts
@@ -8,11 +8,13 @@ import {
   Body,
   UseGuards,
   ParseIntPipe,
+  Req,
 } from "@nestjs/common";
 import { TeamsService } from "./teams.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
 import { Roles } from "../common/guards/roles.decorator";
+import { Request } from "express";
 
 @Controller("teams")
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -20,9 +22,12 @@ export class TeamsController {
   constructor(private teamsService: TeamsService) {}
 
   @Get()
-  @Roles("admin")
-  findAll() {
-    return this.teamsService.findAll();
+  findAll(@Req() req: Request) {
+    const { user } = req as any;
+    if (user.role === "admin") {
+      return this.teamsService.findAll();
+    }
+    return this.teamsService.findByLeader(user.userId);
   }
 
   @Get(":id")

--- a/api/src/teams/teams.service.ts
+++ b/api/src/teams/teams.service.ts
@@ -8,6 +8,20 @@ export class TeamsService {
     return this.prisma.team.findMany({ include: { members: true } });
   }
 
+  findByLeader(userId: number) {
+    return this.prisma.team.findMany({
+      where: { members: { some: { userId, is_leader: true } } },
+      include: { members: true },
+    });
+  }
+
+  findByMember(userId: number) {
+    return this.prisma.team.findMany({
+      where: { members: { some: { userId } } },
+      include: { members: true },
+    });
+  }
+
   findOne(id: number) {
     return this.prisma.team.findUnique({
       where: { id },


### PR DESCRIPTION
## Summary
- allow admin users to create, edit and delete master kegiatan
- let non-admins see only teams they lead

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: ESLint couldn't find configuration)*
- `npm test` in `api` *(fails: jest not found)*
- `npm run build` in `api`

------
https://chatgpt.com/codex/tasks/task_b_68723930e0d4832b983826953f5b060f