### PR TITLE
Implement global dark mode toggle

### DIFF
--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./assets/styles/index.css";
 import { AuthProvider } from "./pages/auth/useAuth.jsx";
+import { ThemeProvider } from "./theme/useTheme.jsx";
 import { BrowserRouter } from "react-router-dom";
 import axios from "axios";
 
@@ -23,7 +24,9 @@ ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter>
       <AuthProvider>
-        <App />
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
       </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -1,7 +1,8 @@
 import { Outlet, useLocation } from "react-router-dom";
 import Sidebar from "./Sidebar";
 import { useAuth } from "../auth/useAuth";
-import { useState, useEffect, useLayoutEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
+import { useTheme } from "../../theme/useTheme.jsx";
 import Swal from "sweetalert2";
 import {
   FaBell,
@@ -26,11 +27,7 @@ export default function Layout() {
     { id: 2, text: "Penugasan baru tersedia", read: false },
     { id: 3, text: "Tim Anda telah diperbarui", read: false },
   ]);
-  const [darkMode, setDarkMode] = useState(() => {
-    const stored = localStorage.getItem("theme");
-    if (stored) return stored === "dark";
-    return window.matchMedia("(prefers-color-scheme: dark)").matches;
-  });
+  const { theme, toggleTheme } = useTheme();
   const [showProfileMenu, setShowProfileMenu] = useState(false);
   const [showNotifMenu, setShowNotifMenu] = useState(false);
 
@@ -59,11 +56,6 @@ export default function Layout() {
     setNotifCount(0);
   };
 
-  useLayoutEffect(() => {
-    const html = document.documentElement;
-    html.classList.toggle("dark", darkMode);
-    localStorage.setItem("theme", darkMode ? "dark" : "light");
-  }, [darkMode]);
 
   useEffect(() => {
     const handleClickOutside = (e) => {
@@ -175,8 +167,8 @@ export default function Layout() {
               <label className="relative inline-flex items-center cursor-pointer">
                 <input
                   type="checkbox"
-                  checked={darkMode}
-                  onChange={(e) => setDarkMode(e.target.checked)}
+                  checked={theme === "dark"}
+                  onChange={toggleTheme}
                   className="sr-only peer"
                 />
                 <div className="relative w-11 h-6 bg-gray-200 dark:bg-gray-700 rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />

--- a/web/src/theme/useTheme.jsx
+++ b/web/src/theme/useTheme.jsx
@@ -1,0 +1,32 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useState } from "react";
+
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored) return stored;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle("dark", theme === "dark");
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}


### PR DESCRIPTION
## Summary
- create `useTheme` hook to manage global theme state
- wrap app with `ThemeProvider`
- update layout to use the new theme context

## Testing
- `npm install` and `npm run lint` in `web`

------
https://chatgpt.com/codex/tasks/task_b_6873274946f4832bb51fea175be48c7b