### PR TITLE
Add 404 page and catch-all route

### DIFF
--- a/web/src/pages/NotFound.jsx
+++ b/web/src/pages/NotFound.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import Button from "../components/ui/Button";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-[60vh] flex flex-col items-center justify-center text-center space-y-4 p-6">
+      <h1 className="text-4xl font-bold">404 - Not Found</h1>
+      <p className="text-gray-600 dark:text-gray-400">Halaman yang Anda cari tidak ditemukan.</p>
+      <Link to="/dashboard">
+        <Button>Ke Dashboard</Button>
+      </Link>
+    </div>
+  );
+}

--- a/web/src/routes/AppRoutes.jsx
+++ b/web/src/routes/AppRoutes.jsx
@@ -14,6 +14,7 @@ const PenugasanDetailPage = React.lazy(() => import("../pages/penugasan/Penugasa
 const LaporanHarianPage = React.lazy(() => import("../pages/laporan/LaporanHarianPage"));
 const KegiatanTambahanPage = React.lazy(() => import("../pages/tambahan/KegiatanTambahanPage"));
 const KegiatanTambahanDetailPage = React.lazy(() => import("../pages/tambahan/KegiatanTambahanDetailPage"));
+const NotFound = React.lazy(() => import("../pages/NotFound"));
 
 function PrivateRoute({ children }) {
   const { token, user } = useAuth();
@@ -54,6 +55,7 @@ export default function AppRoutes() {
         <Route path="laporan-harian" element={<LaporanHarianPage />} />
         <Route path="kegiatan-tambahan" element={<KegiatanTambahanPage />} />
         <Route path="kegiatan-tambahan/:id" element={<KegiatanTambahanDetailPage />} />
+        <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>
     </Suspense>


### PR DESCRIPTION
## Summary
- create `NotFound` page with a button back to Dashboard
- register the page in AppRoutes with a catch-all `*` route

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6874f7cd07e0832baa80c52755f625aa