### PR TITLE
Use NotFoundException in MasterKegiatanService

### DIFF
--- a/api/src/kegiatan/master-kegiatan.service.ts
+++ b/api/src/kegiatan/master-kegiatan.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ForbiddenException } from "@nestjs/common";
+import { Injectable, ForbiddenException, NotFoundException } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 import { CreateMasterKegiatanDto } from "./dto/create-master-kegiatan.dto";
 import { UpdateMasterKegiatanDto } from "./dto/update-master-kegiatan.dto";
@@ -59,7 +59,7 @@ export class MasterKegiatanService {
     const existing = await this.prisma.masterKegiatan.findUnique({
       where: { id },
     });
-    if (!existing) throw new Error("not found");
+    if (!existing) throw new NotFoundException("not found");
     if (role !== "admin") {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: existing.teamId, userId, is_leader: true },
@@ -75,7 +75,7 @@ export class MasterKegiatanService {
 
   async remove(id: number, userId: number, role: string) {
     const existing = await this.prisma.masterKegiatan.findUnique({ where: { id } });
-    if (!existing) throw new Error("not found");
+    if (!existing) throw new NotFoundException("not found");
     if (role !== "admin") {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: existing.teamId, userId, is_leader: true },


### PR DESCRIPTION
## Summary
- replace generic `Error('not found')` with NestJS `NotFoundException`

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_68749f276e3c832ba5c6a4bbfe698bd4