### PR TITLE
Enhance penugasan detail with laporan features

### DIFF
--- a/api/src/laporan/laporan.controller.ts
+++ b/api/src/laporan/laporan.controller.ts
@@ -6,6 +6,8 @@ import {
   Query,
   UseGuards,
   Req,
+  Param,
+  ParseIntPipe,
 } from "@nestjs/common";
 import { Request } from "express";
 import { LaporanService } from "./laporan.service";
@@ -26,5 +28,10 @@ export class LaporanController {
   @Get()
   getByTanggal(@Query("tanggal") tanggal: string) {
     return this.laporanService.getByTanggal(tanggal);
+  }
+
+  @Get('penugasan/:id')
+  getByPenugasan(@Param('id', ParseIntPipe) id: number) {
+    return this.laporanService.getByPenugasan(id);
   }
 }

--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -1,16 +1,29 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, BadRequestException, ForbiddenException } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 
 @Injectable()
 export class LaporanService {
   constructor(private prisma: PrismaService) {}
-  submit(data: any) {
+  async submit(data: any) {
+    const pen = await this.prisma.penugasan.findUnique({
+      where: { id: data.penugasanId },
+    });
+    if (!pen) throw new BadRequestException("Penugasan tidak ditemukan");
+    if (pen.pegawaiId !== data.pegawaiId)
+      throw new ForbiddenException("bukan penugasan anda");
     return this.prisma.laporanHarian.create({ data });
   }
 
   getByTanggal(tanggal: string) {
     return this.prisma.laporanHarian.findMany({
       where: { tanggal: new Date(tanggal) },
+    });
+  }
+
+  getByPenugasan(penugasanId: number) {
+    return this.prisma.laporanHarian.findMany({
+      where: { penugasanId },
+      orderBy: { tanggal: "asc" },
     });
   }
 }


### PR DESCRIPTION
## Summary
- add endpoint to retrieve laporan by penugasan id
- validate user when submitting laporan harian
- show laporan list in PenugasanDetailPage
- allow adding daily status with link evidence from detail page

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: ESLint couldn't find config)*
- `npm test` in `api` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68736382d0b4832b803983c93094999a