### PR TITLE
Improve button accessibility

### DIFF
--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -191,12 +191,14 @@ export default function LaporanHarianPage() {
                     <button
                       onClick={() => openEdit(item)}
                       className="p-1 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                      aria-label="Edit"
                     >
                       <Pencil size={14} />
                     </button>
                     <button
                       onClick={() => remove(item.id)}
                       className="p-1 bg-red-600 hover:bg-red-700 text-white rounded"
+                      aria-label="Hapus"
                     >
                       <Trash2 size={14} />
                     </button>

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -215,12 +215,14 @@ export default function MasterKegiatanPage() {
                 <button
                   onClick={() => openEdit(item)}
                   className="p-2 text-sm bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                  aria-label="Edit"
                 >
                   <Pencil size={16} />
                 </button>
                 <button
                   onClick={() => deleteItem(item)}
                   className="p-2 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                  aria-label="Hapus"
                 >
                   <Trash2 size={16} />
                 </button>

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -187,12 +187,14 @@ export default function PenugasanDetailPage() {
             <button
               onClick={() => setEditing(true)}
               className="p-2 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+              aria-label="Edit"
             >
               <Pencil size={16} />
             </button>
             <button
               onClick={remove}
               className="p-2 bg-red-600 hover:bg-red-700 text-white rounded"
+              aria-label="Hapus"
             >
               <Trash2 size={16} />
             </button>
@@ -412,12 +414,14 @@ export default function PenugasanDetailPage() {
                     <button
                       onClick={() => editLaporan(l)}
                       className="p-1 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                      aria-label="Edit"
                     >
                       <Pencil size={14} />
                     </button>
                     <button
                       onClick={() => deleteLaporan(l.id)}
                       className="p-1 bg-red-600 hover:bg-red-700 text-white rounded"
+                      aria-label="Hapus"
                     >
                       <Trash2 size={14} />
                     </button>

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -185,6 +185,7 @@ export default function PenugasanPage() {
             type="button"
             onClick={fetchData}
             className="px-3 py-[4px] bg-gray-200 dark:bg-gray-700 rounded"
+            aria-label="Filter"
           >
             <FilterIcon size={16} />
           </button>
@@ -238,6 +239,7 @@ export default function PenugasanPage() {
                     <button
                       onClick={() => navigate(`/tugas-mingguan/${p.id}`)}
                       className="text-blue-600 hover:underline text-sm"
+                      aria-label="Detail"
                     >
                       <Eye size={16} />
                     </button>

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -120,12 +120,14 @@ export default function KegiatanTambahanDetailPage() {
             <button
               onClick={() => setEditing(true)}
               className="p-2 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+              aria-label="Edit"
             >
               <Pencil size={16} />
             </button>
             <button
               onClick={remove}
               className="p-2 bg-red-600 hover:bg-red-700 text-white rounded"
+              aria-label="Hapus"
             >
               <Trash2 size={16} />
             </button>

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -159,18 +159,21 @@ export default function KegiatanTambahanPage() {
                   <button
                     onClick={() => openDetail(item.id)}
                     className="p-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+                    aria-label="Detail"
                   >
                     <Eye size={16} />
                   </button>
                   <button
                     onClick={() => openEdit(item)}
                     className="p-2 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                    aria-label="Edit"
                   >
                     <Pencil size={16} />
                   </button>
                   <button
                     onClick={() => remove(item)}
                     className="p-2 bg-red-600 hover:bg-red-700 text-white rounded"
+                    aria-label="Hapus"
                   >
                     <Trash2 size={16} />
                   </button>

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -164,12 +164,14 @@ export default function TeamsPage() {
                 <button
                   onClick={() => openEdit(t)}
                   className="p-2 text-sm bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                  aria-label="Edit"
                 >
                   <Pencil size={16} />
                 </button>
                 <button
                   onClick={() => deleteTeam(t.id)}
                   className="p-2 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                  aria-label="Hapus"
                 >
                   <Trash2 size={16} />
                 </button>

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -207,12 +207,14 @@ export default function UsersPage() {
                 <button
                   onClick={() => openEdit(u)}
                   className="p-2 text-sm bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                  aria-label="Edit"
                 >
                   <Pencil size={16} />
                 </button>
                 <button
                   onClick={() => deleteUser(u.id)}
                   className="p-2 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                  aria-label="Hapus"
                 >
                   <Trash2 size={16} />
                 </button>


### PR DESCRIPTION
## Summary
- add `aria-label` attributes to icon-only action buttons

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6874b5dba0b4832bac24c70c1fd34e4c