### PR TITLE
Fix Modal section closures

### DIFF
--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -304,7 +304,6 @@ export default function MasterKegiatanPage() {
                   className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
                 />
               </div>
-            </div>
             <div className="flex justify-end space-x-2 pt-2">
               <button
                 onClick={() => {

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -391,7 +391,6 @@ export default function PenugasanPage() {
                   />
                 </div>
               </div>
-            </div>
             <div className="flex justify-end space-x-2 pt-2">
               <button
                 onClick={() => {

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -251,7 +251,6 @@ export default function KegiatanTambahanPage() {
                   </option>
                 </select>
               </div>
-            </div>
             <div className="flex justify-end space-x-2 pt-2">
               <button
                 onClick={() => {

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -311,8 +311,7 @@ export default function UsersPage() {
                   ))}
                 </select>
               </div>
-            </div>
-            <div className="flex justify-end space-x-2 pt-2">
+              <div className="flex justify-end space-x-2 pt-2">
               <button
                 onClick={async () => {
                   const r = await Swal.fire({


### PR DESCRIPTION
## Summary
- remove stray closing divs before Modal button groups
- clean up modal components in user, penugasan, tambahan, and master kegiatan pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6874bdc5eb94832b96ef573682056d9d