### PR TITLE
Implement master kegiatan support for daily tasks

### DIFF
--- a/api/prisma/migrations/20250720000000_update_kegiatan_tambahan/migration.sql
+++ b/api/prisma/migrations/20250720000000_update_kegiatan_tambahan/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `KegiatanTambahan`
+  ADD COLUMN `deskripsi` VARCHAR(191) NULL,
+  ADD COLUMN `tanggal_selesai` DATETIME(3) NULL,
+  ADD COLUMN `tanggal_selesai_akhir` DATETIME(3) NULL;

--- a/api/prisma/migrations/20250721000000_add_relations_kegiatan_tambahan/migration.sql
+++ b/api/prisma/migrations/20250721000000_add_relations_kegiatan_tambahan/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `KegiatanTambahan`
+  ADD COLUMN `kegiatanId` INTEGER NOT NULL,
+  ADD COLUMN `teamId` INTEGER NOT NULL,
+  ADD CONSTRAINT `KegiatanTambahan_kegiatanId_fkey` FOREIGN KEY (`kegiatanId`) REFERENCES `MasterKegiatan`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT `KegiatanTambahan_teamId_fkey` FOREIGN KEY (`teamId`) REFERENCES `Team`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -78,8 +78,15 @@ model KegiatanTambahan {
   tanggal  DateTime
   status   String
   bukti_link String?
+  deskripsi String?
+  tanggal_selesai DateTime?
+  tanggal_selesai_akhir DateTime?
   userId   Int
+  kegiatanId Int
+  teamId Int
   user     User     @relation(fields: [userId], references: [id])
+  kegiatan MasterKegiatan @relation(fields: [kegiatanId], references: [id])
+  team     Team  @relation(fields: [teamId], references: [id])
 }
 
 model Role {

--- a/api/src/laporan/dto/update-tambahan.dto.ts
+++ b/api/src/laporan/dto/update-tambahan.dto.ts
@@ -1,14 +1,17 @@
 import { IsDateString, IsInt, IsOptional, IsString } from "class-validator";
 
-export class AddTambahanDto {
+export class UpdateTambahanDto {
+  @IsOptional()
   @IsInt()
-  kegiatanId!: number;
+  kegiatanId?: number;
 
+  @IsOptional()
   @IsDateString()
-  tanggal!: string;
+  tanggal?: string;
 
+  @IsOptional()
   @IsString()
-  status!: string;
+  status?: string;
 
   @IsOptional()
   @IsString()

--- a/api/src/laporan/kegiatan-tambahan.controller.ts
+++ b/api/src/laporan/kegiatan-tambahan.controller.ts
@@ -5,11 +5,16 @@ import {
   Body,
   UseGuards,
   Req,
+  Param,
+  ParseIntPipe,
+  Put,
+  Delete,
 } from "@nestjs/common";
 import { Request } from "express";
 import { TambahanService } from "./kegiatan-tambahan.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { AddTambahanDto } from "./dto/add-tambahan.dto";
+import { UpdateTambahanDto } from "./dto/update-tambahan.dto";
 
 @Controller("kegiatan-tambahan")
 @UseGuards(JwtAuthGuard)
@@ -26,5 +31,27 @@ export class TambahanController {
   getByUser(@Req() req: Request) {
     const userId = (req.user as any).userId;
     return this.tambahanService.getByUser(userId);
+  }
+
+  @Get(":id")
+  detail(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
+    const userId = (req.user as any).userId;
+    return this.tambahanService.getOne(id, userId);
+  }
+
+  @Put(":id")
+  update(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() body: UpdateTambahanDto,
+    @Req() req: Request,
+  ) {
+    const userId = (req.user as any).userId;
+    return this.tambahanService.update(id, body, userId);
+  }
+
+  @Delete(":id")
+  remove(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
+    const userId = (req.user as any).userId;
+    return this.tambahanService.remove(id, userId);
   }
 }

--- a/api/src/laporan/kegiatan-tambahan.service.ts
+++ b/api/src/laporan/kegiatan-tambahan.service.ts
@@ -1,14 +1,63 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, BadRequestException } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 
 @Injectable()
 export class TambahanService {
   constructor(private prisma: PrismaService) {}
-  add(data: any) {
-    return this.prisma.kegiatanTambahan.create({ data });
+  async add(data: any) {
+    const master = await this.prisma.masterKegiatan.findUnique({
+      where: { id: data.kegiatanId },
+    });
+    if (!master) throw new BadRequestException('master kegiatan tidak ditemukan');
+    return this.prisma.kegiatanTambahan.create({
+      data: {
+        nama: master.nama_kegiatan,
+        tanggal: new Date(data.tanggal),
+        status: data.status,
+        bukti_link: data.bukti_link,
+        deskripsi: data.deskripsi,
+        tanggal_selesai: data.tanggal_selesai ? new Date(data.tanggal_selesai) : undefined,
+        tanggal_selesai_akhir: data.tanggal_selesai_akhir ? new Date(data.tanggal_selesai_akhir) : undefined,
+        userId: data.userId,
+        kegiatanId: master.id,
+        teamId: master.teamId,
+      },
+      include: { kegiatan: { include: { team: true } } },
+    });
   }
 
   getByUser(userId: number) {
-    return this.prisma.kegiatanTambahan.findMany({ where: { userId } });
+    return this.prisma.kegiatanTambahan.findMany({
+      where: { userId },
+      include: { kegiatan: { include: { team: true } } },
+    });
+  }
+
+  getOne(id: number, userId: number) {
+    return this.prisma.kegiatanTambahan.findFirst({
+      where: { id, userId },
+      include: { kegiatan: { include: { team: true } } },
+    });
+  }
+
+  async update(id: number, data: any, userId: number) {
+    const updateData: any = { ...data };
+    if (data.kegiatanId) {
+      const master = await this.prisma.masterKegiatan.findUnique({
+        where: { id: data.kegiatanId },
+      });
+      if (!master) throw new BadRequestException('master kegiatan tidak ditemukan');
+      updateData.nama = master.nama_kegiatan;
+      updateData.teamId = master.teamId;
+    }
+    return this.prisma.kegiatanTambahan.update({
+      where: { id, userId },
+      data: updateData,
+      include: { kegiatan: { include: { team: true } } },
+    });
+  }
+
+  remove(id: number, userId: number) {
+    return this.prisma.kegiatanTambahan.delete({ where: { id, userId } });
   }
 }

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -1,0 +1,288 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import axios from "axios";
+import Swal from "sweetalert2";
+import { Pencil, Trash2 } from "lucide-react";
+import Select from "react-select";
+
+const selectStyles = {
+  option: (base) => ({ ...base, color: "#000" }),
+  menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+};
+
+export default function KegiatanTambahanDetailPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [item, setItem] = useState(null);
+  const [editing, setEditing] = useState(false);
+  const [kegiatan, setKegiatan] = useState([]);
+  const [laporanForm, setLaporanForm] = useState({
+    tanggal_selesai: "",
+    tanggal_selesai_akhir: "",
+    bukti_link: "",
+    status: "Selesai Dikerjakan",
+  });
+  const [form, setForm] = useState({
+    kegiatanId: "",
+    tanggal: "",
+    status: "Belum",
+    deskripsi: "",
+  });
+
+  const fetchDetail = async () => {
+    try {
+      const [dRes, kRes] = await Promise.all([
+        axios.get(`/kegiatan-tambahan/${id}`),
+        axios.get("/master-kegiatan?limit=1000"),
+      ]);
+      setItem(dRes.data);
+      setKegiatan(kRes.data.data || kRes.data);
+      setForm({
+        kegiatanId: dRes.data.kegiatanId,
+        tanggal: dRes.data.tanggal.slice(0, 10),
+        status: dRes.data.status,
+        deskripsi: dRes.data.deskripsi || "",
+      });
+    } catch (err) {
+      console.error(err);
+      Swal.fire("Error", "Gagal mengambil data", "error");
+    }
+  };
+
+  useEffect(() => {
+    fetchDetail();
+  }, [id]);
+
+  const save = async () => {
+    try {
+      await axios.put(`/kegiatan-tambahan/${id}`, form);
+      Swal.fire("Berhasil", "Kegiatan diperbarui", "success");
+      setEditing(false);
+      fetchDetail();
+    } catch (err) {
+      console.error(err);
+      Swal.fire("Error", "Gagal menyimpan", "error");
+    }
+  };
+
+  const addLaporan = async () => {
+    try {
+      await axios.put(`/kegiatan-tambahan/${id}`, laporanForm);
+      Swal.fire("Berhasil", "Laporan ditambah", "success");
+      setLaporanForm({
+        tanggal_selesai: "",
+        tanggal_selesai_akhir: "",
+        bukti_link: "",
+        status: "Selesai Dikerjakan",
+      });
+      fetchDetail();
+    } catch (err) {
+      console.error(err);
+      Swal.fire("Error", "Gagal menambah laporan", "error");
+    }
+  };
+
+  const remove = async () => {
+    const r = await Swal.fire({
+      title: "Hapus kegiatan ini?",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonText: "Hapus",
+    });
+    if (!r.isConfirmed) return;
+    try {
+      await axios.delete(`/kegiatan-tambahan/${id}`);
+      Swal.fire("Dihapus", "Kegiatan dihapus", "success");
+      navigate(-1);
+    } catch (err) {
+      console.error(err);
+      Swal.fire("Error", "Gagal menghapus", "error");
+    }
+  };
+
+  if (!item) return <div className="p-6">Memuat...</div>;
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-xl font-semibold">Detail Kegiatan Tambahan</h2>
+        {!editing && (
+          <div className="space-x-2">
+            <button
+              onClick={() => setEditing(true)}
+              className="p-2 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+            >
+              <Pencil size={16} />
+            </button>
+            <button
+              onClick={remove}
+              className="p-2 bg-red-600 hover:bg-red-700 text-white rounded"
+            >
+              <Trash2 size={16} />
+            </button>
+          </div>
+        )}
+      </div>
+      {!editing ? (
+        <div className="space-y-2 bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
+          <div>
+            <div className="text-sm text-gray-500">Nama</div>
+            <div className="font-medium">{item.nama}</div>
+          </div>
+          <div>
+            <div className="text-sm text-gray-500">Tim</div>
+            <div className="font-medium">{item.kegiatan.team?.nama_tim || "-"}</div>
+          </div>
+          <div>
+            <div className="text-sm text-gray-500">Tanggal</div>
+            <div className="font-medium">{item.tanggal.slice(0, 10)}</div>
+          </div>
+          <div>
+            <div className="text-sm text-gray-500">Deskripsi</div>
+            <div className="font-medium">{item.deskripsi || "-"}</div>
+          </div>
+          <div>
+            <div className="text-sm text-gray-500">Status</div>
+            <div className="font-medium">{item.status}</div>
+          </div>
+          {item.tanggal_selesai && (
+            <div>
+              <div className="text-sm text-gray-500">Tanggal Selesai</div>
+              <div className="font-medium">
+                {item.tanggal_selesai.slice(0, 10)}
+                {item.tanggal_selesai_akhir &&
+                  ` - ${item.tanggal_selesai_akhir.slice(0, 10)}`}
+              </div>
+            </div>
+          )}
+          {item.bukti_link && (
+            <div>
+              <div className="text-sm text-gray-500">Bukti</div>
+              <a
+                href={item.bukti_link}
+                target="_blank"
+                rel="noreferrer"
+                className="text-blue-600 underline"
+              >
+                Link
+              </a>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-2 bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
+          <div>
+            <label className="block text-sm mb-1">Kegiatan</label>
+            <Select
+              classNamePrefix="react-select"
+              styles={selectStyles}
+              menuPortalTarget={document.body}
+              options={kegiatan.map((k) => ({ value: k.id, label: k.nama_kegiatan }))}
+              value={
+                form.kegiatanId
+                  ? { value: form.kegiatanId, label: kegiatan.find((k) => k.id === form.kegiatanId)?.nama_kegiatan }
+                  : null
+              }
+              onChange={(o) => setForm({ ...form, kegiatanId: o ? parseInt(o.value, 10) : "" })}
+              placeholder="Pilih kegiatan..."
+            />
+            {form.kegiatanId && (
+              <p className="text-sm mt-1 text-gray-600 dark:text-gray-300">
+                Tim: {kegiatan.find((k) => k.id === form.kegiatanId)?.team?.nama_tim || "-"}
+              </p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Tanggal</label>
+            <input
+              type="date"
+              value={form.tanggal}
+              onChange={(e) => setForm({ ...form, tanggal: e.target.value })}
+              className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Deskripsi</label>
+            <textarea
+              value={form.deskripsi}
+              onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
+              className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Status</label>
+            <select
+              value={form.status}
+              onChange={(e) => setForm({ ...form, status: e.target.value })}
+              className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+            >
+              <option value="Belum">Belum</option>
+              <option value="Sedang Dikerjakan">Sedang Dikerjakan</option>
+              <option value="Selesai Dikerjakan">Selesai Dikerjakan</option>
+            </select>
+          </div>
+          <div className="flex justify-end space-x-2 pt-2">
+            <button
+              onClick={() => setEditing(false)}
+              className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
+            >
+              Batal
+            </button>
+            <button
+              onClick={save}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+            >
+              Simpan
+            </button>
+          </div>
+        </div>
+      )}
+      <div className="space-y-2 bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
+        <h3 className="text-lg font-semibold">Bukti / Laporan Selesai</h3>
+        <div className="space-y-2">
+          <div>
+            <label className="block text-sm mb-1">Tanggal Mulai</label>
+            <input
+              type="date"
+              value={laporanForm.tanggal_selesai}
+              onChange={(e) =>
+                setLaporanForm({ ...laporanForm, tanggal_selesai: e.target.value })
+              }
+              className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Tanggal Akhir</label>
+            <input
+              type="date"
+              value={laporanForm.tanggal_selesai_akhir}
+              onChange={(e) =>
+                setLaporanForm({ ...laporanForm, tanggal_selesai_akhir: e.target.value })
+              }
+              className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Link Bukti</label>
+            <input
+              type="text"
+              value={laporanForm.bukti_link}
+              onChange={(e) =>
+                setLaporanForm({ ...laporanForm, bukti_link: e.target.value })
+              }
+              className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+            />
+          </div>
+        </div>
+        <div className="flex justify-end pt-2">
+          <button
+            onClick={addLaporan}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+          >
+            Simpan Bukti
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -1,10 +1,256 @@
-import React from "react";
+import { useEffect, useState } from "react";
+import axios from "axios";
+import Swal from "sweetalert2";
+import { Plus, Eye, Pencil, Trash2 } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import Select from "react-select";
+
+const selectStyles = {
+  option: (base) => ({ ...base, color: "#000" }),
+  menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+};
 
 export default function KegiatanTambahanPage() {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState(null);
+  const [kegiatan, setKegiatan] = useState([]);
+  const [form, setForm] = useState({
+    kegiatanId: "",
+    tanggal: new Date().toISOString().slice(0, 10),
+    status: "Belum",
+    deskripsi: "",
+  });
+  const navigate = useNavigate();
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      const [tRes, kRes] = await Promise.all([
+        axios.get("/kegiatan-tambahan"),
+        axios.get("/master-kegiatan?limit=1000"),
+      ]);
+      setItems(tRes.data);
+      setKegiatan(kRes.data.data || kRes.data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const openCreate = () => {
+    setEditing(null);
+    setForm({
+      kegiatanId: "",
+      tanggal: new Date().toISOString().slice(0, 10),
+      status: "Belum",
+      deskripsi: "",
+    });
+    setShowForm(true);
+  };
+
+  const openEdit = (item) => {
+    setEditing(item);
+    setForm({
+      kegiatanId: item.kegiatanId,
+      tanggal: item.tanggal.slice(0, 10),
+      status: item.status,
+      deskripsi: item.deskripsi || "",
+    });
+    setShowForm(true);
+  };
+
+  const save = async () => {
+    if (!form.kegiatanId || !form.tanggal) return;
+    try {
+      if (editing) {
+        await axios.put(`/kegiatan-tambahan/${editing.id}`, form);
+      } else {
+        await axios.post("/kegiatan-tambahan", form);
+      }
+      setShowForm(false);
+      setEditing(null);
+      fetchData();
+      Swal.fire("Berhasil", "Data disimpan", "success");
+    } catch (err) {
+      console.error(err);
+      Swal.fire("Error", "Gagal menyimpan", "error");
+    }
+  };
+
+  const remove = async (item) => {
+    const r = await Swal.fire({
+      title: "Hapus kegiatan ini?",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonText: "Hapus",
+    });
+    if (!r.isConfirmed) return;
+    try {
+      await axios.delete(`/kegiatan-tambahan/${item.id}`);
+      fetchData();
+      Swal.fire("Dihapus", "Kegiatan dihapus", "success");
+    } catch (err) {
+      console.error(err);
+      Swal.fire("Error", "Gagal menghapus", "error");
+    }
+  };
+
+  const openDetail = (id) => {
+    navigate(`/kegiatan-tambahan/${id}`);
+  };
+
   return (
-    <div className="p-6">
-      <h1 className="text-xl font-semibold mb-2">Kegiatan Tambahan</h1>
-      <p>Halaman ini belum tersedia.</p>
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-semibold">Kegiatan Tambahan</h1>
+        <button
+          onClick={openCreate}
+          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
+        >
+          <Plus size={16} /> Tambah
+        </button>
+      </div>
+
+      <table className="min-w-full bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow">
+        <thead>
+          <tr className="bg-gray-200 dark:bg-gray-700 text-center text-sm uppercase">
+            <th className="px-4 py-2">No</th>
+            <th className="px-4 py-2">Nama</th>
+            <th className="px-4 py-2">Tim</th>
+            <th className="px-4 py-2">Tanggal</th>
+            <th className="px-4 py-2">Status</th>
+            <th className="px-4 py-2">Aksi</th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading ? (
+            <tr>
+              <td colSpan="5" className="py-4 text-center">
+                Memuat data...
+              </td>
+            </tr>
+          ) : items.length === 0 ? (
+            <tr>
+              <td colSpan="5" className="py-4 text-center">
+                Data tidak ditemukan
+              </td>
+            </tr>
+          ) : (
+            items.map((item, idx) => (
+              <tr key={item.id} className="border-t dark:border-gray-700 text-center">
+                <td className="px-4 py-2">{idx + 1}</td>
+                <td className="px-4 py-2">{item.nama}</td>
+                <td className="px-4 py-2">{item.kegiatan.team?.nama_tim || '-'}</td>
+                <td className="px-4 py-2">{item.tanggal.slice(0,10)}</td>
+                <td className="px-4 py-2">{item.status}</td>
+                <td className="px-4 py-2 space-x-2">
+                  <button
+                    onClick={() => openDetail(item.id)}
+                    className="p-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+                  >
+                    <Eye size={16} />
+                  </button>
+                  <button
+                    onClick={() => openEdit(item)}
+                    className="p-2 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                  >
+                    <Pencil size={16} />
+                  </button>
+                  <button
+                    onClick={() => remove(item)}
+                    className="p-2 bg-red-600 hover:bg-red-700 text-white rounded"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+
+      {showForm && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md space-y-4 shadow-xl">
+            <h2 className="text-xl font-semibold mb-2">
+              {editing ? "Edit Kegiatan" : "Tambah Kegiatan"}
+            </h2>
+            <div className="space-y-2">
+              <div>
+                <label className="block text-sm mb-1">Kegiatan</label>
+                <Select
+                  classNamePrefix="react-select"
+                  styles={selectStyles}
+                  menuPortalTarget={document.body}
+                  options={kegiatan.map((k) => ({ value: k.id, label: k.nama_kegiatan }))}
+                  value={
+                    form.kegiatanId
+                      ? { value: form.kegiatanId, label: kegiatan.find((k) => k.id === form.kegiatanId)?.nama_kegiatan }
+                      : null
+                  }
+                  onChange={(o) => setForm({ ...form, kegiatanId: o ? parseInt(o.value, 10) : "" })}
+                  placeholder="Pilih kegiatan..."
+                />
+                {form.kegiatanId && (
+                  <p className="text-sm mt-1 text-gray-600 dark:text-gray-300">
+                    Tim: {kegiatan.find((k) => k.id === form.kegiatanId)?.team?.nama_tim || "-"}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label className="block text-sm mb-1">Tanggal</label>
+                <input
+                  type="date"
+                  value={form.tanggal}
+                  onChange={(e) => setForm({ ...form, tanggal: e.target.value })}
+                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                />
+              </div>
+              <div>
+                <label className="block text-sm mb-1">Deskripsi</label>
+                <textarea
+                  value={form.deskripsi}
+                  onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
+                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                />
+              </div>
+              <div>
+                <label className="block text-sm mb-1">Status</label>
+                <select
+                  value={form.status}
+                  onChange={(e) => setForm({ ...form, status: e.target.value })}
+                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                >
+                  <option value="Belum">Belum</option>
+                  <option value="Sedang Dikerjakan">Sedang Dikerjakan</option>
+                  <option value="Selesai Dikerjakan">Selesai Dikerjakan</option>
+                </select>
+              </div>
+            </div>
+            <div className="flex justify-end space-x-2 pt-2">
+              <button
+                onClick={() => {
+                  setShowForm(false);
+                  setEditing(null);
+                }}
+                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
+              >
+                Batal
+              </button>
+              <button onClick={save} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded">
+                Simpan
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/routes/AppRoutes.jsx
+++ b/web/src/routes/AppRoutes.jsx
@@ -10,6 +10,7 @@ import PenugasanPage from "../pages/penugasan/PenugasanPage";
 import PenugasanDetailPage from "../pages/penugasan/PenugasanDetailPage";
 import LaporanHarianPage from "../pages/laporan/LaporanHarianPage";
 import KegiatanTambahanPage from "../pages/tambahan/KegiatanTambahanPage";
+import KegiatanTambahanDetailPage from "../pages/tambahan/KegiatanTambahanDetailPage";
 
 function PrivateRoute({ children }) {
   const { token, user } = useAuth();
@@ -47,6 +48,7 @@ export default function AppRoutes() {
         <Route path="penugasan/:id" element={<PenugasanDetailPage />} />
         <Route path="laporan-harian" element={<LaporanHarianPage />} />
         <Route path="kegiatan-tambahan" element={<KegiatanTambahanPage />} />
+        <Route path="kegiatan-tambahan/:id" element={<KegiatanTambahanDetailPage />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## Summary
- extend `KegiatanTambahan` schema with `kegiatanId` and `teamId`
- create migration for new relations
- update DTOs and service logic to use master kegiatan
- enhance daily activities pages to choose master kegiatan and display team info

## Testing
- `npm run lint` in `web`
- `npm run build` in `api`


------
https://chatgpt.com/codex/tasks/task_b_6873a445af8c832bba0fa371c6b1ce9d