### PR TITLE
Remove unused headlessui dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,6 @@
       "name": "webapp",
       "version": "0.0.0",
       "dependencies": {
-        "@headlessui/react": "^2.2.4",
         "axios": "^1.10.0",
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
@@ -1105,26 +1104,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
-    },
-    "node_modules/@headlessui/react": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.4.tgz",
-      "integrity": "sha512-lz+OGcAH1dK93rgSMzXmm1qKOJkBUqZf1L4M8TWLNplftQD3IkoEDdUFNfAn4ylsN6WOTVtWaLmvmaHOUk1dTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react": "^0.26.16",
-        "@react-aria/focus": "^3.20.2",
-        "@react-aria/interactions": "^3.25.0",
-        "@tanstack/react-virtual": "^3.13.9",
-        "use-sync-external-store": "^1.5.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^18 || ^19 || ^19.0.0-rc"
-      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@headlessui/react": "^2.2.4",
     "axios": "^1.10.0",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- delete `@headlessui/react` from package.json
- clean up lockfile references

## Testing
- `npm run lint` *(fails: 'mobileOpen' is defined but never used)*
- `npm test` in `api` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68749f2dc1c8832b94cf663dcf189130