### PR TITLE
Fix duplicate tambahan routes

### DIFF
--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -10,13 +10,13 @@ import {
   UserCog,
 } from "lucide-react";
 
-export default function Sidebar({ mobileOpen, setMobileOpen }) {
+export default function Sidebar({ setMobileOpen }) {
   const { user } = useAuth();
 
   const mainLinks = [
     { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard, show: true },
     { to: "/tugas-mingguan", label: "Tugas Mingguan", icon: ClipboardList, show: true },
-    { to: "/tugas-tambahan", label: "Tugas Tambahan", icon: FilePlus, show: true },
+    { to: "/kegiatan-tambahan", label: "Tugas Tambahan", icon: FilePlus, show: true },
     { to: "/laporan-harian", label: "Laporan Harian", icon: FileText, show: true },
   ];
 

--- a/web/src/routes/AppRoutes.jsx
+++ b/web/src/routes/AppRoutes.jsx
@@ -47,8 +47,6 @@ export default function AppRoutes() {
         <Route path="master-kegiatan" element={<MasterKegiatanPage />} />
         <Route path="tugas-mingguan" element={<PenugasanPage />} />
         <Route path="tugas-mingguan/:id" element={<PenugasanDetailPage />} />
-        <Route path="tugas-tambahan" element={<KegiatanTambahanPage />} />
-        <Route path="tugas-tambahan/:id" element={<KegiatanTambahanDetailPage />} />
         <Route path="laporan-harian" element={<LaporanHarianPage />} />
         <Route path="kegiatan-tambahan" element={<KegiatanTambahanPage />} />
         <Route path="kegiatan-tambahan/:id" element={<KegiatanTambahanDetailPage />} />


### PR DESCRIPTION
## Summary
- clean up additional task routing
- make the sidebar link consistent

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68749f31039c832b85aa7a8c32051f11