### PR TITLE
Move holidays list to utils

### DIFF
--- a/web/src/components/dashboard/DailyOverview.jsx
+++ b/web/src/components/dashboard/DailyOverview.jsx
@@ -1,24 +1,17 @@
+import { getHolidays } from "../../utils/holidays";
+
 const DailyOverview = ({ data = [] }) => {
   if (!Array.isArray(data)) return <p>Data tidak tersedia</p>;
 
   const today = new Date().toISOString().slice(0, 10);
+  const currentYear = new Date(today).getFullYear();
 
   const formatDate = (iso) => {
     const [y, m, d] = iso.split("-");
     return `${d}-${m}-${y}`;
   };
 
-  const HOLIDAYS = [
-    "2025-01-01",
-    "2025-02-10",
-    "2025-03-28",
-    "2025-03-29",
-    "2025-05-01",
-    "2025-05-02",
-    "2025-08-17",
-    "2025-12-25",
-    "2025-12-26",
-  ];
+  const HOLIDAYS = getHolidays(currentYear);
 
   const isWeekend = (iso) => {
     const d = new Date(iso);

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -11,7 +11,6 @@ export default function LaporanHarianPage() {
   const [tanggal, setTanggal] = useState(new Date().toISOString().slice(0, 10));
   const [pageSize, setPageSize] = useState(10);
   const [currentPage, setCurrentPage] = useState(1);
-  const [tanggal, setTanggal] = useState("");
   const [search, setSearch] = useState("");
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState({

--- a/web/src/utils/holidays.js
+++ b/web/src/utils/holidays.js
@@ -1,0 +1,11 @@
+export const getHolidays = (year) => [
+  `${year}-01-01`,
+  `${year}-02-10`,
+  `${year}-03-28`,
+  `${year}-03-29`,
+  `${year}-05-01`,
+  `${year}-05-02`,
+  `${year}-08-17`,
+  `${year}-12-25`,
+  `${year}-12-26`,
+];


### PR DESCRIPTION
## Summary
- refactor DailyOverview to fetch holidays using a util function
- remove duplicate state definition in LaporanHarianPage
- add a new holidays utility

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6874843d6040832bb857978f62e55aff