### PR TITLE
Remove unused month names

### DIFF
--- a/web/src/components/dashboard/MonthlyOverview.jsx
+++ b/web/src/components/dashboard/MonthlyOverview.jsx
@@ -1,18 +1,4 @@
 const MonthlyOverview = ({ data = [] }) => {
-  const monthNames = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "Mei",
-    "Jun",
-    "Jul",
-    "Agu",
-    "Sep",
-    "Okt",
-    "Nov",
-    "Des",
-  ];
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- tidy up MonthlyOverview by removing unused monthNames array

## Testing
- `npm run lint` *(fails: MonitoringTabs.jsx etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68747cf5dba0832bbb2fc7df81975867