### PR TITLE
Improve dashboard with modern stats

### DIFF
--- a/web/src/components/dashboard/DailyOverview.jsx
+++ b/web/src/components/dashboard/DailyOverview.jsx
@@ -5,7 +5,7 @@ const DailyOverview = ({ data = [] }) => {
       <h2 className="text-lg font-semibold mb-3 text-blue-600">
         Kalender Aktivitas Harian
       </h2>
-      <div className="grid grid-cols-7 gap-2">
+      <div className="grid grid-cols-4 sm:grid-cols-7 gap-2">
         {data.map((day, index) => (
           <div
             key={index}
@@ -22,6 +22,9 @@ const DailyOverview = ({ data = [] }) => {
           </div>
         ))}
       </div>
+      <p className="text-xs text-gray-500 mt-2">
+        <span className="text-green-600">✔</span> menandakan ada laporan
+      </p>
     </div>
   );
 };

--- a/web/src/components/dashboard/MonitoringTabs.jsx
+++ b/web/src/components/dashboard/MonitoringTabs.jsx
@@ -3,20 +3,20 @@ import DailyOverview from "./DailyOverview";
 import WeeklyOverview from "./WeeklyOverview";
 import MonthlyOverview from "./MonthlyOverview";
 
-const MonitoringTabs = ({ dailyData, weeklyData, monthlyData }) => {
+const MonitoringTabs = ({ dailyData, weeklyData, monthlyProgress }) => {
   const [tab, setTab] = useState("harian");
 
   const renderContent = () => {
-    switch (tab) {
-      case "harian":
-        return <DailyOverview data={dailyData} />;
-      case "mingguan":
-        return <WeeklyOverview data={weeklyData} />;
-      case "bulanan":
-        return <MonthlyOverview data={monthlyData} />;
-      default:
-        return null;
-    }
+      switch (tab) {
+        case "harian":
+          return <DailyOverview data={dailyData} />;
+        case "mingguan":
+          return <WeeklyOverview data={weeklyData} />;
+        case "bulanan":
+          return <MonthlyOverview data={monthlyProgress} />;
+        default:
+          return null;
+      }
   };
 
   return (

--- a/web/src/components/dashboard/MonthlyOverview.jsx
+++ b/web/src/components/dashboard/MonthlyOverview.jsx
@@ -1,23 +1,40 @@
 const MonthlyOverview = ({ data = [] }) => {
+  const monthNames = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "Mei",
+    "Jun",
+    "Jul",
+    "Agu",
+    "Sep",
+    "Okt",
+    "Nov",
+    "Des",
+  ];
+
   return (
     <div>
       <h2 className="text-lg font-semibold mb-3 text-indigo-600">
         Aktivitas Bulanan
       </h2>
-      <div className="grid grid-cols-5 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
         {data.map((item, index) => (
           <div
             key={index}
-            className={`p-3 rounded-lg text-center text-sm font-medium border ${
-              item.adaAktivitas
-                ? "bg-blue-100 border-blue-500"
-                : "bg-gray-100 dark:bg-gray-700"
-            }`}
+            className="p-3 rounded-lg text-center bg-white dark:bg-gray-800 shadow"
           >
-            <div>{item.tanggal}</div>
-            {item.adaAktivitas && (
-              <div className="text-blue-700 text-xs mt-1">✔</div>
-            )}
+            <div className="font-semibold mb-1">{monthNames[item.bulan - 1]}</div>
+            <div className="text-sm text-gray-600 dark:text-gray-300">
+              {item.persen}% selesai
+            </div>
+            <div className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-full mt-1">
+              <div
+                className="h-2 bg-indigo-500 rounded-full"
+                style={{ width: `${item.persen}%` }}
+              />
+            </div>
           </div>
         ))}
       </div>

--- a/web/src/components/dashboard/StatsSummary.jsx
+++ b/web/src/components/dashboard/StatsSummary.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+const StatsSummary = ({ weeklyData }) => {
+  if (!weeklyData) return null;
+
+  const todayStr = new Date().toISOString().slice(0, 10);
+  const today = weeklyData.detail?.find((d) => d.tanggal === todayStr) || {};
+
+  const tugasHariIni = today.selesai || 0;
+  const tugasMingguIni = weeklyData.totalTugas || 0;
+  const selesai = weeklyData.totalSelesai || 0;
+  const belumSelesai = Math.max(tugasMingguIni - selesai, 0);
+
+  const statStyle = "p-4 rounded-lg shadow text-center";
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className={`${statStyle} bg-blue-50 dark:bg-blue-900`}>
+        <p className="text-sm text-gray-600 dark:text-gray-300">Tugas Hari Ini</p>
+        <p className="text-2xl font-bold text-blue-600 dark:text-blue-200">
+          {tugasHariIni}
+        </p>
+      </div>
+      <div className={`${statStyle} bg-indigo-50 dark:bg-indigo-900`}>
+        <p className="text-sm text-gray-600 dark:text-gray-300">Tugas Minggu Ini</p>
+        <p className="text-2xl font-bold text-indigo-600 dark:text-indigo-200">
+          {tugasMingguIni}
+        </p>
+      </div>
+      <div className={`${statStyle} bg-yellow-50 dark:bg-yellow-900`}>
+        <p className="text-sm text-gray-600 dark:text-gray-300">Belum Selesai</p>
+        <p className="text-2xl font-bold text-yellow-600 dark:text-yellow-200">
+          {belumSelesai}
+        </p>
+      </div>
+      <div className={`${statStyle} bg-green-50 dark:bg-green-900`}>
+        <p className="text-sm text-gray-600 dark:text-gray-300">Selesai</p>
+        <p className="text-2xl font-bold text-green-600 dark:text-green-200">
+          {selesai}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default StatsSummary;

--- a/web/src/components/dashboard/WeeklyOverview.jsx
+++ b/web/src/components/dashboard/WeeklyOverview.jsx
@@ -2,17 +2,16 @@ const WeeklyOverview = ({ data }) => {
   if (!data) return null;
 
   return (
-    <div>
-      <div className="mb-4">
+    <div className="space-y-4">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
         <h2 className="text-xl font-semibold text-purple-600 mb-1">
           Progress Mingguan
         </h2>
         <p className="text-sm text-gray-600 dark:text-gray-300">
           {data.minggu} Bulan {data.bulan} ({data.tanggal})
         </p>
-        <p className="text-sm font-semibold text-purple-700 dark:text-purple-300 mt-2">
-          Total Progress: {data.totalProgress} ({data.totalSelesai}/
-          {data.totalTugas})
+        <p className="text-lg font-semibold text-purple-700 dark:text-purple-300 mt-2">
+          {data.totalProgress}% selesai ({data.totalSelesai}/{data.totalTugas})
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- enhance statistic summary to show today's, weekly and status counts
- redesign daily, weekly and monthly overviews for better UX
- compute monthly progress from assignments for each month

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: couldn't find ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_687370c89a60832bbf5637ed8495ea68