### PR TITLE
Improve pagination behavior

### DIFF
--- a/web/src/components/Pagination.jsx
+++ b/web/src/components/Pagination.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+export default function Pagination({ currentPage, totalPages, onPageChange }) {
+  const getPages = () => {
+    if (totalPages <= 5) {
+      return Array.from({ length: totalPages }, (_, i) => i + 1);
+    }
+    const pages = [1];
+    let start = Math.max(2, currentPage - 1);
+    let end = Math.min(totalPages - 1, currentPage + 1);
+    if (start > 2) pages.push("...");
+    for (let i = start; i <= end; i++) pages.push(i);
+    if (end < totalPages - 1) pages.push("...");
+    pages.push(totalPages);
+    return pages;
+  };
+
+  const pages = getPages();
+
+  return (
+    <div className="space-x-1">
+      <button
+        onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+        disabled={currentPage === 1}
+        className="px-3 py-1 border rounded-full disabled:opacity-50 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+      >
+        Prev
+      </button>
+      {pages.map((p, idx) =>
+        typeof p === "number" ? (
+          <button
+            key={idx}
+            onClick={() => onPageChange(p)}
+            className={`px-3 py-1 rounded-full ${
+              currentPage === p
+                ? "bg-blue-600 text-white"
+                : "border bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+            }`}
+          >
+            {p}
+          </button>
+        ) : (
+          <span key={idx} className="px-2">
+            {p}
+          </span>
+        )
+      )}
+      <button
+        onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+        disabled={currentPage >= totalPages}
+        className="px-3 py-1 border rounded-full disabled:opacity-50 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+      >
+        Next
+      </button>
+    </div>
+  );
+}

--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -5,28 +5,23 @@ import { useAuth } from "../auth/useAuth";
 export default function Sidebar({ mobileOpen, setMobileOpen }) {
   const { user } = useAuth();
 
-  const links = [];
-
-  links.push({ to: "/", label: "Dashboard" });
-
-  if (["admin", "pimpinan"].includes(user?.role)) {
-    links.push({ to: "/users", label: "Kelola Pengguna" });
-    links.push({ to: "/teams", label: "Kelola Tim" });
-  }
-
-  if (["ketua", "admin"].includes(user?.role)) {
-    links.push({ to: "/master-kegiatan", label: "Master Kegiatan" });
-    links.push({ to: "/penugasan", label: "Penugasan Mingguan" });
-  }
-
-  if (["anggota", "ketua", "admin"].includes(user?.role)) {
-    links.push({ to: "/laporan-harian", label: "Laporan Harian" });
-    links.push({ to: "/kegiatan-tambahan", label: "Kegiatan Tambahan" });
-  }
-
-  if (["admin", "pimpinan", "ketua"].includes(user?.role)) {
-    links.push({ to: "/monitoring", label: "Monitoring Kinerja" });
-  }
+  const links = [
+    { to: "/", label: "Dashboard", show: true },
+    { to: "/penugasan", label: "Penugasan Mingguan", show: true },
+    { to: "/laporan-harian", label: "Laporan Harian", show: true },
+    { to: "/kegiatan-tambahan", label: "Kegiatan Tambahan", show: true },
+    {
+      to: "/master-kegiatan",
+      label: "Master Kegiatan",
+      show: ["admin", "ketua"].includes(user?.role),
+    },
+    {
+      to: "/users",
+      label: "Kelola Pengguna",
+      show: user?.role === "admin",
+    },
+    { to: "/teams", label: "Kelola Tim", show: user?.role === "admin" },
+  ];
 
   return (
     <aside className="h-full w-64 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 p-4 shadow-md overflow-y-auto flex flex-col">
@@ -34,7 +29,7 @@ export default function Sidebar({ mobileOpen, setMobileOpen }) {
         SEMAKIN 6502
       </div>
       <nav className="space-y-2">
-        {links.map((link) => (
+        {links.filter((l) => l.show).map((link) => (
           <NavLink
             key={link.to}
             to={link.to}

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import Swal from "sweetalert2";
 import { Pencil, Plus, Trash2, Search } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
+import Pagination from "../../components/Pagination";
 
 export default function MasterKegiatanPage() {
   const { user } = useAuth();
@@ -21,6 +22,7 @@ export default function MasterKegiatanPage() {
   const [perPage, setPerPage] = useState(10);
   const [filterTeam, setFilterTeam] = useState("");
   const [search, setSearch] = useState("");
+  const totalPages = lastPage || 1;
   const fetchItems = useCallback(async () => {
     try {
       setLoading(true);
@@ -123,8 +125,8 @@ export default function MasterKegiatanPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-end">
-        <div className="flex items-end space-x-2">
+      <div className="flex flex-wrap justify-between items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <div>
             <select
               value={filterTeam}
@@ -159,20 +161,6 @@ export default function MasterKegiatanPage() {
             />
           </div>
 
-          <div>
-            <select
-              value={perPage}
-              onChange={(e) => {
-                setPage(1);
-                setPerPage(parseInt(e.target.value, 10));
-              }}
-              className="border px-2 py-1 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-200"
-            >
-              <option value={5}>5</option>
-              <option value={10}>10</option>
-              <option value={25}>25</option>
-            </select>
-          </div>
         </div>
 
         <div>
@@ -242,24 +230,24 @@ export default function MasterKegiatanPage() {
         </tbody>
       </table>
 
-      <div className="flex justify-end space-x-2 mt-2">
-        <button
-          onClick={() => setPage((p) => Math.max(1, p - 1))}
-          disabled={page === 1}
-          className="px-3 py-1 border rounded disabled:opacity-50"
-        >
-          Prev
-        </button>
-        <span className="px-2 py-1">
-          Page {page} / {lastPage}
-        </span>
-        <button
-          onClick={() => setPage((p) => Math.min(lastPage, p + 1))}
-          disabled={page >= lastPage}
-          className="px-3 py-1 border rounded disabled:opacity-50"
-        >
-          Next
-        </button>
+      <div className="flex items-center justify-between mt-4">
+        <div className="space-x-2">
+          <select
+            value={perPage}
+            onChange={(e) => {
+              setPage(1);
+              setPerPage(parseInt(e.target.value, 10));
+            }}
+            className="border rounded px-3 py-2 bg-white text-gray-900 dark:bg-gray-700 dark:text-gray-200"
+          >
+            {[5, 10, 25].map((n) => (
+              <option key={n} value={n} className="text-gray-900 dark:text-gray-200">
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
+        <Pagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />
       </div>
 
       {showForm && (

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -5,6 +5,7 @@ import { Plus, Search, Filter as FilterIcon, Eye } from "lucide-react";
 import Select from "react-select";
 import { useAuth } from "../auth/useAuth";
 import { useNavigate } from "react-router-dom";
+import Pagination from "../../components/Pagination";
 
 const selectStyles = {
   option: (base) => ({ ...base, color: "#000" }),
@@ -14,6 +15,7 @@ const selectStyles = {
 
 export default function PenugasanPage() {
   const { user } = useAuth();
+  const canManage = ["admin", "ketua", "pimpinan"].includes(user?.role);
   const navigate = useNavigate();
   const [penugasan, setPenugasan] = useState([]);
   const [kegiatan, setKegiatan] = useState([]);
@@ -31,6 +33,8 @@ export default function PenugasanPage() {
   const [search, setSearch] = useState("");
   const [filterBulan, setFilterBulan] = useState("");
   const [filterTahun, setFilterTahun] = useState(new Date().getFullYear());
+  const [pageSize, setPageSize] = useState(10);
+  const [currentPage, setCurrentPage] = useState(1);
 
   const fetchData = useCallback(async () => {
       try {
@@ -125,10 +129,12 @@ export default function PenugasanPage() {
     const text = `${k?.nama_kegiatan || ""} ${peg?.nama || ""}`.toLowerCase();
     return text.includes(search.toLowerCase());
   });
+  const paginated = filtered.slice(
+    (currentPage - 1) * pageSize,
+    currentPage * pageSize
+  );
+  const totalPages = Math.ceil(filtered.length / pageSize) || 1;
 
-  if (!["ketua", "admin"].includes(user?.role)) {
-    return <div className="p-6 text-center">Anda tidak memiliki akses ke halaman ini.</div>;
-  }
 
   return (
     <div className="space-y-6">
@@ -141,14 +147,20 @@ export default function PenugasanPage() {
             <input
               type="text"
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setCurrentPage(1);
+              }}
               placeholder="Cari penugasan..."
               className="w-full border rounded-md py-[4px] pl-10 pr-3 bg-white text-gray-900 dark:bg-gray-700 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
             />
           </div>
           <select
             value={filterBulan}
-            onChange={(e) => setFilterBulan(e.target.value)}
+            onChange={(e) => {
+              setFilterBulan(e.target.value);
+              setCurrentPage(1);
+            }}
             className="border rounded px-2 py-[4px] bg-white dark:bg-gray-700 dark:text-gray-200"
           >
             <option value="">Bulan</option>
@@ -159,7 +171,10 @@ export default function PenugasanPage() {
           <input
             type="number"
             value={filterTahun}
-            onChange={(e) => setFilterTahun(parseInt(e.target.value, 10))}
+            onChange={(e) => {
+              setFilterTahun(parseInt(e.target.value, 10));
+              setCurrentPage(1);
+            }}
             className="w-20 border rounded px-2 py-[4px] bg-white dark:bg-gray-700 dark:text-gray-200"
           />
           <button
@@ -170,13 +185,15 @@ export default function PenugasanPage() {
             <FilterIcon size={16} />
           </button>
         </div>
-        <button
-          onClick={openCreate}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
-        >
-          <Plus size={16} />
-          <span className="hidden sm:inline">Tambah Penugasan</span>
-        </button>
+        {canManage && (
+          <button
+            onClick={openCreate}
+            className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
+          >
+            <Plus size={16} />
+            <span className="hidden sm:inline">Tambah Penugasan</span>
+          </button>
+        )}
       </div>
 
       <table className="min-w-full bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow">
@@ -205,12 +222,12 @@ export default function PenugasanPage() {
               </td>
             </tr>
           ) : (
-            filtered.map((p, idx) => {
+            paginated.map((p, idx) => {
               const k = kegiatan.find((k) => k.id === p.kegiatanId);
               const peg = users.find((u) => u.id === p.pegawaiId);
               return (
                 <tr key={p.id} className="border-t dark:border-gray-700 text-center">
-                  <td className="px-2 py-2">{idx + 1}</td>
+                  <td className="px-2 py-2">{(currentPage - 1) * pageSize + idx + 1}</td>
                   <td className="px-4 py-2">{k?.nama_kegiatan || "-"}</td>
                   <td className="px-4 py-2">{k?.team?.nama_tim || "-"}</td>
                   <td className="px-4 py-2">{peg?.nama || "-"}</td>
@@ -231,7 +248,31 @@ export default function PenugasanPage() {
         </tbody>
       </table>
 
-      {showForm && (
+      <div className="flex items-center justify-between mt-4">
+        <div className="space-x-2">
+          <select
+            value={pageSize}
+            onChange={(e) => {
+              setPageSize(parseInt(e.target.value, 10));
+              setCurrentPage(1);
+            }}
+            className="border rounded px-3 py-2 bg-white text-gray-900 dark:bg-gray-700 dark:text-gray-200"
+          >
+            {[5, 10, 25].map((n) => (
+              <option key={n} value={n} className="text-gray-900 dark:text-gray-200">
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
+      </div>
+
+      {canManage && showForm && (
         <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
           <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md space-y-4 shadow-xl">
             <h2 className="text-xl font-semibold mb-2">Tambah Penugasan</h2>

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function KegiatanTambahanPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold mb-2">Kegiatan Tambahan</h1>
+      <p>Halaman ini belum tersedia.</p>
+    </div>
+  );
+}

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import Swal from "sweetalert2";
 import { Pencil, Plus, Trash2, Search } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
+import Pagination from "../../components/Pagination";
 
 export default function TeamsPage() {
   const { user } = useAuth();
@@ -88,6 +89,7 @@ export default function TeamsPage() {
     (currentPage - 1) * pageSize,
     currentPage * pageSize
   );
+  const totalPages = Math.ceil(filtered.length / pageSize) || 1;
 
   if (user?.role !== "admin") {
     return (
@@ -193,47 +195,16 @@ export default function TeamsPage() {
                 value={n}
                 className="text-gray-900 dark:text-gray-200"
               >
-                {n} / halaman
+                {n}
               </option>
             ))}
           </select>
         </div>
-        <div className="space-x-1">
-          <button
-            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-            disabled={currentPage === 1}
-            className="px-3 py-1 border rounded-full disabled:opacity-50 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
-          >
-            Prev
-          </button>
-          {Array.from(
-            { length: Math.ceil(filtered.length / pageSize) || 1 },
-            (_, i) => i + 1
-          ).map((n) => (
-            <button
-              key={n}
-              onClick={() => setCurrentPage(n)}
-              className={`px-3 py-1 rounded-full ${
-                currentPage === n
-                  ? "bg-blue-600 text-white"
-                  : "border bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
-              }`}
-            >
-              {n}
-            </button>
-          ))}
-          <button
-            onClick={() =>
-              setCurrentPage((p) =>
-                Math.min(Math.ceil(filtered.length / pageSize), p + 1)
-              )
-            }
-            disabled={currentPage >= Math.ceil(filtered.length / pageSize)}
-            className="px-3 py-1 border rounded-full disabled:opacity-50 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
-          >
-            Next
-          </button>
-        </div>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
       </div>
 
       {showForm && (

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import Swal from "sweetalert2";
 import { Pencil, Plus, Trash2, Search } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
+import Pagination from "../../components/Pagination";
 
 export default function UsersPage() {
   const { user } = useAuth();
@@ -113,6 +114,7 @@ export default function UsersPage() {
     (currentPage - 1) * pageSize,
     currentPage * pageSize
   );
+  const totalPages = Math.ceil(filteredUsers.length / pageSize) || 1;
 
   if (user?.role !== "admin") {
     return (
@@ -236,47 +238,16 @@ export default function UsersPage() {
                 value={n}
                 className="text-gray-900 dark:text-gray-200"
               >
-                {n} / halaman
+                {n}
               </option>
             ))}
           </select>
         </div>
-        <div className="space-x-1">
-          <button
-            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-            disabled={currentPage === 1}
-            className="px-3 py-1 border rounded-full disabled:opacity-50 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
-          >
-            Prev
-          </button>
-          {Array.from(
-            { length: Math.ceil(filteredUsers.length / pageSize) || 1 },
-            (_, i) => i + 1
-          ).map((n) => (
-            <button
-              key={n}
-              onClick={() => setCurrentPage(n)}
-              className={`px-3 py-1 rounded-full ${
-                currentPage === n
-                  ? "bg-blue-600 text-white"
-                  : "border bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
-              }`}
-            >
-              {n}
-            </button>
-          ))}
-          <button
-            onClick={() =>
-              setCurrentPage((p) =>
-                Math.min(Math.ceil(filteredUsers.length / pageSize), p + 1)
-              )
-            }
-            disabled={currentPage >= Math.ceil(filteredUsers.length / pageSize)}
-            className="px-3 py-1 border rounded-full disabled:opacity-50 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
-          >
-            Next
-          </button>
-        </div>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
       </div>
 
       {showForm && (

--- a/web/src/routes/AppRoutes.jsx
+++ b/web/src/routes/AppRoutes.jsx
@@ -9,6 +9,7 @@ import MasterKegiatanPage from "../pages/master/MasterKegiatanPage";
 import PenugasanPage from "../pages/penugasan/PenugasanPage";
 import PenugasanDetailPage from "../pages/penugasan/PenugasanDetailPage";
 import LaporanHarianPage from "../pages/laporan/LaporanHarianPage";
+import KegiatanTambahanPage from "../pages/tambahan/KegiatanTambahanPage";
 
 function PrivateRoute({ children }) {
   const { token, user } = useAuth();
@@ -45,6 +46,7 @@ export default function AppRoutes() {
         <Route path="penugasan" element={<PenugasanPage />} />
         <Route path="penugasan/:id" element={<PenugasanDetailPage />} />
         <Route path="laporan-harian" element={<LaporanHarianPage />} />
+        <Route path="kegiatan-tambahan" element={<KegiatanTambahanPage />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## Summary
- create a reusable `Pagination` component
- replace per-page pagination blocks with the new component
- compute total pages on each page before rendering
- rearrange sidebar navigation with new permissions
- allow all users to view weekly assignments but restrict create actions
- add placeholder page and route for additional activities

## Testing
- `npm run lint --silent` *(web, warnings only)*
- `npm run lint --silent` *(api, fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_68736c8900f0832bbbd1178a6fbeca44