### PR TITLE
Fix hook dependency warnings

### DIFF
--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -1,7 +1,7 @@
 import { Outlet, useLocation } from "react-router-dom";
 import Sidebar from "./Sidebar";
 import { useAuth } from "../auth/useAuth";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useTheme } from "../../theme/useTheme.jsx";
 import Swal from "sweetalert2";
 import {
@@ -70,16 +70,16 @@ export default function Layout() {
   }, []);
 
   const displayedNotifications = notifications.slice(0, 5);
-  const getPageTitle = () => {
+  const getPageTitle = useCallback(() => {
     const slug = location.pathname.split("/")[1] || "dashboard";
     return slug
       .replaceAll("-", " ")
       .replace(/^\w/, (c) => c.toUpperCase());
-  };
+  }, [location.pathname]);
 
   useEffect(() => {
     document.title = `${getPageTitle()} - SEMAKIN 6502`;
-  }, [location]);
+  }, [getPageTitle]);
 
   return (
     <div className="h-screen overflow-hidden flex text-gray-800 dark:text-gray-100 bg-gray-100 dark:bg-gray-900">

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
 import Swal from "sweetalert2";
@@ -54,7 +54,7 @@ export default function PenugasanDetailPage() {
     "Desember",
   ];
 
-  const fetchDetail = async () => {
+  const fetchDetail = useCallback(async () => {
     try {
       const res = await axios.get(`/penugasan/${id}`);
       setItem(res.data);
@@ -71,7 +71,7 @@ export default function PenugasanDetailPage() {
       console.error(err);
       Swal.fire("Error", "Gagal mengambil data", "error");
     }
-  };
+  }, [id]);
 
   useEffect(() => {
     fetchDetail();
@@ -94,7 +94,7 @@ export default function PenugasanDetailPage() {
     } else if (user) {
       setUsers([user]);
     }
-  }, [id, canManage, user]);
+  }, [id, canManage, user, fetchDetail]);
 
   const save = async () => {
     try {

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -85,7 +85,7 @@ export default function PenugasanPage() {
     } finally {
       setLoading(false);
     }
-  }, [user?.role, filterBulan, filterTahun]);
+  }, [user, filterBulan, filterTahun, canManage]);
 
   useEffect(() => {
     fetchData();

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
 import Swal from "sweetalert2";
@@ -29,7 +29,7 @@ export default function KegiatanTambahanDetailPage() {
     deskripsi: "",
   });
 
-  const fetchDetail = async () => {
+  const fetchDetail = useCallback(async () => {
     try {
       const [dRes, kRes] = await Promise.all([
         axios.get(`/kegiatan-tambahan/${id}`),
@@ -47,11 +47,11 @@ export default function KegiatanTambahanDetailPage() {
       console.error(err);
       Swal.fire("Error", "Gagal mengambil data", "error");
     }
-  };
+  }, [id]);
 
   useEffect(() => {
     fetchDetail();
-  }, [id]);
+  }, [fetchDetail]);
 
   const save = async () => {
     try {


### PR DESCRIPTION
## Summary
- silence linter complaints about Layout title update
- include auth and filter deps in penugasan fetch
- wrap detail fetches in callbacks for dependency safety

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68747cfbb474832bad967091d5e86ff7