### PR TITLE
Display status with StatusBadge on tambahan pages

### DIFF
--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -5,6 +5,7 @@ import Swal from "sweetalert2";
 import { Pencil, Trash2 } from "lucide-react";
 import Select from "react-select";
 import { STATUS } from "../../utils/status";
+import StatusBadge from "../../components/ui/StatusBadge";
 
 const selectStyles = {
   option: (base) => ({ ...base, color: "#000" }),
@@ -154,7 +155,9 @@ export default function KegiatanTambahanDetailPage() {
           </div>
           <div>
             <div className="text-sm text-gray-500">Status</div>
-            <div className="font-medium">{item.status}</div>
+            <div className="font-medium">
+              <StatusBadge status={item.status} />
+            </div>
           </div>
           {item.tanggal_selesai && (
             <div>

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 import Select from "react-select";
 import { STATUS } from "../../utils/status";
 import Modal from "../../components/ui/Modal";
+import StatusBadge from "../../components/ui/StatusBadge";
 
 const selectStyles = {
   option: (base) => ({ ...base, color: "#000" }),
@@ -156,7 +157,9 @@ export default function KegiatanTambahanPage() {
                 <td className="px-4 py-2">{item.nama}</td>
                 <td className="px-4 py-2">{item.kegiatan.team?.nama_tim || '-'}</td>
                 <td className="px-4 py-2">{item.tanggal.slice(0,10)}</td>
-                <td className="px-4 py-2">{item.status}</td>
+                <td className="px-4 py-2">
+                  <StatusBadge status={item.status} />
+                </td>
                 <td className="px-4 py-2 space-x-2">
                   <button
                     onClick={() => openDetail(item.id)}


### PR DESCRIPTION
## Summary
- use the `StatusBadge` component on `KegiatanTambahanPage` and `KegiatanTambahanDetailPage`
- keep styling consistent for dark/light mode

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: missing eslint-plugin-prettier)*

------
https://chatgpt.com/codex/tasks/task_b_6874c3ee3674832ba4ec1d6c0ba69845