### PR TITLE
Implement modal transitions and shared select styles

### DIFF
--- a/web/src/components/ui/Modal.jsx
+++ b/web/src/components/ui/Modal.jsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 export default function Modal({ onClose, children, widthClass = "w-full max-w-md" }) {
   const containerRef = useRef(null);
+  const [visible, setVisible] = useState(false);
+  const [closing, setClosing] = useState(false);
 
   useEffect(() => {
     function handleKey(e) {
@@ -27,20 +29,27 @@ export default function Modal({ onClose, children, widthClass = "w-full max-w-md
       "a[href], button, textarea, input, select, [tabindex]:not([tabindex='-1'])"
     );
     firstInput?.focus();
+    setTimeout(() => setVisible(true), 10);
     return () => document.removeEventListener("keydown", handleKey);
   }, [onClose]);
 
+  function handleClose() {
+    setClosing(true);
+    setVisible(false);
+    setTimeout(onClose, 300);
+  }
+
   return (
     <div
-      className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50"
-      onClick={onClose}
+      className={`fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50 transition-opacity duration-300 ${visible && !closing ? 'opacity-100' : 'opacity-0'}`}
+      onClick={handleClose}
       role="dialog"
       aria-modal="true"
     >
       <div
         ref={containerRef}
         onClick={(e) => e.stopPropagation()}
-        className={`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl space-y-4 ${widthClass}`}
+        className={`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl space-y-4 transform transition-all duration-300 ${visible && !closing ? 'scale-100 opacity-100' : 'scale-95 opacity-0'} ${widthClass}`}
       >
         {children}
       </div>

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -147,23 +147,23 @@ export default function LaporanHarianPage() {
           <Table>
             <thead>
               <tr className="bg-gray-200 dark:bg-gray-700 text-center text-sm uppercase">
-                <th className="px-4 py-2">No</th>
-                <th className="px-4 py-2">Tanggal</th>
-                <th className="px-4 py-2">Status</th>
-                <th className="px-4 py-2">Bukti</th>
-                <th className="px-4 py-2">Catatan</th>
-                <th className="px-4 py-2">Aksi</th>
+                <th className="px-2 py-1 sm:px-4 sm:py-2">No</th>
+                <th className="px-2 py-1 sm:px-4 sm:py-2">Tanggal</th>
+                <th className="px-2 py-1 sm:px-4 sm:py-2">Status</th>
+                <th className="px-2 py-1 sm:px-4 sm:py-2">Bukti</th>
+                <th className="px-2 py-1 sm:px-4 sm:py-2">Catatan</th>
+                <th className="px-2 py-1 sm:px-4 sm:py-2">Aksi</th>
               </tr>
             </thead>
             <tbody>
               {paginated.map((item, idx) => (
                 <tr key={item.id} className="border-t dark:border-gray-700 text-center">
-                  <td className="px-4 py-2">{(currentPage - 1) * pageSize + idx + 1}</td>
-                  <td className="px-4 py-2">{item.tanggal.slice(0, 10)}</td>
-                  <td className="px-4 py-2">
+                  <td className="px-2 py-1 sm:px-4 sm:py-2">{(currentPage - 1) * pageSize + idx + 1}</td>
+                  <td className="px-2 py-1 sm:px-4 sm:py-2">{item.tanggal.slice(0, 10)}</td>
+                  <td className="px-2 py-1 sm:px-4 sm:py-2">
                     <StatusBadge status={item.status} />
                   </td>
-                  <td className="px-4 py-2">
+                  <td className="px-2 py-1 sm:px-4 sm:py-2">
                     {item.bukti_link ? (
                       <a
                         href={item.bukti_link}
@@ -177,8 +177,8 @@ export default function LaporanHarianPage() {
                       "-"
                     )}
                   </td>
-                  <td className="px-4 py-2">{item.catatan || "-"}</td>
-                  <td className="px-4 py-2 space-x-1">
+                  <td className="px-2 py-1 sm:px-4 sm:py-2">{item.catatan || "-"}</td>
+                  <td className="px-2 py-1 sm:px-4 sm:py-2 space-x-1">
                     <Button
                       onClick={() => openEdit(item)}
                       variant="warning"

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -175,11 +175,11 @@ export default function MasterKegiatanPage() {
       <Table>
         <thead>
           <tr className="bg-gray-200 dark:bg-gray-700 text-center text-sm uppercase">
-            <th className="px-4 py-2">No</th>
-            <th className="px-4 py-2">Tim</th>
-            <th className="px-4 py-2">Nama Kegiatan</th>
-            <th className="px-4 py-2">Deskripsi</th>
-            <th className="px-4 py-2">Aksi</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">No</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Tim</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Nama Kegiatan</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Deskripsi</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Aksi</th>
           </tr>
         </thead>
         <tbody>
@@ -201,15 +201,15 @@ export default function MasterKegiatanPage() {
               key={item.id}
               className="border-t dark:border-gray-700 text-center"
             >
-              <td className="px-4 py-2">{(page - 1) * perPage + idx + 1}</td>
-              <td className="px-4 py-2">
+              <td className="px-2 py-1 sm:px-4 sm:py-2">{(page - 1) * perPage + idx + 1}</td>
+              <td className="px-2 py-1 sm:px-4 sm:py-2">
                 {item.team?.nama_tim || item.teamId}
               </td>
-              <td className="px-4 py-2">{item.nama_kegiatan}</td>
-              <th className="px-4 py-2">
+              <td className="px-2 py-1 sm:px-4 sm:py-2">{item.nama_kegiatan}</td>
+              <th className="px-2 py-1 sm:px-4 sm:py-2">
                 {!item.deskripsi ? "-" : item.deskripsi}
               </th>
-              <td className="px-4 py-2 space-x-2">
+              <td className="px-2 py-1 sm:px-4 sm:py-2 space-x-2">
                 <Button
                   onClick={() => openEdit(item)}
                   variant="warning"

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -7,6 +7,7 @@ import {
   confirmDelete,
 } from "../../utils/alerts";
 import Select from "react-select";
+import selectStyles from "../../utils/selectStyles";
 import { Pencil, Trash2 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
@@ -17,10 +18,6 @@ import Table from "../../components/ui/Table";
 import Button from "../../components/ui/Button";
 import months from "../../utils/months";
 
-const selectStyles = {
-  option: (base) => ({ ...base, color: "#000" }),
-  menuPortal: (base) => ({ ...base, zIndex: 9999 }),
-};
 
 export default function PenugasanDetailPage() {
   const { id } = useParams();
@@ -356,12 +353,12 @@ export default function PenugasanDetailPage() {
         <Table className="min-w-full">
           <thead>
             <tr className="bg-gray-200 dark:bg-gray-700 text-center text-sm">
-              <th className="px-2 py-1">No</th>
-              <th className="px-2 py-1">Tanggal</th>
-              <th className="px-2 py-1">Status</th>
-              <th className="px-2 py-1">Bukti</th>
-              <th className="px-2 py-1">Catatan</th>
-              <th className="px-2 py-1">Aksi</th>
+              <th className="px-1 py-0.5 sm:px-2 sm:py-1">No</th>
+              <th className="px-1 py-0.5 sm:px-2 sm:py-1">Tanggal</th>
+              <th className="px-1 py-0.5 sm:px-2 sm:py-1">Status</th>
+              <th className="px-1 py-0.5 sm:px-2 sm:py-1">Bukti</th>
+              <th className="px-1 py-0.5 sm:px-2 sm:py-1">Catatan</th>
+              <th className="px-1 py-0.5 sm:px-2 sm:py-1">Aksi</th>
             </tr>
           </thead>
           <tbody>
@@ -377,12 +374,12 @@ export default function PenugasanDetailPage() {
                   key={l.id}
                   className="border-t dark:border-gray-700 text-center"
                 >
-                  <td className="px-2 py-1">{idx + 1}</td>
-                  <td className="px-2 py-1">{l.tanggal.slice(0, 10)}</td>
-                  <td className="px-2 py-1">
+                  <td className="px-1 py-0.5 sm:px-2 sm:py-1">{idx + 1}</td>
+                  <td className="px-1 py-0.5 sm:px-2 sm:py-1">{l.tanggal.slice(0, 10)}</td>
+                  <td className="px-1 py-0.5 sm:px-2 sm:py-1">
                     <StatusBadge status={l.status} />
                   </td>
-                  <td className="px-2 py-1">
+                  <td className="px-1 py-0.5 sm:px-2 sm:py-1">
                     {l.bukti_link ? (
                       <a
                         href={l.bukti_link}
@@ -396,8 +393,8 @@ export default function PenugasanDetailPage() {
                       "-"
                     )}
                   </td>
-                  <td className="px-2 py-1">{l.catatan || "-"}</td>
-                  <td className="px-2 py-1 space-x-1">
+                  <td className="px-1 py-0.5 sm:px-2 sm:py-1">{l.catatan || "-"}</td>
+                  <td className="px-1 py-0.5 sm:px-2 sm:py-1 space-x-1">
                     <Button
                       onClick={() => editLaporan(l)}
                       variant="warning"

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import Swal from "sweetalert2";
 import { Plus, Filter as FilterIcon, Eye } from "lucide-react";
 import Select from "react-select";
+import selectStyles from "../../utils/selectStyles";
 import StatusBadge from "../../components/ui/StatusBadge";
 import { useAuth } from "../auth/useAuth";
 import { useNavigate } from "react-router-dom";
@@ -14,11 +15,6 @@ import { ROLES } from "../../utils/roles";
 import months from "../../utils/months";
 import SearchInput from "../../components/SearchInput";
 
-const selectStyles = {
-  option: (base) => ({ ...base, color: "#000" }),
-  valueContainer: (base) => ({ ...base, maxHeight: "100px", overflowY: "auto" }),
-  menuPortal: (base) => ({ ...base, zIndex: 9999 }),
-};
 
 export default function PenugasanPage() {
   const { user } = useAuth();
@@ -199,13 +195,13 @@ export default function PenugasanPage() {
       <Table>
         <thead>
           <tr className="bg-gray-200 dark:bg-gray-700 text-center text-sm uppercase">
-            <th className="px-2 py-2">No</th>
-            <th className="px-4 py-2">Kegiatan</th>
-            <th className="px-4 py-2">Tim</th>
-            <th className="px-4 py-2">Pegawai</th>
-            <th className="px-4 py-2">Minggu</th>
-            <th className="px-4 py-2">Status</th>
-            <th className="px-2 py-2">Aksi</th>
+            <th className="px-1 py-1 sm:px-2 sm:py-2">No</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Kegiatan</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Tim</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Pegawai</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Minggu</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Status</th>
+            <th className="px-1 py-1 sm:px-2 sm:py-2">Aksi</th>
           </tr>
         </thead>
         <tbody>
@@ -224,15 +220,15 @@ export default function PenugasanPage() {
           ) : (
             paginated.map((p, idx) => (
                 <tr key={p.id} className="border-t dark:border-gray-700 text-center">
-                  <td className="px-2 py-2">{(currentPage - 1) * pageSize + idx + 1}</td>
-                  <td className="px-4 py-2">{p.kegiatan?.nama_kegiatan || "-"}</td>
-                  <td className="px-4 py-2">{p.kegiatan?.team?.nama_tim || "-"}</td>
-                  <td className="px-4 py-2">{p.pegawai?.nama || "-"}</td>
-                  <td className="px-4 py-2">{p.minggu}</td>
-                  <td className="px-4 py-2">
+                  <td className="px-1 py-1 sm:px-2 sm:py-2">{(currentPage - 1) * pageSize + idx + 1}</td>
+                  <td className="px-2 py-1 sm:px-4 sm:py-2">{p.kegiatan?.nama_kegiatan || "-"}</td>
+                  <td className="px-2 py-1 sm:px-4 sm:py-2">{p.kegiatan?.team?.nama_tim || "-"}</td>
+                  <td className="px-2 py-1 sm:px-4 sm:py-2">{p.pegawai?.nama || "-"}</td>
+                  <td className="px-2 py-1 sm:px-4 sm:py-2">{p.minggu}</td>
+                  <td className="px-2 py-1 sm:px-4 sm:py-2">
                     <StatusBadge status={p.status} />
                   </td>
-                  <td className="px-2 py-2">
+                  <td className="px-1 py-1 sm:px-2 sm:py-2">
                     <Button
                       onClick={() => navigate(`/tugas-mingguan/${p.id}`)}
                       variant="icon"

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -4,14 +4,11 @@ import axios from "axios";
 import Swal from "sweetalert2";
 import { Pencil, Trash2 } from "lucide-react";
 import Select from "react-select";
+import selectStyles from "../../utils/selectStyles";
 import { STATUS } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
 import Button from "../../components/ui/Button";
 
-const selectStyles = {
-  option: (base) => ({ ...base, color: "#000" }),
-  menuPortal: (base) => ({ ...base, zIndex: 9999 }),
-};
 
 export default function KegiatanTambahanDetailPage() {
   const { id } = useParams();

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -6,14 +6,11 @@ import Table from "../../components/ui/Table";
 import { useNavigate } from "react-router-dom";
 import Button from "../../components/ui/Button";
 import Select from "react-select";
+import selectStyles from "../../utils/selectStyles";
 import { STATUS } from "../../utils/status";
 import Modal from "../../components/ui/Modal";
 import StatusBadge from "../../components/ui/StatusBadge";
 
-const selectStyles = {
-  option: (base) => ({ ...base, color: "#000" }),
-  menuPortal: (base) => ({ ...base, zIndex: 9999 }),
-};
 
 export default function KegiatanTambahanPage() {
   const [items, setItems] = useState([]);
@@ -127,12 +124,12 @@ export default function KegiatanTambahanPage() {
       <Table>
         <thead>
           <tr className="bg-gray-200 dark:bg-gray-700 text-center text-sm uppercase">
-            <th className="px-4 py-2">No</th>
-            <th className="px-4 py-2">Nama</th>
-            <th className="px-4 py-2">Tim</th>
-            <th className="px-4 py-2">Tanggal</th>
-            <th className="px-4 py-2">Status</th>
-            <th className="px-4 py-2">Aksi</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">No</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Nama</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Tim</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Tanggal</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Status</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Aksi</th>
           </tr>
         </thead>
         <tbody>
@@ -151,14 +148,14 @@ export default function KegiatanTambahanPage() {
           ) : (
             items.map((item, idx) => (
               <tr key={item.id} className="border-t dark:border-gray-700 text-center">
-                <td className="px-4 py-2">{idx + 1}</td>
-                <td className="px-4 py-2">{item.nama}</td>
-                <td className="px-4 py-2">{item.kegiatan.team?.nama_tim || '-'}</td>
-                <td className="px-4 py-2">{item.tanggal.slice(0,10)}</td>
-                <td className="px-4 py-2">
+                <td className="px-2 py-1 sm:px-4 sm:py-2">{idx + 1}</td>
+                <td className="px-2 py-1 sm:px-4 sm:py-2">{item.nama}</td>
+                <td className="px-2 py-1 sm:px-4 sm:py-2">{item.kegiatan.team?.nama_tim || '-'}</td>
+                <td className="px-2 py-1 sm:px-4 sm:py-2">{item.tanggal.slice(0,10)}</td>
+                <td className="px-2 py-1 sm:px-4 sm:py-2">
                   <StatusBadge status={item.status} />
                 </td>
-                <td className="px-4 py-2 space-x-2">
+                <td className="px-2 py-1 sm:px-4 sm:py-2 space-x-2">
                   <Button
                     onClick={() => openDetail(item.id)}
                     icon

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -126,10 +126,10 @@ export default function TeamsPage() {
       <Table>
         <thead>
           <tr className="bg-gray-200 dark:bg-gray-700 text-center text-sm uppercase">
-            <th className="px-4 py-2">No</th>
-            <th className="px-4 py-2">Nama Tim</th>
-            <th className="px-4 py-2">Jumlah Anggota</th>
-            <th className="px-4 py-2">Aksi</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">No</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Nama Tim</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Jumlah Anggota</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Aksi</th>
           </tr>
         </thead>
         <tbody>
@@ -151,10 +151,10 @@ export default function TeamsPage() {
               key={t.id}
               className="border-t dark:border-gray-700 text-center"
             >
-              <td className="px-4 py-2">{(currentPage - 1) * pageSize + idx + 1}</td>
-              <td className="px-4 py-2">{t.nama_tim}</td>
-              <td className="px-4 py-2">{t.members?.length || 0}</td>
-              <td className="px-4 py-2 space-x-2">
+              <td className="px-2 py-1 sm:px-4 sm:py-2">{(currentPage - 1) * pageSize + idx + 1}</td>
+              <td className="px-2 py-1 sm:px-4 sm:py-2">{t.nama_tim}</td>
+              <td className="px-2 py-1 sm:px-4 sm:py-2">{t.members?.length || 0}</td>
+              <td className="px-2 py-1 sm:px-4 sm:py-2 space-x-2">
                 <Button
                   onClick={() => openEdit(t)}
                   variant="warning"

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -167,12 +167,12 @@ export default function UsersPage() {
       <Table>
         <thead>
           <tr className="bg-gray-200 dark:bg-gray-700 text-center text-sm uppercase">
-            <th className="px-4 py-2">No</th>
-            <th className="px-4 py-2">Nama</th>
-            <th className="px-4 py-2">Email</th>
-            <th className="px-4 py-2">Tim</th>
-            <th className="px-4 py-2">Role</th>
-            <th className="px-4 py-2">Aksi</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">No</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Nama</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Email</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Tim</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Role</th>
+            <th className="px-2 py-1 sm:px-4 sm:py-2">Aksi</th>
           </tr>
         </thead>
         <tbody>
@@ -191,14 +191,14 @@ export default function UsersPage() {
           ) : (
             paginatedUsers.map((u, idx) => (
               <tr key={u.id} className="border-t dark:border-gray-700">
-                <td className="px-4 py-2 text-center">{(currentPage - 1) * pageSize + idx + 1}</td>
-              <td className="px-4 py-2">{u.nama}</td>
-              <td className="px-4 py-2 text">{u.email}</td>
-              <td className="px-4 py-2 text-center">
+              <td className="px-2 py-1 sm:px-4 sm:py-2 text-center">{(currentPage - 1) * pageSize + idx + 1}</td>
+              <td className="px-2 py-1 sm:px-4 sm:py-2">{u.nama}</td>
+              <td className="px-2 py-1 sm:px-4 sm:py-2 text">{u.email}</td>
+              <td className="px-2 py-1 sm:px-4 sm:py-2 text-center">
                 {u.members?.[0]?.team?.nama_tim || "-"}
               </td>
-              <td className="px-4 py-2 capitalize text-center">{u.role}</td>
-              <td className="px-4 py-2 space-x-2 text-center">
+              <td className="px-2 py-1 sm:px-4 sm:py-2 capitalize text-center">{u.role}</td>
+              <td className="px-2 py-1 sm:px-4 sm:py-2 space-x-2 text-center">
                 <Button
                   onClick={() => openEdit(u)}
                   variant="warning"

--- a/web/src/utils/selectStyles.js
+++ b/web/src/utils/selectStyles.js
@@ -1,0 +1,11 @@
+export const selectStyles = {
+  option: (base) => ({ ...base, color: "#000" }),
+  valueContainer: (base) => ({
+    ...base,
+    maxHeight: "100px",
+    overflowY: "auto",
+  }),
+  menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+};
+
+export default selectStyles;


### PR DESCRIPTION
## Summary
- add fade/scale transitions to `Modal`
- share React Select styling via `selectStyles` util
- tweak table padding for better mobile layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6874f079657c832bbc5d6bed1b62e6fb