### PR TITLE
Update sweetalert2 to non-vulnerable release

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,7 +16,7 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
         "react-select": "^5.10.2",
-        "sweetalert2": "^11.10.0"
+        "sweetalert2": "10.16.9"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -4825,13 +4825,12 @@
       }
     },
     "node_modules/sweetalert2": {
-      "version": "11.22.2",
-      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.22.2.tgz",
-      "integrity": "sha512-GFQGzw8ZXF23PO79WMAYXLl4zYmLiaKqYJwcp5eBF07wiI5BYPbZtKi2pcvVmfUQK+FqL1risJAMxugcPbGIyg==",
+      "version": "10.16.9",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-10.16.9.tgz",
+      "integrity": "sha512-oNe+md5tmmS3fGfVHa7gVPlun7Td2oANSacnZCeghnrr3OHBi6UPVPU+GFrymwaDqwQspACilLRmRnM7aTjNPA==",
       "license": "MIT",
       "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/limonte"
+        "url": "https://sweetalert2.github.io/#donations"
       }
     },
     "node_modules/tabbable": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
     "react-select": "^5.10.2",
-    "sweetalert2": "^11.10.0"
+    "sweetalert2": "10.16.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",


### PR DESCRIPTION
## Summary
- downgrade `sweetalert2` dependency to `10.16.9` to avoid known vulnerabilities
- regenerate lockfile

## Testing
- `npm install`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_b_6874843c2d24832b85df8d97fcb534a3