### PR TITLE
Add reusable modal component

### DIFF
--- a/web/src/components/ui/Modal.jsx
+++ b/web/src/components/ui/Modal.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export default function Modal({ onClose, children, widthClass = "w-full max-w-md" }) {
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className={`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl space-y-4 ${widthClass}`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import { Pencil, Trash2, Search } from "lucide-react";
 import Swal from "sweetalert2";
 import Pagination from "../../components/Pagination";
+import Modal from "../../components/ui/Modal";
 import { STATUS } from "../../utils/status";
 
 export default function LaporanHarianPage() {
@@ -239,9 +240,12 @@ export default function LaporanHarianPage() {
         </div>
         </>
       )}
-      {showForm && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md space-y-4 shadow-xl">
+        {showForm && (
+          <Modal
+            onClose={() => {
+              setShowForm(false);
+            }}
+          >
             <h3 className="text-lg font-semibold">Edit Laporan Harian</h3>
             <div className="space-y-2">
               <div>
@@ -313,9 +317,8 @@ export default function LaporanHarianPage() {
                 Simpan
               </button>
             </div>
-          </div>
-        </div>
-      )}
+          </Modal>
+        )}
     </div>
   );
 }

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -4,6 +4,7 @@ import Swal from "sweetalert2";
 import { Pencil, Plus, Trash2, Search } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
+import Modal from "../../components/ui/Modal";
 import { ROLES } from "../../utils/roles";
 
 export default function MasterKegiatanPage() {
@@ -252,17 +253,21 @@ export default function MasterKegiatanPage() {
       </div>
 
       {showForm && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md space-y-4 shadow-xl">
-            <h2 className="text-xl font-semibold mb-2">
-              {editing ? "Edit Kegiatan" : "Tambah Kegiatan"}
-            </h2>
-            <div className="space-y-2">
-              <div>
-                <label className="block text-sm mb-1">
-                  Tim <span className="text-red-500">*</span>
-                </label>
-                <select
+        <Modal
+          onClose={() => {
+            setShowForm(false);
+            setEditing(null);
+          }}
+        >
+          <h2 className="text-xl font-semibold mb-2">
+            {editing ? "Edit Kegiatan" : "Tambah Kegiatan"}
+          </h2>
+          <div className="space-y-2">
+            <div>
+              <label className="block text-sm mb-1">
+                Tim <span className="text-red-500">*</span>
+              </label>
+              <select
                   value={form.teamId}
                   onChange={(e) =>
                     setForm({ ...form, teamId: parseInt(e.target.value, 10) })
@@ -322,7 +327,7 @@ export default function MasterKegiatanPage() {
               </p>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
     </div>
   );

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -6,6 +6,7 @@ import Select from "react-select";
 import { useAuth } from "../auth/useAuth";
 import { useNavigate } from "react-router-dom";
 import Pagination from "../../components/Pagination";
+import Modal from "../../components/ui/Modal";
 import { ROLES } from "../../utils/roles";
 import months from "../../utils/months";
 
@@ -273,14 +274,17 @@ export default function PenugasanPage() {
       </div>
 
       {canManage && showForm && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md space-y-4 shadow-xl">
-            <h2 className="text-xl font-semibold mb-2">Tambah Penugasan</h2>
-            <div className="space-y-2">
-              <div>
-                <label className="block text-sm mb-1">
-                  Kegiatan <span className="text-red-500">*</span>
-                </label>
+        <Modal
+          onClose={() => {
+            setShowForm(false);
+          }}
+        >
+          <h2 className="text-xl font-semibold mb-2">Tambah Penugasan</h2>
+          <div className="space-y-2">
+            <div>
+              <label className="block text-sm mb-1">
+                Kegiatan <span className="text-red-500">*</span>
+              </label>
                 <Select
                   classNamePrefix="react-select"
                   className="mb-1"
@@ -409,7 +413,7 @@ export default function PenugasanPage() {
               </button>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
     </div>
   );

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -5,6 +5,7 @@ import { Plus, Eye, Pencil, Trash2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import Select from "react-select";
 import { STATUS } from "../../utils/status";
+import Modal from "../../components/ui/Modal";
 
 const selectStyles = {
   option: (base) => ({ ...base, color: "#000" }),
@@ -182,17 +183,21 @@ export default function KegiatanTambahanPage() {
       </table>
 
       {showForm && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md space-y-4 shadow-xl">
-            <h2 className="text-xl font-semibold mb-2">
-              {editing ? "Edit Kegiatan" : "Tambah Kegiatan"}
-            </h2>
-            <div className="space-y-2">
-              <div>
-                <label className="block text-sm mb-1">Kegiatan</label>
-                <Select
-                  classNamePrefix="react-select"
-                  styles={selectStyles}
+        <Modal
+          onClose={() => {
+            setShowForm(false);
+            setEditing(null);
+          }}
+        >
+          <h2 className="text-xl font-semibold mb-2">
+            {editing ? "Edit Kegiatan" : "Tambah Kegiatan"}
+          </h2>
+          <div className="space-y-2">
+            <div>
+              <label className="block text-sm mb-1">Kegiatan</label>
+              <Select
+                classNamePrefix="react-select"
+                styles={selectStyles}
                   menuPortalTarget={document.body}
                   options={kegiatan.map((k) => ({ value: k.id, label: k.nama_kegiatan }))}
                   value={
@@ -258,7 +263,7 @@ export default function KegiatanTambahanPage() {
               </button>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
     </div>
   );

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -4,6 +4,7 @@ import Swal from "sweetalert2";
 import { Pencil, Plus, Trash2, Search } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
+import Modal from "../../components/ui/Modal";
 import { ROLES } from "../../utils/roles";
 
 export default function TeamsPage() {
@@ -209,17 +210,20 @@ export default function TeamsPage() {
       </div>
 
       {showForm && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md space-y-4 shadow-xl">
-            <h2 className="text-xl font-semibold mb-2">
-              {editingTeam ? "Edit Tim" : "Tambah Tim"}
-            </h2>
-            <div className="space-y-2">
-              <div>
-                <label className="block text-sm mb-1">Nama Tim</label>
-                <input
-                  type="text"
-                  value={form.nama_tim}
+        <Modal
+          onClose={() => {
+            setShowForm(false);
+          }}
+        >
+          <h2 className="text-xl font-semibold mb-2">
+            {editingTeam ? "Edit Tim" : "Tambah Tim"}
+          </h2>
+          <div className="space-y-2">
+            <div>
+              <label className="block text-sm mb-1">Nama Tim</label>
+              <input
+                type="text"
+                value={form.nama_tim}
                   onChange={(e) =>
                     setForm({ ...form, nama_tim: e.target.value })
                   }
@@ -249,8 +253,7 @@ export default function TeamsPage() {
                 Simpan
               </button>
             </div>
-          </div>
-        </div>
+          </Modal>
       )}
     </div>
   );

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -4,6 +4,7 @@ import Swal from "sweetalert2";
 import { Pencil, Plus, Trash2, Search } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
+import Modal from "../../components/ui/Modal";
 import { ROLES } from "../../utils/roles";
 
 export default function UsersPage() {
@@ -252,17 +253,20 @@ export default function UsersPage() {
       </div>
 
       {showForm && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md space-y-4 shadow-xl">
-            <h2 className="text-xl font-semibold mb-2">
-              {editingUser ? "Edit Pengguna" : "Tambah Pengguna"}
-            </h2>
-            <div className="space-y-2">
-              <div>
-                <label className="block text-sm mb-1">
-                  Nama <span className="text-red-500">*</span>
-                </label>
-                <input
+        <Modal
+          onClose={() => {
+            setShowForm(false);
+          }}
+        >
+          <h2 className="text-xl font-semibold mb-2">
+            {editingUser ? "Edit Pengguna" : "Tambah Pengguna"}
+          </h2>
+          <div className="space-y-2">
+            <div>
+              <label className="block text-sm mb-1">
+                Nama <span className="text-red-500">*</span>
+              </label>
+              <input
                   type="text"
                   value={form.nama}
                   onChange={(e) => setForm({ ...form, nama: e.target.value })}
@@ -337,7 +341,7 @@ export default function UsersPage() {
               </p>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- create `Modal` component with accessibility and close overlay
- use `Modal` across pages instead of inline modal markup

## Testing
- `npm run lint` *(fails: Parsing error in JSX)*

------
https://chatgpt.com/codex/tasks/task_b_6874b5d8f880832ba11e49ee84bd454e