### PR TITLE
Create months utility

### DIFF
--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -5,6 +5,7 @@ import Swal from "sweetalert2";
 import Select from "react-select";
 import { Pencil, Trash2 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
+import months from "../../utils/months";
 
 const selectStyles = {
   option: (base) => ({ ...base, color: "#000" }),
@@ -39,20 +40,6 @@ export default function PenugasanDetailPage() {
     catatan: "",
   });
 
-  const months = [
-    "Januari",
-    "Februari",
-    "Maret",
-    "April",
-    "Mei",
-    "Juni",
-    "Juli",
-    "Agustus",
-    "September",
-    "Oktober",
-    "November",
-    "Desember",
-  ];
 
   const fetchDetail = useCallback(async () => {
     try {

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -6,6 +6,7 @@ import Select from "react-select";
 import { useAuth } from "../auth/useAuth";
 import { useNavigate } from "react-router-dom";
 import Pagination from "../../components/Pagination";
+import months from "../../utils/months";
 
 const selectStyles = {
   option: (base) => ({ ...base, color: "#000" }),
@@ -119,20 +120,6 @@ export default function PenugasanPage() {
     }
   };
 
-  const months = [
-    "Januari",
-    "Februari",
-    "Maret",
-    "April",
-    "Mei",
-    "Juni",
-    "Juli",
-    "Agustus",
-    "September",
-    "Oktober",
-    "November",
-    "Desember",
-  ];
 
   const filtered = penugasan.filter((p) => {
     const text = `${p.kegiatan?.nama_kegiatan || ""} ${p.pegawai?.nama || ""}`.toLowerCase();

--- a/web/src/utils/months.js
+++ b/web/src/utils/months.js
@@ -1,0 +1,16 @@
+export const months = [
+  "Januari",
+  "Februari",
+  "Maret",
+  "April",
+  "Mei",
+  "Juni",
+  "Juli",
+  "Agustus",
+  "September",
+  "Oktober",
+  "November",
+  "Desember",
+];
+
+export default months;


### PR DESCRIPTION
## Summary
- centralize months list in a new util
- reuse months util in Penugasan pages

## Testing
- `npm run lint` *(fails: 'mobileOpen' is defined but never used)*
- `npm run lint` in api *(fails: parserOptions project not found and many TS lint errors)*
- `npm test` in api *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68749f2d2034832b9fb12ebd9fd040ea