### PR TITLE
Add reusable button utilities

### DIFF
--- a/web/src/assets/styles/index.css
+++ b/web/src/assets/styles/index.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .icon-button {
+    @apply p-2 text-sm rounded focus:outline-none transition;
+  }
+
+  .add-button {
+    @apply flex items-center gap-2;
+  }
+}

--- a/web/src/components/ui/Button.jsx
+++ b/web/src/components/ui/Button.jsx
@@ -8,7 +8,7 @@ export default function Button({
   ...props
 }) {
   const base = icon
-    ? "p-2 text-sm rounded focus:outline-none transition"
+    ? "icon-button"
     : "px-4 py-2 rounded focus:outline-none transition";
   const variants = {
     primary: "bg-blue-600 hover:bg-blue-700 text-white",

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -164,7 +164,7 @@ export default function MasterKegiatanPage() {
         </div>
 
         <div>
-          <Button onClick={openCreate} className="flex items-center gap-2">
+          <Button onClick={openCreate} className="add-button">
             <Plus size={16} />
             <span className="hidden sm:inline">Tambah Kegiatan</span>
           </Button>

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -182,14 +182,14 @@ export default function PenugasanPage() {
           <button
             type="button"
             onClick={fetchData}
-            className="px-3 py-[4px] bg-gray-200 dark:bg-gray-700 rounded"
+            className="icon-button bg-gray-200 dark:bg-gray-700"
             aria-label="Filter"
           >
             <FilterIcon size={16} />
           </button>
         </div>
         {canManage && (
-          <Button onClick={openCreate} className="flex items-center gap-2">
+          <Button onClick={openCreate} className="add-button">
             <Plus size={16} />
             <span className="hidden sm:inline">Tambah Penugasan</span>
           </Button>

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -119,7 +119,7 @@ export default function KegiatanTambahanPage() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-xl font-semibold">Kegiatan Tambahan</h1>
-        <Button onClick={openCreate} className="flex items-center gap-2">
+        <Button onClick={openCreate} className="add-button">
           <Plus size={16} /> Tambah
         </Button>
       </div>

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -117,7 +117,7 @@ export default function TeamsPage() {
             placeholder="Cari tim..."
           />
         </div>
-        <Button onClick={openCreate} className="flex items-center gap-2">
+        <Button onClick={openCreate} className="add-button">
           <Plus size={16} />
           <span className="hidden sm:inline">Tambah Tim</span>
         </Button>

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -158,7 +158,7 @@ export default function UsersPage() {
             ))}
           </select>
         </div>
-        <Button onClick={openCreate} className="flex items-center gap-2">
+        <Button onClick={openCreate} className="add-button">
           <Plus size={16} />
           <span className="hidden sm:inline">Tambah Pengguna</span>
         </Button>


### PR DESCRIPTION
## Summary
- create `icon-button` and `add-button` utilities
- use the new utilities in pages
- update Button component to rely on `icon-button`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6874eb17c324832ba114cd4e095293a9