### PR TITLE
Improve missing-data handling

### DIFF
--- a/api/src/kegiatan/master-kegiatan.service.ts
+++ b/api/src/kegiatan/master-kegiatan.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, ForbiddenException, NotFoundException } from "@nestjs/common";
+import {
+  Injectable,
+  ForbiddenException,
+  NotFoundException,
+} from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 import { ROLES } from "../common/roles.constants";
 import { CreateMasterKegiatanDto } from "./dto/create-master-kegiatan.dto";
@@ -60,7 +64,7 @@ export class MasterKegiatanService {
     const existing = await this.prisma.masterKegiatan.findUnique({
       where: { id },
     });
-    if (!existing) throw new Error("not found");
+    if (!existing) throw new NotFoundException("not found");
     if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: existing.teamId, userId, is_leader: true },
@@ -76,7 +80,7 @@ export class MasterKegiatanService {
 
   async remove(id: number, userId: number, role: string) {
     const existing = await this.prisma.masterKegiatan.findUnique({ where: { id } });
-    if (!existing) throw new Error("not found");
+    if (!existing) throw new NotFoundException("not found");
     if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: existing.teamId, userId, is_leader: true },

--- a/api/src/kegiatan/penugasan.service.ts
+++ b/api/src/kegiatan/penugasan.service.ts
@@ -1,7 +1,7 @@
 import {
   Injectable,
   ForbiddenException,
-  BadRequestException,
+  NotFoundException,
 } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 import { ROLES } from "../common/roles.constants";
@@ -56,7 +56,7 @@ export class PenugasanService {
       where: { id: data.kegiatanId },
     });
     if (!master) {
-      throw new BadRequestException("master kegiatan tidak ditemukan");
+      throw new NotFoundException("master kegiatan tidak ditemukan");
     }
     if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
@@ -85,7 +85,7 @@ export class PenugasanService {
       where: { id: data.kegiatanId },
     });
     if (!master) {
-      throw new BadRequestException("master kegiatan tidak ditemukan");
+      throw new NotFoundException("master kegiatan tidak ditemukan");
     }
     if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
@@ -139,7 +139,7 @@ export class PenugasanService {
       where: { id },
       include: { kegiatan: true },
     });
-    if (!existing) throw new BadRequestException("not found");
+    if (!existing) throw new NotFoundException("not found");
     if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: existing.kegiatan.teamId, userId, is_leader: true },
@@ -167,7 +167,7 @@ export class PenugasanService {
       where: { id },
       include: { kegiatan: true },
     });
-    if (!existing) throw new BadRequestException("not found");
+    if (!existing) throw new NotFoundException("not found");
     if (role !== ROLES.ADMIN) {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: existing.kegiatan.teamId, userId, is_leader: true },

--- a/api/src/laporan/kegiatan-tambahan.service.ts
+++ b/api/src/laporan/kegiatan-tambahan.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 
 @Injectable()
@@ -9,7 +9,7 @@ export class TambahanService {
       where: { id: data.kegiatanId },
     });
     
-    if (!master) throw new BadRequestException('master kegiatan tidak ditemukan');
+    if (!master) throw new NotFoundException('master kegiatan tidak ditemukan');
     return this.prisma.kegiatanTambahan.create({
       data: {
         nama: master.nama_kegiatan,
@@ -47,7 +47,7 @@ export class TambahanService {
       const master = await this.prisma.masterKegiatan.findUnique({
         where: { id: data.kegiatanId },
       });
-      if (!master) throw new BadRequestException('master kegiatan tidak ditemukan');
+      if (!master) throw new NotFoundException('master kegiatan tidak ditemukan');
       updateData.nama = master.nama_kegiatan;
       updateData.teamId = master.teamId;
     }

--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -1,7 +1,7 @@
 import {
   Injectable,
-  BadRequestException,
   ForbiddenException,
+  NotFoundException,
 } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 import { Workbook } from "exceljs";
@@ -14,7 +14,7 @@ export class LaporanService {
     const pen = await this.prisma.penugasan.findUnique({
       where: { id: data.penugasanId },
     });
-    if (!pen) throw new BadRequestException("Penugasan tidak ditemukan");
+    if (!pen) throw new NotFoundException("Penugasan tidak ditemukan");
     if (pen.pegawaiId !== data.pegawaiId)
       throw new ForbiddenException("bukan penugasan anda");
     return this.prisma.laporanHarian.create({
@@ -63,7 +63,7 @@ export class LaporanService {
     const existing = await this.prisma.laporanHarian.findUnique({
       where: { id },
     });
-    if (!existing) throw new BadRequestException("not found");
+    if (!existing) throw new NotFoundException("not found");
     if (existing.pegawaiId !== userId)
       throw new ForbiddenException("bukan laporan anda");
     return this.prisma.laporanHarian.update({
@@ -81,7 +81,7 @@ export class LaporanService {
     const existing = await this.prisma.laporanHarian.findUnique({
       where: { id },
     });
-    if (!existing) throw new BadRequestException("not found");
+    if (!existing) throw new NotFoundException("not found");
     if (existing.pegawaiId !== userId)
       throw new ForbiddenException("bukan laporan anda");
     await this.prisma.laporanHarian.delete({ where: { id } });


### PR DESCRIPTION
## Summary
- throw `NotFoundException` instead of generic errors when a record doesn't exist
- update bad request checks in assignment and report services

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_6874a604080c832b9274f61b5b584a64