### PR TITLE
Add username login option

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -90,7 +90,7 @@ Server berjalan di: `http://localhost:3000`
 
 | Method | Endpoint                   | Deskripsi                    | Role     |
 |--------|----------------------------|------------------------------|----------|
-| POST   | `/auth/login`              | Login user & dapatkan token  | semua    |
+| POST   | `/auth/login`              | Login user & dapatkan token (body: `{ identifier, password }`) | semua    |
 | GET    | `/users`                   | Lihat semua user             | admin    |
 | GET    | `/teams`                   | Daftar tim                   | admin    |
 | POST   | `/master-kegiatan`         | Tambah kegiatan              | ketua tim    |

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -11,6 +11,7 @@ datasource db {
 model User {
   id        Int                @id @default(autoincrement())
   nama      String
+  username  String             @unique
   email     String             @unique
   password  String
   role      String

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -20,6 +20,7 @@ async function main() {
   const admin = await prisma.user.create({
     data: {
       nama: "Admin Utama",
+      username: "admin",
       email: "admin@bps.go.id",
       password: await hash("password"),
       role: "admin",
@@ -31,6 +32,7 @@ async function main() {
     update: {},
     create: {
       nama: "Pimpinan BPS",
+      username: "pimpinan",
       email: "pimpinan@bps.go.id",
       password: await hash("password"),
       role: "pimpinan",
@@ -42,6 +44,7 @@ async function main() {
     update: {},
     create: {
       nama: "Ketua Tim Sosial",
+      username: "ketua.sosial",
       email: "ketua.sosial@bps.go.id",
       password: await hash("password"),
       role: "ketua",
@@ -53,6 +56,7 @@ async function main() {
     update: {},
     create: {
       nama: "Ketua Tim IPDS",
+      username: "ketua.ipds",
       email: "ketua.ipds@bps.go.id",
       password: await hash("password"),
       role: "ketua",
@@ -64,6 +68,7 @@ async function main() {
     update: {},
     create: {
       nama: "Anggota A",
+      username: "anggota.a",
       email: "anggota.a@bps.go.id",
       password: await hash("password"),
       role: "anggota",
@@ -75,6 +80,7 @@ async function main() {
     update: {},
     create: {
       nama: "Anggota B",
+      username: "anggota.b",
       email: "anggota.b@bps.go.id",
       password: await hash("password"),
       role: "anggota",

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ export class AuthController {
 
   @Post("login")
   login(@Body() body: LoginDto) {
-    return this.authService.login(body.email, body.password);
+    const identifier = body.email ?? body.username ?? "";
+    return this.authService.login(identifier, body.password);
   }
 }

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -7,9 +7,12 @@ import * as bcrypt from "bcrypt";
 export class AuthService {
   constructor(private jwtService: JwtService, private prisma: PrismaService) {}
 
-  async login(email: string, password: string) {
-    const user = await this.prisma.user.findUnique({ where: { email } });
-    if (!user) throw new UnauthorizedException("Email tidak ditemukan");
+  async login(identifier: string, password: string) {
+    const where = identifier.includes("@")
+      ? { email: identifier }
+      : { username: identifier };
+    const user = await this.prisma.user.findUnique({ where });
+    if (!user) throw new UnauthorizedException("Email/Username tidak ditemukan");
 
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) throw new UnauthorizedException("Password salah");

--- a/api/src/auth/dto/login.dto.ts
+++ b/api/src/auth/dto/login.dto.ts
@@ -1,8 +1,13 @@
-import { IsEmail, IsString, MinLength } from "class-validator";
+import { IsEmail, IsOptional, IsString, MinLength, ValidateIf } from "class-validator";
 
 export class LoginDto {
+  @ValidateIf((o) => !o.username)
   @IsEmail()
-  email!: string;
+  email?: string;
+
+  @ValidateIf((o) => !o.email)
+  @IsString()
+  username?: string;
 
   @IsString()
   @MinLength(6)

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -21,12 +21,18 @@ export class UsersService {
     if (data.password) {
       data.password = await hashPassword(data.password);
     }
+    if (!data.username && data.email) {
+      data.username = data.email.split("@")[0];
+    }
     return this.prisma.user.create({ data });
   }
 
   async update(id: number, data: any) {
     if (data.password) {
       data.password = await hashPassword(data.password);
+    }
+    if (data.email) {
+      data.username = data.email.split("@")[0];
     }
     return this.prisma.user.update({ where: { id }, data });
   }

--- a/web/src/pages/auth/LoginPage.jsx
+++ b/web/src/pages/auth/LoginPage.jsx
@@ -4,7 +4,7 @@ import { useAuth } from "./useAuth";
 import { Eye, EyeOff } from "lucide-react";
 
 export default function LoginPage() {
-  const [form, setForm] = useState({ email: "", password: "" });
+  const [form, setForm] = useState({ identifier: "", password: "" });
   const [error, setError] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const { setToken, setUser } = useAuth();
@@ -28,7 +28,7 @@ export default function LoginPage() {
       window.location.href = "/";
     } catch (err) {
       console.error("Login failed:", err?.response?.data || err.message);
-      setError("Login gagal. Periksa email dan password.");
+      setError("Login gagal. Periksa email/username dan password.");
 
       // hanya kosongkan password
       setForm((prev) => ({ ...prev, password: "" }));
@@ -49,13 +49,13 @@ export default function LoginPage() {
         <div className="space-y-4">
           <div>
             <label className="block text-sm text-zinc-700 dark:text-zinc-300 mb-1">
-              Email <span className="text-red-500">*</span>
+              Email atau Username <span className="text-red-500">*</span>
             </label>
             <input
-              type="email"
-              placeholder="Email"
-              value={form.email ?? ""}
-              onChange={(e) => setForm({ ...form, email: e.target.value })}
+              type="text"
+              placeholder="Email atau Username"
+              value={form.identifier ?? ""}
+              onChange={(e) => setForm({ ...form, identifier: e.target.value })}
               className="w-full px-4 py-2 border border-zinc-300 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-zinc-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-600"
             />
           </div>


### PR DESCRIPTION
## Summary
- support login using email or username derived from email
- extend `User` model with `username`
- compute username automatically when creating/updating users
- update login controller and DTO to accept username
- update frontend login page to request username or email
- document new login body in API README

## Testing
- `npm run build` in `api`
- `npm run lint` in `api` *(fails: ESLint couldn't find config)*
- `npm test` in `api` *(fails: jest not found)*
- `npm run build` in `web`
- `npm test` in `web` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687252e9cc08832b9a48f66d0307edad