### PR TITLE
Add icon button variants and replace raw buttons

### DIFF
--- a/web/src/components/ui/Button.jsx
+++ b/web/src/components/ui/Button.jsx
@@ -3,14 +3,20 @@ import React from "react";
 export default function Button({
   children,
   variant = "primary",
+  icon = false,
   className = "",
   ...props
 }) {
-  const base = "px-4 py-2 rounded focus:outline-none transition";
+  const base = icon
+    ? "p-2 text-sm rounded focus:outline-none transition"
+    : "px-4 py-2 rounded focus:outline-none transition";
   const variants = {
     primary: "bg-blue-600 hover:bg-blue-700 text-white",
     secondary:
       "bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white",
+    danger: "bg-red-600 hover:bg-red-700 text-white",
+    warning: "bg-yellow-500 hover:bg-yellow-600 text-white",
+    icon: "text-blue-600 hover:underline",
   };
   return (
     <button

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -179,20 +179,22 @@ export default function LaporanHarianPage() {
                   </td>
                   <td className="px-4 py-2">{item.catatan || "-"}</td>
                   <td className="px-4 py-2 space-x-1">
-                    <button
+                    <Button
                       onClick={() => openEdit(item)}
-                      className="p-1 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                      variant="warning"
+                      icon
                       aria-label="Edit"
                     >
                       <Pencil size={14} />
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       onClick={() => remove(item.id)}
-                      className="p-1 bg-red-600 hover:bg-red-700 text-white rounded"
+                      variant="danger"
+                      icon
                       aria-label="Hapus"
                     >
                       <Trash2 size={14} />
-                    </button>
+                    </Button>
                   </td>
                 </tr>
               ))}

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -164,13 +164,10 @@ export default function MasterKegiatanPage() {
         </div>
 
         <div>
-          <button
-            onClick={openCreate}
-            className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
-          >
+          <Button onClick={openCreate} className="flex items-center gap-2">
             <Plus size={16} />
             <span className="hidden sm:inline">Tambah Kegiatan</span>
-          </button>
+          </Button>
         </div>
 
       </div>
@@ -211,20 +208,22 @@ export default function MasterKegiatanPage() {
                 {!item.deskripsi ? "-" : item.deskripsi}
               </th>
               <td className="px-4 py-2 space-x-2">
-                <button
+                <Button
                   onClick={() => openEdit(item)}
-                  className="p-2 text-sm bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                  variant="warning"
+                  icon
                   aria-label="Edit"
                 >
                   <Pencil size={16} />
-                </button>
-                <button
+                </Button>
+                <Button
                   onClick={() => deleteItem(item)}
-                  className="p-2 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                  variant="danger"
+                  icon
                   aria-label="Hapus"
                 >
                   <Trash2 size={16} />
-                </button>
+                </Button>
               </td>
             </tr>
           ))

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -188,20 +188,22 @@ export default function PenugasanDetailPage() {
         <h2 className="text-xl font-semibold">Detail Penugasan</h2>
         {canManage && !editing && (
           <div className="space-x-2">
-            <button
+            <Button
               onClick={() => setEditing(true)}
-              className="p-2 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+              variant="warning"
+              icon
               aria-label="Edit"
             >
               <Pencil size={16} />
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={remove}
-              className="p-2 bg-red-600 hover:bg-red-700 text-white rounded"
+              variant="danger"
+              icon
               aria-label="Hapus"
             >
               <Trash2 size={16} />
-            </button>
+            </Button>
           </div>
         )}
       </div>
@@ -353,12 +355,9 @@ export default function PenugasanDetailPage() {
       <div className="space-y-2 bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
         <div className="flex justify-between items-center">
           <h3 className="text-lg font-semibold">Laporan Harian</h3>
-          <button
-            onClick={openLaporan}
-            className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded"
-          >
+          <Button onClick={openLaporan} className="px-3 py-1">
             Tambah
-          </button>
+          </Button>
         </div>
         <Table className="min-w-full">
           <thead>
@@ -405,20 +404,22 @@ export default function PenugasanDetailPage() {
                   </td>
                   <td className="px-2 py-1">{l.catatan || "-"}</td>
                   <td className="px-2 py-1 space-x-1">
-                    <button
+                    <Button
                       onClick={() => editLaporan(l)}
-                      className="p-1 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                      variant="warning"
+                      icon
                       aria-label="Edit"
                     >
                       <Pencil size={14} />
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       onClick={() => deleteLaporan(l.id)}
-                      className="p-1 bg-red-600 hover:bg-red-700 text-white rounded"
+                      variant="danger"
+                      icon
                       aria-label="Hapus"
                     >
                       <Trash2 size={14} />
-                    </button>
+                    </Button>
                   </td>
                 </tr>
               ))

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -189,13 +189,10 @@ export default function PenugasanPage() {
           </button>
         </div>
         {canManage && (
-          <button
-            onClick={openCreate}
-            className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
-          >
+          <Button onClick={openCreate} className="flex items-center gap-2">
             <Plus size={16} />
             <span className="hidden sm:inline">Tambah Penugasan</span>
-          </button>
+          </Button>
         )}
       </div>
 
@@ -236,13 +233,14 @@ export default function PenugasanPage() {
                     <StatusBadge status={p.status} />
                   </td>
                   <td className="px-2 py-2">
-                    <button
+                    <Button
                       onClick={() => navigate(`/tugas-mingguan/${p.id}`)}
-                      className="text-blue-600 hover:underline text-sm"
+                      variant="icon"
+                      icon
                       aria-label="Detail"
                     >
                       <Eye size={16} />
-                    </button>
+                    </Button>
                   </td>
                 </tr>
               ))

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -119,20 +119,22 @@ export default function KegiatanTambahanDetailPage() {
         <h2 className="text-xl font-semibold">Detail Kegiatan Tambahan</h2>
         {!editing && (
           <div className="space-x-2">
-            <button
+            <Button
               onClick={() => setEditing(true)}
-              className="p-2 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+              variant="warning"
+              icon
               aria-label="Edit"
             >
               <Pencil size={16} />
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={remove}
-              className="p-2 bg-red-600 hover:bg-red-700 text-white rounded"
+              variant="danger"
+              icon
               aria-label="Hapus"
             >
               <Trash2 size={16} />
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -119,12 +119,9 @@ export default function KegiatanTambahanPage() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-xl font-semibold">Kegiatan Tambahan</h1>
-        <button
-          onClick={openCreate}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
-        >
+        <Button onClick={openCreate} className="flex items-center gap-2">
           <Plus size={16} /> Tambah
-        </button>
+        </Button>
       </div>
 
       <Table>
@@ -162,27 +159,29 @@ export default function KegiatanTambahanPage() {
                   <StatusBadge status={item.status} />
                 </td>
                 <td className="px-4 py-2 space-x-2">
-                  <button
+                  <Button
                     onClick={() => openDetail(item.id)}
-                    className="p-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+                    icon
                     aria-label="Detail"
                   >
                     <Eye size={16} />
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     onClick={() => openEdit(item)}
-                    className="p-2 bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                    variant="warning"
+                    icon
                     aria-label="Edit"
                   >
                     <Pencil size={16} />
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     onClick={() => remove(item)}
-                    className="p-2 bg-red-600 hover:bg-red-700 text-white rounded"
+                    variant="danger"
+                    icon
                     aria-label="Hapus"
                   >
                     <Trash2 size={16} />
-                  </button>
+                  </Button>
                 </td>
               </tr>
           ))

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -117,13 +117,10 @@ export default function TeamsPage() {
             placeholder="Cari tim..."
           />
         </div>
-        <button
-          onClick={openCreate}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
-        >
+        <Button onClick={openCreate} className="flex items-center gap-2">
           <Plus size={16} />
           <span className="hidden sm:inline">Tambah Tim</span>
-        </button>
+        </Button>
       </div>
 
       <Table>
@@ -158,20 +155,22 @@ export default function TeamsPage() {
               <td className="px-4 py-2">{t.nama_tim}</td>
               <td className="px-4 py-2">{t.members?.length || 0}</td>
               <td className="px-4 py-2 space-x-2">
-                <button
+                <Button
                   onClick={() => openEdit(t)}
-                  className="p-2 text-sm bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                  variant="warning"
+                  icon
                   aria-label="Edit"
                 >
                   <Pencil size={16} />
-                </button>
-                <button
+                </Button>
+                <Button
                   onClick={() => deleteTeam(t.id)}
-                  className="p-2 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                  variant="danger"
+                  icon
                   aria-label="Hapus"
                 >
                   <Trash2 size={16} />
-                </button>
+                </Button>
               </td>
             </tr>
           ))

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -157,13 +157,10 @@ export default function UsersPage() {
             ))}
           </select>
         </div>
-        <button
-          onClick={openCreate}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
-        >
+        <Button onClick={openCreate} className="flex items-center gap-2">
           <Plus size={16} />
           <span className="hidden sm:inline">Tambah Pengguna</span>
-        </button>
+        </Button>
       </div>
 
       <Table>
@@ -201,20 +198,22 @@ export default function UsersPage() {
               </td>
               <td className="px-4 py-2 capitalize text-center">{u.role}</td>
               <td className="px-4 py-2 space-x-2 text-center">
-                <button
+                <Button
                   onClick={() => openEdit(u)}
-                  className="p-2 text-sm bg-yellow-500 hover:bg-yellow-600 text-white rounded"
+                  variant="warning"
+                  icon
                   aria-label="Edit"
                 >
                   <Pencil size={16} />
-                </button>
-                <button
+                </Button>
+                <Button
                   onClick={() => deleteUser(u.id)}
-                  className="p-2 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+                  variant="danger"
+                  icon
                   aria-label="Hapus"
                 >
                   <Trash2 size={16} />
-                </button>
+                </Button>
               </td>
             </tr>
           ))


### PR DESCRIPTION
## Summary
- support icon mode and danger/warning/icon variants in `Button`
- use `<Button>` component instead of raw buttons across pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6874e4c2a108832b9b4b798cff9b5737