### PR TITLE
Add alert helpers and refactor pages

### DIFF
--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -1,6 +1,11 @@
 import { useEffect, useState, useCallback } from "react";
 import axios from "axios";
-import Swal from "sweetalert2";
+import {
+  showSuccess,
+  showError,
+  showWarning,
+  confirmDelete,
+} from "../../utils/alerts";
 import { Pencil, Plus, Trash2 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
@@ -80,10 +85,9 @@ export default function MasterKegiatanPage() {
 
   const saveItem = async () => {
     if (!form.teamId || isNaN(form.teamId) || !form.nama_kegiatan) {
-      Swal.fire(
+      showWarning(
         "Lengkapi data",
         "Tim dan nama kegiatan wajib diisi",
-        "warning"
       );
       return;
     }
@@ -96,25 +100,20 @@ export default function MasterKegiatanPage() {
       setShowForm(false);
       setEditing(null);
       fetchItems();
-      Swal.fire("Berhasil", "Kegiatan disimpan", "success");
+      showSuccess("Berhasil", "Kegiatan disimpan");
     } catch (err) {
       console.error("Gagal menyimpan kegiatan", err);
-      Swal.fire("Error", "Gagal menyimpan kegiatan", "error");
+      showError("Error", "Gagal menyimpan kegiatan");
     }
   };
 
   const deleteItem = async (item) => {
-    const r = await Swal.fire({
-      title: "Hapus kegiatan ini?",
-      icon: "warning",
-      showCancelButton: true,
-      confirmButtonText: "Hapus",
-    });
+    const r = await confirmDelete("Hapus kegiatan ini?");
     if (!r.isConfirmed) return;
     try {
       await axios.delete(`/master-kegiatan/${item.id}`);
       fetchItems();
-      Swal.fire("Dihapus", "Kegiatan berhasil dihapus", "success");
+      showSuccess("Dihapus", "Kegiatan berhasil dihapus");
     } catch (err) {
       console.error("Gagal menghapus kegiatan", err);
     }

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -1,7 +1,11 @@
 import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
-import Swal from "sweetalert2";
+import {
+  showSuccess,
+  showError,
+  confirmDelete,
+} from "../../utils/alerts";
 import Select from "react-select";
 import { Pencil, Trash2 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
@@ -62,7 +66,7 @@ export default function PenugasanDetailPage() {
       });
     } catch (err) {
       console.error(err);
-      Swal.fire("Error", "Gagal mengambil data", "error");
+      showError("Error", "Gagal mengambil data");
     }
   }, [id]);
 
@@ -92,12 +96,12 @@ export default function PenugasanDetailPage() {
   const save = async () => {
     try {
       await axios.put(`/penugasan/${id}`, form);
-      Swal.fire("Berhasil", "Penugasan diperbarui", "success");
+      showSuccess("Berhasil", "Penugasan diperbarui");
       setEditing(false);
       fetchDetail();
     } catch (err) {
       console.error(err);
-      Swal.fire("Error", "Gagal memperbarui", "error");
+      showError("Error", "Gagal memperbarui");
     }
   };
 
@@ -125,10 +129,10 @@ export default function PenugasanDetailPage() {
       setShowLaporanForm(false);
       const r = await axios.get(`/laporan-harian/penugasan/${id}`);
       setLaporan(r.data);
-      Swal.fire("Berhasil", "Laporan disimpan", "success");
+      showSuccess("Berhasil", "Laporan disimpan");
     } catch (err) {
       console.error(err);
-      Swal.fire("Error", "Gagal menyimpan laporan", "error");
+      showError("Error", "Gagal menyimpan laporan");
     }
   };
 
@@ -144,39 +148,29 @@ export default function PenugasanDetailPage() {
   };
 
   const deleteLaporan = async (laporanId) => {
-    const r = await Swal.fire({
-      title: "Hapus laporan ini?",
-      icon: "warning",
-      showCancelButton: true,
-      confirmButtonText: "Hapus",
-    });
+    const r = await confirmDelete("Hapus laporan ini?");
     if (!r.isConfirmed) return;
     try {
       await axios.delete(`/laporan-harian/${laporanId}`);
       const res = await axios.get(`/laporan-harian/penugasan/${id}`);
       setLaporan(res.data);
-      Swal.fire("Dihapus", "Laporan dihapus", "success");
+      showSuccess("Dihapus", "Laporan dihapus");
     } catch (err) {
       console.error(err);
-      Swal.fire("Error", "Gagal menghapus laporan", "error");
+      showError("Error", "Gagal menghapus laporan");
     }
   };
 
   const remove = async () => {
-    const r = await Swal.fire({
-      title: "Hapus penugasan ini?",
-      icon: "warning",
-      showCancelButton: true,
-      confirmButtonText: "Hapus",
-    });
+    const r = await confirmDelete("Hapus penugasan ini?");
     if (!r.isConfirmed) return;
     try {
       await axios.delete(`/penugasan/${id}`);
-      Swal.fire("Dihapus", "Penugasan dihapus", "success");
+      showSuccess("Dihapus", "Penugasan dihapus");
       navigate(-1);
     } catch (err) {
       console.error(err);
-      Swal.fire("Error", "Gagal menghapus", "error");
+      showError("Error", "Gagal menghapus");
     }
   };
 

--- a/web/src/utils/alerts.js
+++ b/web/src/utils/alerts.js
@@ -1,0 +1,38 @@
+import Swal from "sweetalert2";
+
+const baseOptions = {
+  heightAuto: false,
+  width: 400,
+};
+
+const showAlert = (title, text, icon) =>
+  Swal.fire({
+    title,
+    text,
+    icon,
+    confirmButtonText: "OK",
+    ...baseOptions,
+  });
+
+export const showSuccess = (title, text = "") => showAlert(title, text, "success");
+
+export const showError = (title, text = "") => showAlert(title, text, "error");
+
+export const showWarning = (title, text = "") => showAlert(title, text, "warning");
+
+export const confirmDelete = (title = "Hapus item ini?") =>
+  Swal.fire({
+    title,
+    icon: "warning",
+    showCancelButton: true,
+    confirmButtonText: "Hapus",
+    cancelButtonText: "Batal",
+    ...baseOptions,
+  });
+
+export default {
+  showSuccess,
+  showError,
+  showWarning,
+  confirmDelete,
+};


### PR DESCRIPTION
## Summary
- add reusable alert helpers in `src/utils/alerts.js`
- refactor `MasterKegiatanPage.jsx` to use alert helpers
- refactor `PenugasanDetailPage.jsx` to use alert helpers

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6874e7fa7810832bad0027ca807931ee