### PR TITLE
Add spinner loader component

### DIFF
--- a/web/src/components/Loading.jsx
+++ b/web/src/components/Loading.jsx
@@ -1,9 +1,11 @@
 import React from "react";
+import Spinner from "./Spinner";
 
 export default function Loading() {
   return (
-    <div className="py-10 text-center">
-      Loading...
+    <div className="py-10 text-center space-y-2">
+      <Spinner className="h-6 w-6 mx-auto" />
+      <div>Loading...</div>
     </div>
   );
 }

--- a/web/src/components/Spinner.jsx
+++ b/web/src/components/Spinner.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+export default function Spinner({ className = "h-5 w-5" }) {
+  return (
+    <svg
+      className={`animate-spin ${className} text-gray-600 dark:text-gray-200`}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  );
+}

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -7,6 +7,7 @@ import {
   confirmDelete,
 } from "../../utils/alerts";
 import { Pencil, Plus, Trash2 } from "lucide-react";
+import Spinner from "../../components/Spinner";
 import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
@@ -184,7 +185,9 @@ export default function MasterKegiatanPage() {
         <tbody>
           {loading ? (
             <tr>
-              <td colSpan="5" className="py-4 text-center">Memuat data...</td>
+              <td colSpan="5" className="py-4 text-center">
+                <Spinner className="h-6 w-6 mx-auto" />
+              </td>
             </tr>
           ) : items.length === 0 ? (
             <tr>

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -8,6 +8,7 @@ import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
 import Button from "../../components/ui/Button";
 import SearchInput from "../../components/SearchInput";
+import Spinner from "../../components/Spinner";
 import { ROLES } from "../../utils/roles";
 
 export default function UsersPage() {
@@ -178,7 +179,7 @@ export default function UsersPage() {
           {loading ? (
             <tr>
               <td colSpan="6" className="py-4 text-center">
-                Memuat data...
+                <Spinner className="h-6 w-6 mx-auto" />
               </td>
             </tr>
           ) : paginatedUsers.length === 0 ? (


### PR DESCRIPTION
## Summary
- add a reusable `Spinner` component
- show the spinner in the `Loading` component
- include the spinner in table loading rows

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6874e9d01e50832b9f9c808a62a9896d