### PR TITLE
Add role normalization helper

### DIFF
--- a/api/src/common/roles.ts
+++ b/api/src/common/roles.ts
@@ -1,0 +1,16 @@
+import { BadRequestException } from "@nestjs/common";
+
+export const VALID_ROLES = ["admin", "pimpinan", "ketua", "anggota"] as const;
+
+export type ValidRole = (typeof VALID_ROLES)[number];
+
+export function normalizeRole(role: string): ValidRole {
+  if (!role) {
+    throw new BadRequestException("role is required");
+  }
+  const r = role.toLowerCase();
+  if (!VALID_ROLES.includes(r as ValidRole)) {
+    throw new BadRequestException(`invalid role: ${role}`);
+  }
+  return r as ValidRole;
+}

--- a/api/src/kegiatan/penugasan.service.ts
+++ b/api/src/kegiatan/penugasan.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
 } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
+import { normalizeRole } from "../common/roles";
 
 @Injectable()
 export class PenugasanService {
@@ -14,7 +15,7 @@ export class PenugasanService {
     userId: number,
     filter: { bulan?: string; tahun?: number }
   ) {
-    role = role?.toLowerCase?.() || role;
+    role = normalizeRole(role);
     const opts: any = {
       include: {
         kegiatan: { include: { team: true } },
@@ -50,7 +51,7 @@ export class PenugasanService {
   }
 
   async assign(data: any, userId: number, role: string) {
-    role = role?.toLowerCase?.() || role;
+    role = normalizeRole(role);
     const master = await this.prisma.masterKegiatan.findUnique({
       where: { id: data.kegiatanId },
     });
@@ -79,7 +80,7 @@ export class PenugasanService {
   }
 
   async assignBulk(data: any, userId: number, role: string) {
-    role = role?.toLowerCase?.() || role;
+    role = normalizeRole(role);
     const master = await this.prisma.masterKegiatan.findUnique({
       where: { id: data.kegiatanId },
     });
@@ -108,7 +109,7 @@ export class PenugasanService {
   }
 
   async findOne(id: number, role: string, userId: number) {
-    role = role?.toLowerCase?.() || role;
+    role = normalizeRole(role);
     const where: any = { id };
 
     if (role === "admin" || role === "pimpinan") {
@@ -133,7 +134,7 @@ export class PenugasanService {
   }
 
   async update(id: number, data: any, userId: number, role: string) {
-    role = role?.toLowerCase?.() || role;
+    role = normalizeRole(role);
     const existing = await this.prisma.penugasan.findUnique({
       where: { id },
       include: { kegiatan: true },
@@ -161,7 +162,7 @@ export class PenugasanService {
   }
 
   async remove(id: number, userId: number, role: string) {
-    role = role?.toLowerCase?.() || role;
+    role = normalizeRole(role);
     const existing = await this.prisma.penugasan.findUnique({
       where: { id },
       include: { kegiatan: true },


### PR DESCRIPTION
## Summary
- add `normalizeRole` helper with role validation
- use `normalizeRole` in `PenugasanService` instead of inline lowercasing

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68749f2b38b8832b8c37312c6a5d4d91