### PR TITLE
Clean unused weekly calculations

### DIFF
--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -62,20 +62,6 @@ const Dashboard = () => {
           axios.get("/monitoring/bulanan", { params: { bulan: String(year), ...filters } }),
         ]);
 
-        const mingguKe = Math.ceil(today.getDate() / 7);
-        const weekAssignments = (penRes.data || []).filter(
-          (p) => parseInt(p.minggu, 10) === mingguKe
-        );
-        const selesaiCount = weekAssignments.filter((p) =>
-          String(p.status).toLowerCase().includes("selesai")
-        ).length;
-
-        const weeklyDataFixed = {
-          ...weeklyRes.data,
-          totalTugas: weekAssignments.length,
-          totalSelesai: selesaiCount,
-        };
-
         setDailyData(dailyRes.data);
         setWeeklyList(weeklyArray);
         setWeekIndex(currentIndex);


### PR DESCRIPTION
## Summary
- remove unused variables from dashboard page

## Testing
- `npm run lint` *(fails: monthlyData never used, monthlyProgress undefined, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68746529a3d4832b89bb0ae0e54e8b9c