### PR TITLE
Implement accessibility and performance improvements

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,12 +1,18 @@
-import LoginPage from "./pages/auth/LoginPage";
+import React, { Suspense } from "react";
 import AppRoutes from "./routes/AppRoutes";
 import { useAuth } from "./pages/auth/useAuth";
+
+const LoginPage = React.lazy(() => import("./pages/auth/LoginPage"));
 
 export default function App() {
   const { token, user } = useAuth();
 
   if (!token || !user) {
-    return <LoginPage />;
+    return (
+      <Suspense fallback={<div>Loading...</div>}>
+        <LoginPage />
+      </Suspense>
+    );
   }
 
   return <AppRoutes />;

--- a/web/src/components/ui/Button.jsx
+++ b/web/src/components/ui/Button.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+export default function Button({
+  children,
+  variant = "primary",
+  className = "",
+  ...props
+}) {
+  const base = "px-4 py-2 rounded focus:outline-none transition";
+  const variants = {
+    primary: "bg-blue-600 hover:bg-blue-700 text-white",
+    secondary:
+      "bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white",
+  };
+  return (
+    <button
+      className={`${base} ${variants[variant] ?? ""} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/web/src/components/ui/Modal.jsx
+++ b/web/src/components/ui/Modal.jsx
@@ -1,6 +1,35 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 
 export default function Modal({ onClose, children, widthClass = "w-full max-w-md" }) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    function handleKey(e) {
+      if (e.key === "Escape") onClose();
+      if (e.key === "Tab") {
+        const focusable = containerRef.current?.querySelectorAll(
+          "a[href], button, textarea, input, select, [tabindex]:not([tabindex='-1'])"
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+    document.addEventListener("keydown", handleKey);
+    const firstInput = containerRef.current?.querySelector(
+      "a[href], button, textarea, input, select, [tabindex]:not([tabindex='-1'])"
+    );
+    firstInput?.focus();
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
   return (
     <div
       className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50"
@@ -9,6 +38,7 @@ export default function Modal({ onClose, children, widthClass = "w-full max-w-md
       aria-modal="true"
     >
       <div
+        ref={containerRef}
         onClick={(e) => e.stopPropagation()}
         className={`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl space-y-4 ${widthClass}`}
       >

--- a/web/src/pages/auth/LoginPage.jsx
+++ b/web/src/pages/auth/LoginPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import axios from "axios";
 import { useAuth } from "./useAuth";
+import Button from "../../components/ui/Button";
 import { Eye, EyeOff } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
@@ -53,10 +54,11 @@ export default function LoginPage() {
           className="space-y-4"
         >
           <div>
-            <label className="block text-sm text-zinc-700 dark:text-zinc-300 mb-1">
+            <label htmlFor="identifier" className="block text-sm text-zinc-700 dark:text-zinc-300 mb-1">
               Email atau Username
             </label>
             <input
+              id="identifier"
               type="text"
               placeholder="Email atau Username"
               value={form.identifier ?? ""}
@@ -66,11 +68,12 @@ export default function LoginPage() {
           </div>
 
           <div>
-            <label className="block text-sm text-zinc-700 dark:text-zinc-300 mb-1">
+            <label htmlFor="password" className="block text-sm text-zinc-700 dark:text-zinc-300 mb-1">
               Password
             </label>
             <div className="relative">
               <input
+                id="password"
                 type={showPassword ? "text" : "password"}
                 placeholder="********"
                 value={form.password ?? ""}
@@ -91,12 +94,9 @@ export default function LoginPage() {
             <div className="text-red-500 text-sm text-center">{error}</div>
           )}
 
-          <button
-            type="submit"
-            className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 rounded-lg transition duration-200"
-          >
+          <Button type="submit" className="w-full font-semibold">
             Login
-          </button>
+          </Button>
         </form>
 
         <p className="text-xs text-zinc-400 text-center">

--- a/web/src/pages/auth/useAuth.jsx
+++ b/web/src/pages/auth/useAuth.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useContext, useState, useEffect } from "react";
+import { createContext, useContext, useState, useEffect, useMemo } from "react";
 
 const AuthContext = createContext();
 
@@ -23,11 +23,12 @@ export function AuthProvider({ children }) {
     }
   }, [token, user]);
 
-  return (
-    <AuthContext.Provider value={{ token, setToken, user, setUser }}>
-      {children}
-    </AuthContext.Provider>
+  const value = useMemo(
+    () => ({ token, setToken, user, setUser }),
+    [token, user]
   );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 export function useAuth() {

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -5,6 +5,7 @@ import Swal from "sweetalert2";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
+import Button from "../../components/ui/Button";
 import { STATUS } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
 import SearchInput from "../../components/SearchInput";
@@ -105,8 +106,9 @@ export default function LaporanHarianPage() {
     <div className="p-6 space-y-4">
       <div className="flex flex-wrap items-end gap-2">
         <div>
-          <label className="block text-sm mb-1">Tanggal</label>
+          <label htmlFor="filterTanggal" className="block text-sm mb-1">Tanggal</label>
           <input
+            id="filterTanggal"
             type="date"
             value={tanggal}
             onChange={(e) => {
@@ -239,10 +241,11 @@ export default function LaporanHarianPage() {
             <h3 className="text-lg font-semibold">Edit Laporan Harian</h3>
             <div className="space-y-2">
               <div>
-                <label className="block text-sm mb-1">
+                <label htmlFor="tanggal" className="block text-sm mb-1">
                   Tanggal<span className="text-red-500">*</span>
                 </label>
                 <input
+                  id="tanggal"
                   type="date"
                   value={form.tanggal}
                   onChange={(e) =>
@@ -252,10 +255,11 @@ export default function LaporanHarianPage() {
                 />
               </div>
               <div>
-                <label className="block text-sm mb-1">
+                <label htmlFor="status" className="block text-sm mb-1">
                   Status<span className="text-red-500">*</span>
                 </label>
                 <select
+                  id="status"
                   value={form.status}
                   onChange={(e) => setForm({ ...form, status: e.target.value })}
                   className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
@@ -271,8 +275,9 @@ export default function LaporanHarianPage() {
               </div>
               {form.status === STATUS.SELESAI_DIKERJAKAN && (
                 <div>
-                  <label className="block text-sm mb-1">Link Bukti</label>
+                  <label htmlFor="bukti_link" className="block text-sm mb-1">Link Bukti</label>
                   <input
+                    id="bukti_link"
                     type="text"
                     value={form.bukti_link}
                     onChange={(e) =>
@@ -283,8 +288,9 @@ export default function LaporanHarianPage() {
                 </div>
               )}
               <div>
-                <label className="block text-sm mb-1">Catatan</label>
+                <label htmlFor="catatan" className="block text-sm mb-1">Catatan</label>
                 <textarea
+                  id="catatan"
                   value={form.catatan}
                   onChange={(e) =>
                     setForm({ ...form, catatan: e.target.value })
@@ -294,18 +300,10 @@ export default function LaporanHarianPage() {
               </div>
             </div>
             <div className="flex justify-end space-x-2 pt-2">
-              <button
-                onClick={() => setShowForm(false)}
-                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
-              >
+              <Button variant="secondary" onClick={() => setShowForm(false)}>
                 Batal
-              </button>
-              <button
-                onClick={saveForm}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
-              >
-                Simpan
-              </button>
+              </Button>
+              <Button onClick={saveForm}>Simpan</Button>
             </div>
           </Modal>
         )}

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -6,6 +6,7 @@ import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
+import Button from "../../components/ui/Button";
 import { ROLES } from "../../utils/roles";
 import SearchInput from "../../components/SearchInput";
 
@@ -263,16 +264,17 @@ export default function MasterKegiatanPage() {
           </h2>
           <div className="space-y-2">
             <div>
-              <label className="block text-sm mb-1">
+              <label htmlFor="teamId" className="block text-sm mb-1">
                 Tim <span className="text-red-500">*</span>
               </label>
               <select
-                  value={form.teamId}
-                  onChange={(e) =>
-                    setForm({ ...form, teamId: parseInt(e.target.value, 10) })
-                  }
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
-                >
+                id="teamId"
+                value={form.teamId}
+                onChange={(e) =>
+                  setForm({ ...form, teamId: parseInt(e.target.value, 10) })
+                }
+                className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+              >
                   <option value="">Pilih tim</option>
                   {teams.map((t) => (
                     <option key={t.id} value={t.id}>
@@ -281,45 +283,42 @@ export default function MasterKegiatanPage() {
                   ))}
                 </select>
               </div>
-              <div>
-                <label className="block text-sm mb-1">
-                  Nama Kegiatan <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={form.nama_kegiatan}
-                  onChange={(e) =>
-                    setForm({ ...form, nama_kegiatan: e.target.value })
-                  }
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
-                />
+            <div>
+              <label htmlFor="namaKegiatan" className="block text-sm mb-1">
+                Nama Kegiatan <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="namaKegiatan"
+                type="text"
+                value={form.nama_kegiatan}
+                onChange={(e) =>
+                  setForm({ ...form, nama_kegiatan: e.target.value })
+                }
+                className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+              />
               </div>
-              <div>
-                <label className="block text-sm mb-1">Deskripsi</label>
-                <textarea
-                  value={form.deskripsi}
-                  onChange={(e) =>
-                    setForm({ ...form, deskripsi: e.target.value })
-                  }
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
-                />
+            <div>
+              <label htmlFor="deskripsi" className="block text-sm mb-1">Deskripsi</label>
+              <textarea
+                id="deskripsi"
+                value={form.deskripsi}
+                onChange={(e) =>
+                  setForm({ ...form, deskripsi: e.target.value })
+                }
+                className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+              />
               </div>
             <div className="flex justify-end space-x-2 pt-2">
-              <button
+              <Button
+                variant="secondary"
                 onClick={() => {
                   setShowForm(false);
                   setEditing(null);
                 }}
-                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
               >
                 Batal
-              </button>
-              <button
-                onClick={saveItem}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
-              >
-                Simpan
-              </button>
+              </Button>
+              <Button onClick={saveItem}>Simpan</Button>
               <p className="text-xs text-gray-500 ml-2 self-center">
                 * wajib diisi
               </p>

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -10,6 +10,7 @@ import { STATUS } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
+import Button from "../../components/ui/Button";
 import months from "../../utils/months";
 
 const selectStyles = {
@@ -245,8 +246,9 @@ export default function PenugasanDetailPage() {
         <div className="space-y-2 bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
           <h2 className="text-xl font-semibold">Edit Penugasan</h2>
           <div>
-            <label className="block text-sm mb-1">Kegiatan</label>
+            <label htmlFor="kegiatan" className="block text-sm mb-1">Kegiatan</label>
             <Select
+              inputId="kegiatan"
               classNamePrefix="react-select"
               styles={selectStyles}
               menuPortalTarget={document.body}
@@ -267,8 +269,9 @@ export default function PenugasanDetailPage() {
             />
           </div>
           <div>
-            <label className="block text-sm mb-1">Pegawai</label>
+            <label htmlFor="pegawai" className="block text-sm mb-1">Pegawai</label>
             <Select
+              inputId="pegawai"
               classNamePrefix="react-select"
               styles={selectStyles}
               menuPortalTarget={document.body}
@@ -286,8 +289,9 @@ export default function PenugasanDetailPage() {
             />
           </div>
           <div>
-            <label className="block text-sm mb-1">Deskripsi</label>
+            <label htmlFor="deskripsi" className="block text-sm mb-1">Deskripsi</label>
             <textarea
+              id="deskripsi"
               value={form.deskripsi}
               onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
               className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
@@ -295,8 +299,9 @@ export default function PenugasanDetailPage() {
           </div>
           <div className="grid grid-cols-3 gap-2">
             <div>
-              <label className="block text-sm mb-1">Minggu</label>
+              <label htmlFor="minggu" className="block text-sm mb-1">Minggu</label>
               <input
+                id="minggu"
                 type="number"
                 value={form.minggu}
                 min="1"
@@ -308,8 +313,9 @@ export default function PenugasanDetailPage() {
               />
             </div>
             <div>
-              <label className="block text-sm mb-1">Bulan</label>
+              <label htmlFor="bulan" className="block text-sm mb-1">Bulan</label>
               <select
+                id="bulan"
                 value={form.bulan}
                 onChange={(e) =>
                   setForm({ ...form, bulan: parseInt(e.target.value, 10) })
@@ -324,8 +330,9 @@ export default function PenugasanDetailPage() {
               </select>
             </div>
             <div>
-              <label className="block text-sm mb-1">Tahun</label>
+              <label htmlFor="tahun" className="block text-sm mb-1">Tahun</label>
               <input
+                id="tahun"
                 type="number"
                 value={form.tahun}
                 onChange={(e) =>
@@ -336,18 +343,10 @@ export default function PenugasanDetailPage() {
             </div>
           </div>
           <div className="flex justify-end space-x-2 pt-2">
-            <button
-              onClick={() => setEditing(false)}
-              className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
-            >
+            <Button variant="secondary" onClick={() => setEditing(false)}>
               Batal
-            </button>
-            <button
-              onClick={save}
-              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
-            >
-              Simpan
-            </button>
+            </Button>
+            <Button onClick={save}>Simpan</Button>
           </div>
         </div>
       )}
@@ -435,10 +434,11 @@ export default function PenugasanDetailPage() {
             </h3>
             <div className="space-y-2">
               <div>
-                <label className="block text-sm mb-1">
+                <label htmlFor="laporanTanggal" className="block text-sm mb-1">
                   Tanggal<span className="text-red-500">*</span>
                 </label>
                 <input
+                  id="laporanTanggal"
                   type="date"
                   value={laporanForm.tanggal}
                   onChange={(e) =>
@@ -448,10 +448,11 @@ export default function PenugasanDetailPage() {
                 />
               </div>
               <div>
-                <label className="block text-sm mb-1">
+                <label htmlFor="laporanStatus" className="block text-sm mb-1">
                   Status<span className="text-red-500">*</span>
                 </label>
                 <select
+                  id="laporanStatus"
                   value={laporanForm.status}
                   onChange={(e) =>
                     setLaporanForm({ ...laporanForm, status: e.target.value })
@@ -469,10 +470,11 @@ export default function PenugasanDetailPage() {
               </div>
               {laporanForm.status === STATUS.SELESAI_DIKERJAKAN && (
                 <div>
-                  <label className="block text-sm mb-1">
+                  <label htmlFor="buktiLink" className="block text-sm mb-1">
                     Link Bukti <span className="text-red-500">*</span>
                   </label>
                   <input
+                    id="buktiLink"
                     type="text"
                     value={laporanForm.bukti_link}
                     onChange={(e) =>
@@ -486,8 +488,9 @@ export default function PenugasanDetailPage() {
                 </div>
               )}
               <div>
-                <label className="block text-sm mb-1">Catatan</label>
+                <label htmlFor="catatan" className="block text-sm mb-1">Catatan</label>
                 <textarea
+                  id="catatan"
                   value={laporanForm.catatan}
                   onChange={(e) =>
                     setLaporanForm({ ...laporanForm, catatan: e.target.value })
@@ -497,18 +500,10 @@ export default function PenugasanDetailPage() {
               </div>
             </div>
             <div className="flex justify-end space-x-2 pt-2">
-              <button
-                onClick={() => setShowLaporanForm(false)}
-                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
-              >
+              <Button variant="secondary" onClick={() => setShowLaporanForm(false)}>
                 Batal
-              </button>
-              <button
-                onClick={saveLaporan}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
-              >
-                Simpan
-              </button>
+              </Button>
+              <Button onClick={saveLaporan}>Simpan</Button>
             </div>
         </Modal>
       )}

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -9,6 +9,7 @@ import { useNavigate } from "react-router-dom";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
+import Button from "../../components/ui/Button";
 import { ROLES } from "../../utils/roles";
 import months from "../../utils/months";
 import SearchInput from "../../components/SearchInput";
@@ -282,10 +283,11 @@ export default function PenugasanPage() {
           <h2 className="text-xl font-semibold mb-2">Tambah Penugasan</h2>
           <div className="space-y-2">
             <div>
-              <label className="block text-sm mb-1">
+              <label htmlFor="kegiatanId" className="block text-sm mb-1">
                 Kegiatan <span className="text-red-500">*</span>
               </label>
                 <Select
+                  inputId="kegiatanId"
                   classNamePrefix="react-select"
                   className="mb-1"
                   styles={selectStyles}
@@ -306,19 +308,20 @@ export default function PenugasanPage() {
                   isSearchable
                 />
               </div>
-              <div>
-                <label className="block text-sm mb-1">
-                  Pegawai <span className="text-red-500">*</span>
-                </label>
-                <Select
-                  isMulti
-                  classNamePrefix="react-select"
-                  className="mb-1"
-                  styles={selectStyles}
-                  menuPortalTarget={document.body}
-                  options={users
-                    .filter((u) => u.role !== ROLES.ADMIN)
-                    .map((u) => ({ value: u.id, label: `${u.nama}` }))}
+            <div>
+              <label htmlFor="pegawaiIds" className="block text-sm mb-1">
+                Pegawai <span className="text-red-500">*</span>
+              </label>
+              <Select
+                inputId="pegawaiIds"
+                isMulti
+                classNamePrefix="react-select"
+                className="mb-1"
+                styles={selectStyles}
+                menuPortalTarget={document.body}
+                options={users
+                  .filter((u) => u.role !== ROLES.ADMIN)
+                  .map((u) => ({ value: u.id, label: `${u.nama}` }))}
                   value={form.pegawaiIds
                     .map((id) => {
                       const u = users.find((x) => x.id === id);
@@ -347,18 +350,20 @@ export default function PenugasanPage() {
                   Pilih Semua
                 </button>
               </div>
-              <div>
-                <label className="block text-sm mb-1">Deskripsi</label>
-                <textarea
-                  value={form.deskripsi}
-                  onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
-                />
+            <div>
+              <label htmlFor="deskripsi" className="block text-sm mb-1">Deskripsi</label>
+              <textarea
+                id="deskripsi"
+                value={form.deskripsi}
+                onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
+                className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+              />
               </div>
               <div className="grid grid-cols-3 gap-2">
                 <div>
-                  <label className="block text-sm mb-1">Minggu</label>
+                  <label htmlFor="minggu" className="block text-sm mb-1">Minggu</label>
                   <input
+                    id="minggu"
                     type="number"
                     value={form.minggu}
                     min="1"
@@ -368,8 +373,9 @@ export default function PenugasanPage() {
                   />
                 </div>
                 <div>
-                  <label className="block text-sm mb-1">Bulan</label>
+                  <label htmlFor="bulan" className="block text-sm mb-1">Bulan</label>
                   <select
+                    id="bulan"
                     value={form.bulan}
                     onChange={(e) => setForm({ ...form, bulan: parseInt(e.target.value, 10) })}
                     className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
@@ -382,8 +388,9 @@ export default function PenugasanPage() {
                   </select>
                 </div>
                 <div>
-                  <label className="block text-sm mb-1">Tahun</label>
+                  <label htmlFor="tahun" className="block text-sm mb-1">Tahun</label>
                   <input
+                    id="tahun"
                     type="number"
                     value={form.tahun}
                     onChange={(e) => setForm({ ...form, tahun: parseInt(e.target.value, 10) })}
@@ -392,7 +399,8 @@ export default function PenugasanPage() {
                 </div>
               </div>
             <div className="flex justify-end space-x-2 pt-2">
-              <button
+              <Button
+                variant="secondary"
                 onClick={() => {
                   Swal.fire({
                     text: "Batalkan penambahan penugasan?",
@@ -403,13 +411,10 @@ export default function PenugasanPage() {
                     if (r.isConfirmed) setShowForm(false);
                   });
                 }}
-                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
               >
                 Batal
-              </button>
-              <button onClick={save} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded">
-                Simpan
-              </button>
+              </Button>
+              <Button onClick={save}>Simpan</Button>
             </div>
           </div>
         </Modal>

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -6,6 +6,7 @@ import { Pencil, Trash2 } from "lucide-react";
 import Select from "react-select";
 import { STATUS } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
+import Button from "../../components/ui/Button";
 
 const selectStyles = {
   option: (base) => ({ ...base, color: "#000" }),
@@ -186,8 +187,9 @@ export default function KegiatanTambahanDetailPage() {
       ) : (
         <div className="space-y-2 bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
           <div>
-            <label className="block text-sm mb-1">Kegiatan</label>
+            <label htmlFor="kegiatan" className="block text-sm mb-1">Kegiatan</label>
             <Select
+              inputId="kegiatan"
               classNamePrefix="react-select"
               styles={selectStyles}
               menuPortalTarget={document.body}
@@ -207,8 +209,9 @@ export default function KegiatanTambahanDetailPage() {
             )}
           </div>
           <div>
-            <label className="block text-sm mb-1">Tanggal</label>
+            <label htmlFor="tanggal" className="block text-sm mb-1">Tanggal</label>
             <input
+              id="tanggal"
               type="date"
               value={form.tanggal}
               onChange={(e) => setForm({ ...form, tanggal: e.target.value })}
@@ -216,16 +219,18 @@ export default function KegiatanTambahanDetailPage() {
             />
           </div>
           <div>
-            <label className="block text-sm mb-1">Deskripsi</label>
+            <label htmlFor="deskripsi" className="block text-sm mb-1">Deskripsi</label>
             <textarea
+              id="deskripsi"
               value={form.deskripsi}
               onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
               className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
             />
           </div>
           <div>
-            <label className="block text-sm mb-1">Status</label>
+            <label htmlFor="status" className="block text-sm mb-1">Status</label>
             <select
+              id="status"
               value={form.status}
               onChange={(e) => setForm({ ...form, status: e.target.value })}
               className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
@@ -240,18 +245,10 @@ export default function KegiatanTambahanDetailPage() {
             </select>
           </div>
           <div className="flex justify-end space-x-2 pt-2">
-            <button
-              onClick={() => setEditing(false)}
-              className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
-            >
+            <Button variant="secondary" onClick={() => setEditing(false)}>
               Batal
-            </button>
-            <button
-              onClick={save}
-              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
-            >
-              Simpan
-            </button>
+            </Button>
+            <Button onClick={save}>Simpan</Button>
           </div>
         </div>
       )}
@@ -259,8 +256,9 @@ export default function KegiatanTambahanDetailPage() {
         <h3 className="text-lg font-semibold">Bukti / Laporan Selesai</h3>
         <div className="space-y-2">
           <div>
-            <label className="block text-sm mb-1">Tanggal Mulai</label>
+            <label htmlFor="tanggalMulai" className="block text-sm mb-1">Tanggal Mulai</label>
             <input
+              id="tanggalMulai"
               type="date"
               value={laporanForm.tanggal_selesai}
               onChange={(e) =>
@@ -270,8 +268,9 @@ export default function KegiatanTambahanDetailPage() {
             />
           </div>
           <div>
-            <label className="block text-sm mb-1">Tanggal Akhir</label>
+            <label htmlFor="tanggalAkhir" className="block text-sm mb-1">Tanggal Akhir</label>
             <input
+              id="tanggalAkhir"
               type="date"
               value={laporanForm.tanggal_selesai_akhir}
               onChange={(e) =>
@@ -281,8 +280,9 @@ export default function KegiatanTambahanDetailPage() {
             />
           </div>
           <div>
-            <label className="block text-sm mb-1">Link Bukti</label>
+            <label htmlFor="buktiLink" className="block text-sm mb-1">Link Bukti</label>
             <input
+              id="buktiLink"
               type="text"
               value={laporanForm.bukti_link}
               onChange={(e) =>
@@ -293,12 +293,7 @@ export default function KegiatanTambahanDetailPage() {
           </div>
         </div>
         <div className="flex justify-end pt-2">
-          <button
-            onClick={addLaporan}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
-          >
-            Simpan Bukti
-          </button>
+          <Button onClick={addLaporan}>Simpan Bukti</Button>
         </div>
       </div>
     </div>

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -4,6 +4,7 @@ import Swal from "sweetalert2";
 import { Plus, Eye, Pencil, Trash2 } from "lucide-react";
 import Table from "../../components/ui/Table";
 import { useNavigate } from "react-router-dom";
+import Button from "../../components/ui/Button";
 import Select from "react-select";
 import { STATUS } from "../../utils/status";
 import Modal from "../../components/ui/Modal";
@@ -201,8 +202,9 @@ export default function KegiatanTambahanPage() {
           </h2>
           <div className="space-y-2">
             <div>
-              <label className="block text-sm mb-1">Kegiatan</label>
+              <label htmlFor="kegiatan" className="block text-sm mb-1">Kegiatan</label>
               <Select
+                inputId="kegiatan"
                 classNamePrefix="react-select"
                 styles={selectStyles}
                   menuPortalTarget={document.body}
@@ -222,8 +224,9 @@ export default function KegiatanTambahanPage() {
                 )}
               </div>
               <div>
-                <label className="block text-sm mb-1">Tanggal</label>
+                <label htmlFor="tanggal" className="block text-sm mb-1">Tanggal</label>
                 <input
+                  id="tanggal"
                   type="date"
                   value={form.tanggal}
                   onChange={(e) => setForm({ ...form, tanggal: e.target.value })}
@@ -231,16 +234,18 @@ export default function KegiatanTambahanPage() {
                 />
               </div>
               <div>
-                <label className="block text-sm mb-1">Deskripsi</label>
+                <label htmlFor="deskripsi" className="block text-sm mb-1">Deskripsi</label>
                 <textarea
+                  id="deskripsi"
                   value={form.deskripsi}
                   onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
                   className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
                 />
               </div>
               <div>
-                <label className="block text-sm mb-1">Status</label>
+                <label htmlFor="status" className="block text-sm mb-1">Status</label>
                 <select
+                  id="status"
                   value={form.status}
                   onChange={(e) => setForm({ ...form, status: e.target.value })}
                   className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
@@ -255,18 +260,16 @@ export default function KegiatanTambahanPage() {
                 </select>
               </div>
             <div className="flex justify-end space-x-2 pt-2">
-              <button
+              <Button
+                variant="secondary"
                 onClick={() => {
                   setShowForm(false);
                   setEditing(null);
                 }}
-                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
               >
                 Batal
-              </button>
-              <button onClick={save} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded">
-                Simpan
-              </button>
+              </Button>
+              <Button onClick={save}>Simpan</Button>
             </div>
           </div>
         </Modal>

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -6,6 +6,7 @@ import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
+import Button from "../../components/ui/Button";
 import { ROLES } from "../../utils/roles";
 import SearchInput from "../../components/SearchInput";
 
@@ -217,19 +218,21 @@ export default function TeamsPage() {
           </h2>
           <div className="space-y-2">
             <div>
-              <label className="block text-sm mb-1">Nama Tim</label>
+              <label htmlFor="namaTim" className="block text-sm mb-1">Nama Tim</label>
               <input
+                id="namaTim"
                 type="text"
                 value={form.nama_tim}
-                  onChange={(e) =>
-                    setForm({ ...form, nama_tim: e.target.value })
-                  }
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
-                />
-              </div>
+                onChange={(e) =>
+                  setForm({ ...form, nama_tim: e.target.value })
+                }
+                className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+              />
+            </div>
             </div>
             <div className="flex justify-end space-x-2 pt-2">
-              <button
+              <Button
+                variant="secondary"
                 onClick={async () => {
                   const r = await Swal.fire({
                     title: "Batalkan perubahan?",
@@ -239,16 +242,12 @@ export default function TeamsPage() {
                   });
                   if (r.isConfirmed) setShowForm(false);
                 }}
-                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
               >
                 Batal
-              </button>
-              <button
-                onClick={saveTeam}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
-              >
+              </Button>
+              <Button onClick={saveTeam}>
                 Simpan
-              </button>
+              </Button>
             </div>
           </Modal>
       )}

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -6,6 +6,7 @@ import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
+import Button from "../../components/ui/Button";
 import SearchInput from "../../components/SearchInput";
 import { ROLES } from "../../utils/roles";
 
@@ -260,49 +261,53 @@ export default function UsersPage() {
           </h2>
           <div className="space-y-2">
             <div>
-              <label className="block text-sm mb-1">
+              <label htmlFor="nama" className="block text-sm mb-1">
                 Nama <span className="text-red-500">*</span>
               </label>
               <input
-                  type="text"
-                  value={form.nama}
-                  onChange={(e) => setForm({ ...form, nama: e.target.value })}
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
-                />
-              </div>
-              <div>
-                <label className="block text-sm mb-1">
-                  Email <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="email"
-                  value={form.email}
-                  onChange={(e) => setForm({ ...form, email: e.target.value })}
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
-                />
-              </div>
-              <div>
-                <label className="block text-sm mb-1">
-                  Password <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="password"
-                  value={form.password}
-                  onChange={(e) =>
-                    setForm({ ...form, password: e.target.value })
-                  }
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
-                />
-              </div>
-              <div>
-                <label className="block text-sm mb-1">
-                  Role <span className="text-red-500">*</span>
-                </label>
-                <select
-                  value={form.role}
-                  onChange={(e) => setForm({ ...form, role: e.target.value })}
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
-                >
+                id="nama"
+                type="text"
+                value={form.nama}
+                onChange={(e) => setForm({ ...form, nama: e.target.value })}
+                className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+              />
+            </div>
+            <div>
+              <label htmlFor="email" className="block text-sm mb-1">
+                Email <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+                className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="block text-sm mb-1">
+                Password <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={form.password}
+                onChange={(e) =>
+                  setForm({ ...form, password: e.target.value })
+                }
+                className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+              />
+            </div>
+            <div>
+              <label htmlFor="role" className="block text-sm mb-1">
+                Role <span className="text-red-500">*</span>
+              </label>
+              <select
+                id="role"
+                value={form.role}
+                onChange={(e) => setForm({ ...form, role: e.target.value })}
+                className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+              >
                   <option value="">Pilih role</option>
                   {roles.map((r) => (
                     <option key={r.id} value={r.name}>
@@ -312,7 +317,8 @@ export default function UsersPage() {
                 </select>
               </div>
               <div className="flex justify-end space-x-2 pt-2">
-              <button
+              <Button
+                variant="secondary"
                 onClick={async () => {
                   const r = await Swal.fire({
                     title: "Batalkan perubahan?",
@@ -322,16 +328,12 @@ export default function UsersPage() {
                   });
                   if (r.isConfirmed) setShowForm(false);
                 }}
-                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded"
               >
                 Batal
-              </button>
-              <button
-                onClick={saveUser}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
-              >
+              </Button>
+              <Button onClick={saveUser}>
                 Simpan
-              </button>
+              </Button>
               <p className="text-xs text-gray-500 ml-2 self-center">
                 * wajib diisi
               </p>

--- a/web/src/theme/useTheme.jsx
+++ b/web/src/theme/useTheme.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState, useMemo } from "react";
 
 const ThemeContext = createContext();
 
@@ -21,11 +21,12 @@ export function ThemeProvider({ children }) {
 
   const toggleTheme = () => setTheme((prev) => (prev === "dark" ? "light" : "dark"));
 
-  return (
-    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
-      {children}
-    </ThemeContext.Provider>
+  const value = useMemo(
+    () => ({ theme, setTheme, toggleTheme }),
+    [theme]
   );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
 export function useTheme() {


### PR DESCRIPTION
## Summary
- lazy load the login page via `React.lazy`
- add `Button` component for common styling
- enhance `Modal` to trap focus and close on Escape
- memoize auth and theme context values
- connect form labels to inputs across multiple pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6874b4042008832bb7ff5bff5e9016a2