### PR TITLE
Rename bulan param to year

### DIFF
--- a/api/src/monitoring/monitoring.controller.ts
+++ b/api/src/monitoring/monitoring.controller.ts
@@ -93,13 +93,13 @@ export class MonitoringController {
 
   @Get("bulanan")
   async bulanan(
-    @Query("bulan") bulan?: string,
+    @Query("year") year?: string,
     @Req() req?: Request,
     @Query("teamId") teamId?: string,
     @Query("userId") userId?: string,
   ) {
-    if (!bulan) {
-      throw new BadRequestException("query 'bulan' diperlukan");
+    if (!year) {
+      throw new BadRequestException("query 'year' diperlukan");
     }
     const user = req?.user as any;
     const role = user?.role;
@@ -123,6 +123,6 @@ export class MonitoringController {
       }
     }
 
-    return this.monitoringService.bulanan(bulan, tId, uId);
+    return this.monitoringService.bulanan(year, tId, uId);
   }
 }

--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -127,12 +127,12 @@ export class MonitoringService {
     };
   }
 
-  async bulanan(bulan: string, teamId?: number, userId?: number) {
-    const year = parseInt(bulan, 10);
-    if (isNaN(year)) throw new BadRequestException("bulan tidak valid");
+  async bulanan(year: string, teamId?: number, userId?: number) {
+    const yr = parseInt(year, 10);
+    if (isNaN(yr)) throw new BadRequestException("year tidak valid");
 
-    const start = new Date(year, 0, 1);
-    const end = new Date(year, 11, 31);
+    const start = new Date(yr, 0, 1);
+    const end = new Date(yr, 11, 31);
 
     const harianWhere: any = { tanggal: { gte: start, lte: end } };
     if (userId) harianWhere.pegawaiId = userId;

--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -59,7 +59,7 @@ const Dashboard = () => {
         const [dailyRes, weeklyArray, monthlyRes] = await Promise.all([
           axios.get("/monitoring/harian", { params: { tanggal, ...filters } }),
           Promise.all(weeklyPromises),
-          axios.get("/monitoring/bulanan", { params: { bulan: String(year), ...filters } }),
+          axios.get("/monitoring/bulanan", { params: { year: String(year), ...filters } }),
         ]);
 
         setDailyData(dailyRes.data);

--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -10,7 +10,7 @@ import {
   UserCog,
 } from "lucide-react";
 
-export default function Sidebar({ mobileOpen, setMobileOpen }) {
+export default function Sidebar({ setMobileOpen }) {
   const { user } = useAuth();
 
   const mainLinks = [


### PR DESCRIPTION
## Summary
- rename API query parameter `bulan` to `year`
- update service logic for `bulanan`
- adjust Dashboard call to pass `year`
- fix unused prop warning in Sidebar

## Testing
- `npm --prefix web run lint`
- `npm --prefix api run lint` *(fails: missing eslint config/prettier issues)*
- `npm --prefix api test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68749f2ca24c832ba02ce3f94f275f2c