### PR TITLE
Enable dark theme toggle and logout confirmation

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/bps.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>SEMAKIN 6502</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/public/bps.svg
+++ b/web/public/bps.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect width="120" height="120" rx="20" fill="#006cb8" />
+  <text x="60" y="75" font-size="60" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" fill="white">BPS</text>
+</svg>

--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -2,6 +2,7 @@ import { Outlet, useLocation } from "react-router-dom";
 import Sidebar from "./Sidebar";
 import { useAuth } from "../auth/useAuth";
 import { useState, useEffect, useRef } from "react";
+import Swal from "sweetalert2";
 import {
   FaBell,
   FaMoon,
@@ -25,16 +26,27 @@ export default function Layout() {
     { id: 2, text: "Penugasan baru tersedia", read: false },
     { id: 3, text: "Tim Anda telah diperbarui", read: false },
   ]);
-  const [darkMode, setDarkMode] = useState(() =>
-    document.documentElement.classList.contains("dark")
-  );
+  const [darkMode, setDarkMode] = useState(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored) return stored === "dark";
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  });
   const [showProfileMenu, setShowProfileMenu] = useState(false);
   const [showNotifMenu, setShowNotifMenu] = useState(false);
 
   const profileRef = useRef();
   const notifRef = useRef();
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    const r = await Swal.fire({
+      title: "Logout?",
+      text: "Anda yakin ingin logout?",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonText: "Logout",
+      cancelButtonText: "Batal",
+    });
+    if (!r.isConfirmed) return;
     localStorage.removeItem("token");
     localStorage.removeItem("user");
     setToken(null);

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- support class-based dark theme in Tailwind
- add BPS favicon and update title
- add theme slider persistence
- confirm logout action with SweetAlert

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68729a062254832b891f159ba6391c81