### PR TITLE
Centralize month names for monitoring service

### DIFF
--- a/api/src/common/months.ts
+++ b/api/src/common/months.ts
@@ -1,0 +1,18 @@
+export const MONTHS = [
+  "Januari",
+  "Februari",
+  "Maret",
+  "April",
+  "Mei",
+  "Juni",
+  "Juli",
+  "Agustus",
+  "September",
+  "Oktober",
+  "November",
+  "Desember",
+] as const;
+
+export type MonthName = (typeof MONTHS)[number];
+
+export default MONTHS;

--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
+import MONTHS from "../common/months";
 
 @Injectable()
 export class MonitoringService {
@@ -162,22 +163,7 @@ export class MonitoringService {
       [...harian, ...tambahan].map((r) => r.tanggal.getMonth()),
     );
 
-    const monthNames = [
-      "Januari",
-      "Februari",
-      "Maret",
-      "April",
-      "Mei",
-      "Juni",
-      "Juli",
-      "Agustus",
-      "September",
-      "Oktober",
-      "November",
-      "Desember",
-    ];
-
-    return monthNames.map((name, idx) => ({
+    return MONTHS.map((name, idx) => ({
       tanggal: name,
       adaAktivitas: monthsWithActivity.has(idx),
     }));
@@ -185,21 +171,7 @@ export class MonitoringService {
 }
 
 function monthName(date: Date) {
-  const names = [
-    "Januari",
-    "Februari",
-    "Maret",
-    "April",
-    "Mei",
-    "Juni",
-    "Juli",
-    "Agustus",
-    "September",
-    "Oktober",
-    "November",
-    "Desember",
-  ];
-  return names[date.getMonth()];
+  return MONTHS[date.getMonth()];
 }
 
 function getWeekNumber(d: Date) {


### PR DESCRIPTION
## Summary
- add `MONTHS` constant for backend utilities
- reuse new month names constant in monitoring service

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: Cannot find name 'normalizeRole')*
- `npm run lint` in `web` directory
- `npm run build` in `web` directory

------
https://chatgpt.com/codex/tasks/task_b_6874a79d6868832b9adcd7893964d6d5