### PR TITLE
Implement daily reports page

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -430,6 +430,38 @@ async function main() {
     }
     await prisma.penugasan.createMany({ data: rows });
   }
+
+  // seed laporan harian based on penugasan
+  const penugasans = await prisma.penugasan.findMany();
+  if (penugasans.length) {
+    const statuses = [
+      "Belum Dikerjakan",
+      "Sedang Dikerjakan",
+      "Selesai Dikerjakan",
+    ];
+    const today = new Date();
+    const dates = [0, 1, 2].map((d) => {
+      const t = new Date(today);
+      t.setDate(today.getDate() - d);
+      return t;
+    });
+
+    const reports = [] as any[];
+    for (const p of penugasans) {
+      for (const dt of dates) {
+        reports.push({
+          penugasanId: p.id,
+          pegawaiId: p.pegawaiId,
+          tanggal: dt,
+          status: statuses[Math.floor(Math.random() * statuses.length)],
+        });
+      }
+    }
+
+    if (reports.length) {
+      await prisma.laporanHarian.createMany({ data: reports, skipDuplicates: true });
+    }
+  }
 }
 
 main()

--- a/api/src/laporan/laporan.controller.ts
+++ b/api/src/laporan/laporan.controller.ts
@@ -6,6 +6,8 @@ import {
   Query,
   UseGuards,
   Req,
+  Param,
+  ParseIntPipe,
 } from "@nestjs/common";
 import { Request } from "express";
 import { LaporanService } from "./laporan.service";
@@ -26,5 +28,10 @@ export class LaporanController {
   @Get()
   getByTanggal(@Query("tanggal") tanggal: string) {
     return this.laporanService.getByTanggal(tanggal);
+  }
+
+  @Get("penugasan/:id")
+  getByPenugasan(@Param("id", ParseIntPipe) id: number) {
+    return this.laporanService.getByPenugasan(id);
   }
 }

--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -11,6 +11,20 @@ export class LaporanService {
   getByTanggal(tanggal: string) {
     return this.prisma.laporanHarian.findMany({
       where: { tanggal: new Date(tanggal) },
+      include: {
+        pegawai: true,
+        penugasan: { include: { kegiatan: true } },
+      },
+    });
+  }
+
+  getByPenugasan(penugasanId: number) {
+    return this.prisma.laporanHarian.findMany({
+      where: { penugasanId },
+      include: {
+        pegawai: true,
+        penugasan: { include: { kegiatan: true } },
+      },
     });
   }
 }

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { Search } from "lucide-react";
+
+export default function LaporanHarianPage() {
+  const today = new Date().toISOString().split("T")[0];
+  const [tanggal, setTanggal] = useState(today);
+  const [laporan, setLaporan] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      const res = await axios.get("/laporan-harian", { params: { tanggal } });
+      setLaporan(res.data);
+    } catch (err) {
+      console.error("Gagal mengambil laporan", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [tanggal]);
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-end gap-2">
+        <div>
+          <label className="block text-sm mb-1">Tanggal</label>
+          <input
+            type="date"
+            value={tanggal}
+            onChange={(e) => setTanggal(e.target.value)}
+            className="border rounded px-3 py-1 bg-white dark:bg-gray-700"
+          />
+        </div>
+        <button
+          onClick={fetchData}
+          className="h-9 px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded"
+        >
+          <Search size={16} />
+        </button>
+      </div>
+      {loading ? (
+        <div>Memuat...</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm border border-gray-300 dark:border-gray-700">
+            <thead>
+              <tr className="bg-gray-200 dark:bg-gray-700">
+                <th className="px-3 py-2 border">Pegawai</th>
+                <th className="px-3 py-2 border">Kegiatan</th>
+                <th className="px-3 py-2 border">Status</th>
+                <th className="px-3 py-2 border">Bukti</th>
+                <th className="px-3 py-2 border">Catatan</th>
+              </tr>
+            </thead>
+            <tbody>
+              {laporan.map((item) => (
+                <tr key={item.id} className="border-t">
+                  <td className="px-3 py-1 border">{item.pegawai?.nama || "-"}</td>
+                  <td className="px-3 py-1 border">
+                    {item.penugasan?.kegiatan?.nama_kegiatan || "-"}
+                  </td>
+                  <td className="px-3 py-1 border">{item.status}</td>
+                  <td className="px-3 py-1 border">
+                    {item.bukti_link ? (
+                      <a
+                        href={item.bukti_link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 underline"
+                      >
+                        Lihat
+                      </a>
+                    ) : (
+                      "-"
+                    )}
+                  </td>
+                  <td className="px-3 py-1 border">{item.catatan || "-"}</td>
+                </tr>
+              ))}
+              {laporan.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="text-center py-4 text-gray-500 dark:text-gray-300"
+                  >
+                    Tidak ada laporan
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/routes/AppRoutes.jsx
+++ b/web/src/routes/AppRoutes.jsx
@@ -8,6 +8,7 @@ import TeamsPage from "../pages/teams/TeamsPage";
 import MasterKegiatanPage from "../pages/master/MasterKegiatanPage";
 import PenugasanPage from "../pages/penugasan/PenugasanPage";
 import PenugasanDetailPage from "../pages/penugasan/PenugasanDetailPage";
+import LaporanHarianPage from "../pages/laporan/LaporanHarianPage";
 
 function PrivateRoute({ children }) {
   const { token, user } = useAuth();
@@ -43,6 +44,7 @@ export default function AppRoutes() {
         <Route path="master-kegiatan" element={<MasterKegiatanPage />} />
         <Route path="penugasan" element={<PenugasanPage />} />
         <Route path="penugasan/:id" element={<PenugasanDetailPage />} />
+        <Route path="laporan-harian" element={<LaporanHarianPage />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## Summary
- show related data for daily reports
- create LaporanHarianPage to list submitted reports
- register new route in AppRoutes
- seed laporan harian with sample reports
- add service and route to fetch reports by penugasan

## Testing
- `npm run lint` in `web` *(fails: Cannot find package '@eslint/js')*
- `npm run lint` in `api` *(fails: ESLint couldn't find configuration)*
- `npm test` in `api` *(fails: jest not found)*
- `npm test` in `web` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68735cc9f458832ba96ffacc19821353