### PR TITLE
Centralize role constants

### DIFF
--- a/api/src/common/roles.constants.ts
+++ b/api/src/common/roles.constants.ts
@@ -1,0 +1,8 @@
+export const ROLES = {
+  ADMIN: "admin",
+  KETUA: "ketua",
+  ANGGOTA: "anggota",
+  PIMPINAN: "pimpinan",
+} as const;
+
+export type Role = (typeof ROLES)[keyof typeof ROLES];

--- a/api/src/kegiatan/master-kegiatan.service.ts
+++ b/api/src/kegiatan/master-kegiatan.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, ForbiddenException } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
+import { ROLES } from "../common/roles.constants";
 import { CreateMasterKegiatanDto } from "./dto/create-master-kegiatan.dto";
 import { UpdateMasterKegiatanDto } from "./dto/update-master-kegiatan.dto";
 
@@ -39,7 +40,7 @@ export class MasterKegiatanService {
   }
 
   async create(data: CreateMasterKegiatanDto, userId: number, role: string) {
-    if (role !== "admin") {
+    if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: data.teamId, userId, is_leader: true },
       });
@@ -60,7 +61,7 @@ export class MasterKegiatanService {
       where: { id },
     });
     if (!existing) throw new Error("not found");
-    if (role !== "admin") {
+    if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: existing.teamId, userId, is_leader: true },
       });
@@ -76,7 +77,7 @@ export class MasterKegiatanService {
   async remove(id: number, userId: number, role: string) {
     const existing = await this.prisma.masterKegiatan.findUnique({ where: { id } });
     if (!existing) throw new Error("not found");
-    if (role !== "admin") {
+    if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: existing.teamId, userId, is_leader: true },
       });

--- a/api/src/kegiatan/penugasan.service.ts
+++ b/api/src/kegiatan/penugasan.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
 } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
+import { ROLES } from "../common/roles.constants";
 
 @Injectable()
 export class PenugasanService {
@@ -26,9 +27,9 @@ export class PenugasanService {
     if (filter.bulan) opts.where.bulan = filter.bulan;
     if (filter.tahun) opts.where.tahun = filter.tahun;
 
-    if (role === "admin" || role === "pimpinan") {
+    if (role === ROLES.ADMIN || role === ROLES.PIMPINAN) {
       // admins and top management can see all assignments
-    } else if (role === "ketua") {
+    } else if (role === ROLES.KETUA) {
       // team leaders can see assignments in their teams as well as tasks
       // assigned specifically to them
       opts.where.OR = [
@@ -57,7 +58,7 @@ export class PenugasanService {
     if (!master) {
       throw new BadRequestException("master kegiatan tidak ditemukan");
     }
-    if (role !== "admin") {
+    if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: master.teamId, userId, is_leader: true },
       });
@@ -86,7 +87,7 @@ export class PenugasanService {
     if (!master) {
       throw new BadRequestException("master kegiatan tidak ditemukan");
     }
-    if (role !== "admin") {
+    if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: master.teamId, userId, is_leader: true },
       });
@@ -111,9 +112,9 @@ export class PenugasanService {
     role = role?.toLowerCase?.() || role;
     const where: any = { id };
 
-    if (role === "admin" || role === "pimpinan") {
+    if (role === ROLES.ADMIN || role === ROLES.PIMPINAN) {
       // no additional restrictions
-    } else if (role === "ketua") {
+    } else if (role === ROLES.KETUA) {
       where.OR = [
         {
           kegiatan: {
@@ -139,7 +140,7 @@ export class PenugasanService {
       include: { kegiatan: true },
     });
     if (!existing) throw new BadRequestException("not found");
-    if (role !== "admin") {
+    if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: existing.kegiatan.teamId, userId, is_leader: true },
       });
@@ -167,7 +168,7 @@ export class PenugasanService {
       include: { kegiatan: true },
     });
     if (!existing) throw new BadRequestException("not found");
-    if (role !== "admin") {
+    if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: existing.kegiatan.teamId, userId, is_leader: true },
       });

--- a/api/src/monitoring/monitoring.controller.ts
+++ b/api/src/monitoring/monitoring.controller.ts
@@ -12,6 +12,7 @@ import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
 import { PrismaService } from "../prisma.service";
 import { Request } from "express";
+import { ROLES } from "../common/roles.constants";
 
 @Controller("monitoring")
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -36,7 +37,7 @@ export class MonitoringController {
     let tId = teamId ? parseInt(teamId, 10) : undefined;
     let uId = userId ? parseInt(userId, 10) : undefined;
 
-    if (role !== "admin" && role !== "pimpinan") {
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
       const uid = user.userId;
       if (tId) {
         const member = await this.prisma.member.findFirst({
@@ -71,7 +72,7 @@ export class MonitoringController {
     let tId = teamId ? parseInt(teamId, 10) : undefined;
     let uId = userId ? parseInt(userId, 10) : undefined;
 
-    if (role !== "admin" && role !== "pimpinan") {
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
       const uid = user.userId;
       if (tId) {
         const member = await this.prisma.member.findFirst({
@@ -106,7 +107,7 @@ export class MonitoringController {
     let tId = teamId ? parseInt(teamId, 10) : undefined;
     let uId = userId ? parseInt(userId, 10) : undefined;
 
-    if (role !== "admin" && role !== "pimpinan") {
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
       const uid = user.userId;
       if (tId) {
         const member = await this.prisma.member.findFirst({

--- a/api/src/teams/teams.controller.ts
+++ b/api/src/teams/teams.controller.ts
@@ -15,6 +15,7 @@ import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
 import { Roles } from "../common/guards/roles.decorator";
 import { Request } from "express";
+import { ROLES } from "../common/roles.constants";
 
 @Controller("teams")
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -24,38 +25,38 @@ export class TeamsController {
   @Get()
   findAll(@Req() req: Request) {
     const { user } = req as any;
-    if (user.role === "admin") {
+    if (user.role === ROLES.ADMIN) {
       return this.teamsService.findAll();
     }
     return this.teamsService.findByLeader(user.userId);
   }
 
   @Get(":id")
-  @Roles("admin")
+  @Roles(ROLES.ADMIN)
   findOne(@Param("id", ParseIntPipe) id: number) {
     return this.teamsService.findOne(id);
   }
 
   @Post()
-  @Roles("admin")
+  @Roles(ROLES.ADMIN)
   create(@Body() body: any) {
     return this.teamsService.create(body);
   }
 
   @Put(":id")
-  @Roles("admin")
+  @Roles(ROLES.ADMIN)
   update(@Param("id", ParseIntPipe) id: number, @Body() body: any) {
     return this.teamsService.update(id, body);
   }
 
   @Delete(":id")
-  @Roles("admin")
+  @Roles(ROLES.ADMIN)
   remove(@Param("id", ParseIntPipe) id: number) {
     return this.teamsService.remove(id);
   }
 
   @Post(":id/members")
-  @Roles("admin")
+  @Roles(ROLES.ADMIN)
   addMember(@Param("id", ParseIntPipe) teamId: number, @Body() member: any) {
     return this.teamsService.addMember(teamId, member);
   }

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -13,6 +13,7 @@ import { UsersService } from "./users.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
 import { Roles } from "../common/guards/roles.decorator";
+import { ROLES } from "../common/roles.constants";
 import { CreateUserDto } from "./dto/create-user.dto";
 import { UpdateUserDto } from "./dto/update-user.dto";
 
@@ -22,31 +23,31 @@ export class UsersController {
   constructor(private usersService: UsersService) {}
 
   @Get()
-  @Roles("admin", "ketua")
+  @Roles(ROLES.ADMIN, ROLES.KETUA)
   findAll() {
     return this.usersService.findAll();
   }
 
   @Get(":id")
-  @Roles("admin")
+  @Roles(ROLES.ADMIN)
   findOne(@Param("id", ParseIntPipe) id: number) {
     return this.usersService.findOne(id);
   }
 
   @Post()
-  @Roles("admin")
+  @Roles(ROLES.ADMIN)
   create(@Body() body: CreateUserDto) {
     return this.usersService.create(body);
   }
 
   @Put(":id")
-  @Roles("admin")
+  @Roles(ROLES.ADMIN)
   update(@Param("id", ParseIntPipe) id: number, @Body() body: UpdateUserDto) {
     return this.usersService.update(id, body);
   }
 
   @Delete(":id")
-  @Roles("admin")
+  @Roles(ROLES.ADMIN)
   remove(@Param("id", ParseIntPipe) id: number) {
     return this.usersService.remove(id);
   }

--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -3,6 +3,7 @@ import StatsSummary from "../../components/dashboard/StatsSummary";
 import { useAuth } from "../auth/useAuth";
 import axios from "axios";
 import React, { useEffect, useState } from "react";
+import { ROLES } from "../../utils/roles";
 
 const Dashboard = () => {
   const { user } = useAuth();
@@ -41,10 +42,10 @@ const Dashboard = () => {
 
       try {
         const filters = {};
-        if (user?.role === "anggota") {
+        if (user?.role === ROLES.ANGGOTA) {
           filters.userId = user.id;
         }
-        if (user?.role === "ketua" && user?.teamId) {
+        if (user?.role === ROLES.KETUA && user?.teamId) {
           filters.teamId = user.teamId;
         }
 

--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -15,6 +15,7 @@ import {
   FaIdBadge,
   FaCheckCircle,
 } from "react-icons/fa";
+import { ROLES } from "../../utils/roles";
 
 export default function Layout() {
   const { user, setToken, setUser } = useAuth();
@@ -89,7 +90,7 @@ export default function Layout() {
           mobileOpen ? "translate-x-0" : "-translate-x-full"
         } md:translate-x-0 w-64`}
       >
-        <Sidebar mobileOpen={mobileOpen} setMobileOpen={setMobileOpen} />
+        <Sidebar setMobileOpen={setMobileOpen} />
       </div>
 
       {/* Overlay untuk mobile */}
@@ -183,7 +184,7 @@ export default function Layout() {
                 onClick={() => setShowProfileMenu(!showProfileMenu)}
                 className="flex items-center space-x-2 text-sm focus:outline-none"
               >
-                {user?.role === "admin" ? (
+                {user?.role === ROLES.ADMIN ? (
                   <FaUserCircle className="text-2xl" />
                 ) : (
                   <img
@@ -195,16 +196,16 @@ export default function Layout() {
                   />
                 )}
                 <div className="hidden md:block text-left">
-                  {user?.role === "admin" ? (
+                  {user?.role === ROLES.ADMIN ? (
                     <div className="font-semibold">Admin</div>
                   ) : (
                     <>
                       <div className="font-semibold">{user?.nama}</div>
                       <div className="text-xs capitalize text-gray-500 dark:text-gray-300">
-                        {user?.role === "pimpinan"
+                        {user?.role === ROLES.PIMPINAN
                           ? "Pimpinan"
                           : `${
-                              user?.role === "ketua" ? "Ketua Tim" : "Anggota Tim"
+                              user?.role === ROLES.KETUA ? "Ketua Tim" : "Anggota Tim"
                             } ${
                               user?.team ||
                               user?.teamName ||

--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -9,8 +9,9 @@ import {
   Users,
   UserCog,
 } from "lucide-react";
+import { ROLES } from "../../utils/roles";
 
-export default function Sidebar({ mobileOpen, setMobileOpen }) {
+export default function Sidebar({ setMobileOpen }) {
   const { user } = useAuth();
 
   const mainLinks = [
@@ -25,10 +26,10 @@ export default function Sidebar({ mobileOpen, setMobileOpen }) {
       to: "/master-kegiatan",
       label: "Master Kegiatan",
       icon: List,
-      show: ["admin", "ketua"].includes(user?.role),
+      show: [ROLES.ADMIN, ROLES.KETUA].includes(user?.role),
     },
-    { to: "/users", label: "Kelola Pengguna", icon: Users, show: user?.role === "admin" },
-    { to: "/teams", label: "Kelola Tim", icon: UserCog, show: user?.role === "admin" },
+    { to: "/users", label: "Kelola Pengguna", icon: Users, show: user?.role === ROLES.ADMIN },
+    { to: "/teams", label: "Kelola Tim", icon: UserCog, show: user?.role === ROLES.ADMIN },
   ];
 
   const renderLink = (link) => {

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -4,6 +4,7 @@ import Swal from "sweetalert2";
 import { Pencil, Plus, Trash2, Search } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
+import { ROLES } from "../../utils/roles";
 
 export default function MasterKegiatanPage() {
   const { user } = useAuth();
@@ -115,7 +116,7 @@ export default function MasterKegiatanPage() {
     }
   };
 
-  if (!["ketua", "admin"].includes(user?.role)) {
+  if (![ROLES.KETUA, ROLES.ADMIN].includes(user?.role)) {
     return (
       <div className="p-6 text-center">
         Anda tidak memiliki akses ke halaman ini.

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -5,6 +5,7 @@ import Swal from "sweetalert2";
 import Select from "react-select";
 import { Pencil, Trash2 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
+import { ROLES } from "../../utils/roles";
 
 const selectStyles = {
   option: (base) => ({ ...base, color: "#000" }),
@@ -15,7 +16,7 @@ export default function PenugasanDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { user } = useAuth();
-  const canManage = ["admin", "ketua", "pimpinan"].includes(user?.role);
+  const canManage = [ROLES.ADMIN, ROLES.KETUA, ROLES.PIMPINAN].includes(user?.role);
   const [item, setItem] = useState(null);
   const [kegiatan, setKegiatan] = useState([]);
   const [users, setUsers] = useState([]);
@@ -277,7 +278,7 @@ export default function PenugasanDetailPage() {
               styles={selectStyles}
               menuPortalTarget={document.body}
               options={users
-                .filter((u) => u.role !== "admin")
+                .filter((u) => u.role !== ROLES.ADMIN)
                 .map((u) => ({ value: u.id, label: u.nama }))}
               value={{
                 value: form.pegawaiId,

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -6,6 +6,7 @@ import Select from "react-select";
 import { useAuth } from "../auth/useAuth";
 import { useNavigate } from "react-router-dom";
 import Pagination from "../../components/Pagination";
+import { ROLES } from "../../utils/roles";
 
 const selectStyles = {
   option: (base) => ({ ...base, color: "#000" }),
@@ -15,7 +16,7 @@ const selectStyles = {
 
 export default function PenugasanPage() {
   const { user } = useAuth();
-  const canManage = ["admin", "ketua", "pimpinan"].includes(user?.role);
+  const canManage = [ROLES.ADMIN, ROLES.KETUA, ROLES.PIMPINAN].includes(user?.role);
   const navigate = useNavigate();
   const [penugasan, setPenugasan] = useState([]);
   const [kegiatan, setKegiatan] = useState([]);
@@ -59,7 +60,7 @@ export default function PenugasanPage() {
       ]);
 
       let kRes;
-      if (user?.role === "admin") {
+      if (user?.role === ROLES.ADMIN) {
         kRes = await axios.get("/master-kegiatan");
       } else {
         const tId = tRes.data[0]?.id;
@@ -318,7 +319,7 @@ export default function PenugasanPage() {
                   styles={selectStyles}
                   menuPortalTarget={document.body}
                   options={users
-                    .filter((u) => u.role !== "admin")
+                    .filter((u) => u.role !== ROLES.ADMIN)
                     .map((u) => ({ value: u.id, label: `${u.nama}` }))}
                   value={form.pegawaiIds
                     .map((id) => {
@@ -340,7 +341,7 @@ export default function PenugasanPage() {
                   onClick={() =>
                     setForm({
                       ...form,
-                      pegawaiIds: users.filter((u) => u.role !== "admin").map((u) => u.id),
+                      pegawaiIds: users.filter((u) => u.role !== ROLES.ADMIN).map((u) => u.id),
                     })
                   }
                   className="mt-1 px-3 py-1 text-sm bg-gray-200 dark:bg-gray-700 rounded"

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -4,6 +4,7 @@ import Swal from "sweetalert2";
 import { Pencil, Plus, Trash2, Search } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
+import { ROLES } from "../../utils/roles";
 
 export default function TeamsPage() {
   const { user } = useAuth();
@@ -91,7 +92,7 @@ export default function TeamsPage() {
   );
   const totalPages = Math.ceil(filtered.length / pageSize) || 1;
 
-  if (user?.role !== "admin") {
+  if (user?.role !== ROLES.ADMIN) {
     return (
       <div className="p-6 text-center">
         Anda tidak memiliki akses ke halaman ini.

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -4,6 +4,7 @@ import Swal from "sweetalert2";
 import { Pencil, Plus, Trash2, Search } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
+import { ROLES } from "../../utils/roles";
 
 export default function UsersPage() {
   const { user } = useAuth();
@@ -116,7 +117,7 @@ export default function UsersPage() {
   );
   const totalPages = Math.ceil(filteredUsers.length / pageSize) || 1;
 
-  if (user?.role !== "admin") {
+  if (user?.role !== ROLES.ADMIN) {
     return (
       <div className="p-6 text-center">
         Anda tidak memiliki akses ke halaman ini.

--- a/web/src/utils/roles.js
+++ b/web/src/utils/roles.js
@@ -1,0 +1,6 @@
+export const ROLES = {
+  ADMIN: "admin",
+  KETUA: "ketua",
+  ANGGOTA: "anggota",
+  PIMPINAN: "pimpinan",
+};


### PR DESCRIPTION
## Summary
- add `ROLES` constants to backend and frontend
- refactor controllers and services to use constants
- refactor frontend pages to use constants

## Testing
- `npm run lint` (web)
- `npm run lint` (api, fails: ESLint couldn't find plugins)
- `npm test` (api, fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_b_68749f2ffed8832bae793dce07fb55d2