### PR TITLE
Improve focus styling and badge contrast

### DIFF
--- a/web/src/assets/styles/index.css
+++ b/web/src/assets/styles/index.css
@@ -4,7 +4,7 @@
 
 @layer components {
   .icon-button {
-    @apply p-2 text-sm rounded focus:outline-none transition;
+    @apply p-2 text-sm rounded focus:outline-none transition focus-visible:ring-2 focus-visible:ring-offset-2 ring-blue-500;
   }
 
   .add-button {

--- a/web/src/components/ui/Button.jsx
+++ b/web/src/components/ui/Button.jsx
@@ -9,7 +9,8 @@ export default function Button({
 }) {
   const base = icon
     ? "icon-button"
-    : "px-4 py-2 rounded focus:outline-none transition";
+    :
+      "px-4 py-2 rounded focus:outline-none transition focus-visible:ring-2 focus-visible:ring-offset-2 ring-blue-500";
   const variants = {
     primary: "bg-blue-600 hover:bg-blue-700 text-white",
     secondary:

--- a/web/src/components/ui/StatusBadge.jsx
+++ b/web/src/components/ui/StatusBadge.jsx
@@ -3,11 +3,11 @@ import { STATUS } from "../../utils/status";
 
 const colorMap = {
   [STATUS.BELUM]:
-    "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200",
+    "bg-gray-200 text-gray-900 dark:bg-gray-600 dark:text-gray-100",
   [STATUS.SEDANG_DIKERJAKAN]:
-    "bg-yellow-100 text-yellow-800 dark:bg-yellow-700 dark:text-yellow-200",
+    "bg-yellow-200 text-yellow-900 dark:bg-yellow-600 dark:text-yellow-100",
   [STATUS.SELESAI_DIKERJAKAN]:
-    "bg-green-100 text-green-800 dark:bg-green-700 dark:text-green-200",
+    "bg-green-200 text-green-900 dark:bg-green-600 dark:text-green-100",
 };
 
 export default function StatusBadge({ status }) {

--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -107,7 +107,7 @@ export default function Layout() {
         <div className="flex items-center justify-between gap-2 p-4 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 flex-shrink-0">
           <div className="flex items-center space-x-3">
             <button
-              className="md:hidden text-xl text-gray-700 dark:text-gray-100"
+              className="md:hidden text-xl text-gray-700 dark:text-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ring-blue-500"
               onClick={() => setMobileOpen(!mobileOpen)}
               aria-label={mobileOpen ? "Close menu" : "Open menu"}
             >
@@ -123,7 +123,7 @@ export default function Layout() {
             <div className="relative" ref={notifRef}>
               <button
                 onClick={() => setShowNotifMenu(!showNotifMenu)}
-                className="relative"
+                className="relative focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ring-blue-500"
                 aria-label="Notifications"
               >
                 <FaBell className="text-xl cursor-pointer" />
@@ -185,7 +185,7 @@ export default function Layout() {
             <div className="relative" ref={profileRef}>
               <button
                 onClick={() => setShowProfileMenu(!showProfileMenu)}
-                className="flex items-center space-x-2 text-sm focus:outline-none"
+                className="flex items-center space-x-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ring-blue-500"
               >
                 {user?.role === ROLES.ADMIN ? (
                   <FaUserCircle className="text-2xl" />


### PR DESCRIPTION
## Summary
- add focus-visible ring to Button base styles
- apply consistent focus styling to standalone icon buttons
- bump contrast for StatusBadge colors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6874ed3b9694832b9ef3321ed57eb7b1