### PR TITLE
Add weekly assignment feature

### DIFF
--- a/api/src/teams/teams.service.ts
+++ b/api/src/teams/teams.service.ts
@@ -5,27 +5,29 @@ import { PrismaService } from "../prisma.service";
 export class TeamsService {
   constructor(private prisma: PrismaService) {}
   findAll() {
-    return this.prisma.team.findMany({ include: { members: true } });
+    return this.prisma.team.findMany({
+      include: { members: { include: { user: true } } },
+    });
   }
 
   findByLeader(userId: number) {
     return this.prisma.team.findMany({
       where: { members: { some: { userId, is_leader: true } } },
-      include: { members: true },
+      include: { members: { include: { user: true } } },
     });
   }
 
   findByMember(userId: number) {
     return this.prisma.team.findMany({
       where: { members: { some: { userId } } },
-      include: { members: true },
+      include: { members: { include: { user: true } } },
     });
   }
 
   findOne(id: number) {
     return this.prisma.team.findUnique({
       where: { id },
-      include: { members: true },
+      include: { members: { include: { user: true } } },
     });
   }
 

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -1,0 +1,256 @@
+import { useEffect, useState, useCallback } from "react";
+import axios from "axios";
+import Swal from "sweetalert2";
+import { Plus, Search } from "lucide-react";
+import { useAuth } from "../auth/useAuth";
+
+export default function PenugasanPage() {
+  const { user } = useAuth();
+  const [penugasan, setPenugasan] = useState([]);
+  const [teams, setTeams] = useState([]);
+  const [kegiatan, setKegiatan] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState({
+    kegiatanId: "",
+    pegawaiId: "",
+    minggu: 1,
+    bulan: new Date().getMonth() + 1,
+    tahun: new Date().getFullYear(),
+  });
+  const [search, setSearch] = useState("");
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [pRes, tRes, kRes] = await Promise.all([
+        axios.get("/penugasan"),
+        axios.get("/teams"),
+        axios.get("/master-kegiatan"),
+      ]);
+      setPenugasan(pRes.data);
+      setTeams(tRes.data);
+      setKegiatan(kRes.data.data || kRes.data);
+    } catch (err) {
+      console.error("Gagal mengambil data penugasan", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const openCreate = () => {
+    setForm({
+      kegiatanId: "",
+      pegawaiId: "",
+      minggu: 1,
+      bulan: new Date().getMonth() + 1,
+      tahun: new Date().getFullYear(),
+    });
+    setShowForm(true);
+  };
+
+  const save = async () => {
+    if (!form.kegiatanId || !form.pegawaiId) {
+      Swal.fire("Lengkapi data", "Kegiatan dan pegawai wajib dipilih", "warning");
+      return;
+    }
+    try {
+      await axios.post("/penugasan", form);
+      setShowForm(false);
+      fetchData();
+      Swal.fire("Berhasil", "Penugasan ditambah", "success");
+    } catch (err) {
+      console.error("Gagal menyimpan penugasan", err);
+      Swal.fire("Error", "Gagal menyimpan penugasan", "error");
+    }
+  };
+
+  const months = [
+    "Januari",
+    "Februari",
+    "Maret",
+    "April",
+    "Mei",
+    "Juni",
+    "Juli",
+    "Agustus",
+    "September",
+    "Oktober",
+    "November",
+    "Desember",
+  ];
+
+  const filtered = penugasan.filter((p) => {
+    const k = kegiatan.find((k) => k.id === p.kegiatanId);
+    const peg = teams
+      .flatMap((t) => t.members.map((m) => m.user))
+      .find((u) => u.id === p.pegawaiId);
+    const text = `${k?.nama_kegiatan || ""} ${peg?.nama || ""}`.toLowerCase();
+    return text.includes(search.toLowerCase());
+  });
+
+  if (!["ketua", "admin"].includes(user?.role)) {
+    return <div className="p-6 text-center">Anda tidak memiliki akses ke halaman ini.</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap justify-between items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          <div className="relative">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <Search size={16} className="text-gray-400 dark:text-gray-300" />
+            </div>
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Cari penugasan..."
+              className="w-full border rounded-md py-[4px] pl-10 pr-3 bg-white text-gray-900 dark:bg-gray-700 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+        <button
+          onClick={openCreate}
+          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
+        >
+          <Plus size={16} />
+          <span className="hidden sm:inline">Tambah Penugasan</span>
+        </button>
+      </div>
+
+      <table className="min-w-full bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow">
+        <thead>
+          <tr className="bg-gray-200 dark:bg-gray-700 text-center text-sm uppercase">
+            <th className="px-4 py-2">Kegiatan</th>
+            <th className="px-4 py-2">Pegawai</th>
+            <th className="px-4 py-2">Minggu</th>
+            <th className="px-4 py-2">Bulan</th>
+            <th className="px-4 py-2">Tahun</th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading ? (
+            <tr>
+              <td colSpan="5" className="py-4 text-center">
+                Memuat data...
+              </td>
+            </tr>
+          ) : filtered.length === 0 ? (
+            <tr>
+              <td colSpan="5" className="py-4 text-center">
+                Data tidak ditemukan
+              </td>
+            </tr>
+          ) : (
+            filtered.map((p) => {
+              const k = kegiatan.find((k) => k.id === p.kegiatanId);
+              const peg = teams
+                .flatMap((t) => t.members.map((m) => m.user))
+                .find((u) => u.id === p.pegawaiId);
+              return (
+                <tr key={p.id} className="border-t dark:border-gray-700 text-center">
+                  <td className="px-4 py-2">{k?.nama_kegiatan || "-"}</td>
+                  <td className="px-4 py-2">{peg?.nama || "-"}</td>
+                  <td className="px-4 py-2">{p.minggu}</td>
+                  <td className="px-4 py-2">{p.bulan}</td>
+                  <td className="px-4 py-2">{p.tahun}</td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+
+      {showForm && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md space-y-4 shadow-xl">
+            <h2 className="text-xl font-semibold mb-2">Tambah Penugasan</h2>
+            <div className="space-y-2">
+              <div>
+                <label className="block text-sm mb-1">Kegiatan <span className="text-red-500">*</span></label>
+                <select
+                  value={form.kegiatanId}
+                  onChange={(e) => setForm({ ...form, kegiatanId: parseInt(e.target.value, 10) })}
+                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                >
+                  <option value="">Pilih kegiatan</option>
+                  {kegiatan.map((k) => (
+                    <option key={k.id} value={k.id}>
+                      {k.nama_kegiatan}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm mb-1">Pegawai <span className="text-red-500">*</span></label>
+                <select
+                  value={form.pegawaiId}
+                  onChange={(e) => setForm({ ...form, pegawaiId: parseInt(e.target.value, 10) })}
+                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                >
+                  <option value="">Pilih pegawai</option>
+                  {teams.flatMap((t) =>
+                    t.members.map((m) => (
+                      <option key={m.user.id} value={m.user.id}>
+                        {t.nama_tim} - {m.user.nama}
+                      </option>
+                    ))
+                  )}
+                </select>
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                <div>
+                  <label className="block text-sm mb-1">Minggu</label>
+                  <input
+                    type="number"
+                    value={form.minggu}
+                    min="1"
+                    max="5"
+                    onChange={(e) => setForm({ ...form, minggu: parseInt(e.target.value, 10) })}
+                    className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm mb-1">Bulan</label>
+                  <select
+                    value={form.bulan}
+                    onChange={(e) => setForm({ ...form, bulan: parseInt(e.target.value, 10) })}
+                    className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                  >
+                    {months.map((m, i) => (
+                      <option key={i + 1} value={i + 1}>
+                        {m}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm mb-1">Tahun</label>
+                  <input
+                    type="number"
+                    value={form.tahun}
+                    onChange={(e) => setForm({ ...form, tahun: parseInt(e.target.value, 10) })}
+                    className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="flex justify-end space-x-2 pt-2">
+              <button onClick={() => setShowForm(false)} className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded">
+                Batal
+              </button>
+              <button onClick={save} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded">
+                Simpan
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/routes/AppRoutes.jsx
+++ b/web/src/routes/AppRoutes.jsx
@@ -6,6 +6,7 @@ import { useAuth } from "../pages/auth/useAuth";
 import UsersPage from "../pages/users/UsersPage";
 import TeamsPage from "../pages/teams/TeamsPage";
 import MasterKegiatanPage from "../pages/master/MasterKegiatanPage";
+import PenugasanPage from "../pages/penugasan/PenugasanPage";
 
 function PrivateRoute({ children }) {
   const { token, user } = useAuth();
@@ -39,6 +40,7 @@ export default function AppRoutes() {
         <Route path="users" element={<UsersPage />} />
         <Route path="teams" element={<TeamsPage />} />
         <Route path="master-kegiatan" element={<MasterKegiatanPage />} />
+        <Route path="penugasan" element={<PenugasanPage />} />
         {/* Tambahkan rute lainnya nanti di sini */}
       </Route>
     </Routes>


### PR DESCRIPTION
## Summary
- extend team service to include user info on members
- add frontend page for weekly assignments
- register the new page in app routes

## Testing
- `npm run lint` (web)
- `npm run lint` (api) *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_687327ab4b9c832b8d15a10ae48457d9