### PR TITLE
Throw NotFoundException for missing Users and Teams

### DIFF
--- a/api/src/teams/teams.service.ts
+++ b/api/src/teams/teams.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 
 @Injectable()
@@ -24,11 +24,13 @@ export class TeamsService {
     });
   }
 
-  findOne(id: number) {
-    return this.prisma.team.findUnique({
+  async findOne(id: number) {
+    const team = await this.prisma.team.findUnique({
       where: { id },
       include: { members: { include: { user: true } } },
     });
+    if (!team) throw new NotFoundException("not found");
+    return team;
   }
 
   create(data: any) {

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 import { hashPassword } from "../common/hash";
 
@@ -13,8 +13,10 @@ export class UsersService {
     });
   }
 
-  findOne(id: number) {
-    return this.prisma.user.findUnique({ where: { id } });
+  async findOne(id: number) {
+    const user = await this.prisma.user.findUnique({ where: { id } });
+    if (!user) throw new NotFoundException("not found");
+    return user;
   }
 
   async create(data: any) {


### PR DESCRIPTION
## Summary
- handle `findUnique` returning `null` in `UsersService.findOne` and `TeamsService.findOne`
- import `NotFoundException` in both services

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6874ac02b8f8832bb44bcdb040ceaa1a