### PR TITLE
Enforce JWT secret env

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -50,11 +50,12 @@ npm install
 ```
 
 3. **Konfigurasi environment**
-Buat file `.env` dan isi:
+Buat file `.env` dan isi (nilai `JWT_SECRET` wajib diisi, server akan gagal start jika kosong):
 ```
 DATABASE_URL="mysql://root:password@localhost:3306/semakin_6502"
 JWT_SECRET="supersecretjwtkey"
 ```
+Jika `JWT_SECRET` tidak diatur, aplikasi akan langsung keluar dengan error.
 
 4. **Setup database**
 ```bash

--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -6,10 +6,16 @@ import { AuthController } from "./auth.controller";
 import { PrismaService } from "../prisma.service"; // ⬅ Import manual
 import { JwtStrategy } from "./jwt.strategy";
 
+const jwtSecret = process.env.JWT_SECRET;
+if (!jwtSecret) {
+  // Fail fast when JWT_SECRET is missing
+  throw new Error("JWT_SECRET environment variable is required");
+}
+
 @Module({
   imports: [
     JwtModule.register({
-      secret: process.env.JWT_SECRET || "supersecretjwtkey",
+      secret: jwtSecret,
       signOptions: { expiresIn: process.env.JWT_EXPIRES_IN || "1d" },
     }),
   ],


### PR DESCRIPTION
## Summary
- ensure API exits if `JWT_SECRET` is missing
- document the new requirement in the API README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_b_687465642b48832b8502b04b53cd60c0