### PR TITLE
Add ESLint config for API

### DIFF
--- a/api/eslint.config.js
+++ b/api/eslint.config.js
@@ -1,0 +1,36 @@
+const { FlatCompat } = require('@eslint/eslintrc');
+const js = require('@eslint/js');
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+module.exports = [
+  ...compat.extends(
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'plugin:prettier/recommended'
+  ),
+  ...compat.env({
+    node: true,
+    jest: true,
+  }),
+  ...compat.config({
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+      project: 'tsconfig.json',
+      tsconfigRootDir: __dirname,
+      sourceType: 'module',
+    },
+    plugins: ['@typescript-eslint'],
+    ignorePatterns: ['dist/', 'node_modules/'],
+    rules: {
+      '@typescript-eslint/interface-name-prefix': 'off',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  }),
+];

--- a/api/package.json
+++ b/api/package.json
@@ -8,7 +8,7 @@
     "start:dev": "nest start --watch",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint . --ext .ts",
     "test": "jest",
     "seed": "ts-node prisma/seed.ts"
   },


### PR DESCRIPTION
## Summary
- add `eslint.config.js` with NestJS oriented rules
- adjust `lint` script to use new config

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_6874843c75fc832bb823726cd6bbb619