### PR TITLE
Add confirmAlert wrapper for Swal confirmations

### DIFF
--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import { Pencil, Trash2 } from "lucide-react";
 import Swal from "sweetalert2";
+import confirmAlert from "../utils/confirmAlert";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
@@ -65,10 +66,9 @@ export default function LaporanHarianPage() {
   };
 
   const remove = async (id) => {
-    const r = await Swal.fire({
+    const r = await confirmAlert({
       title: "Hapus laporan ini?",
       icon: "warning",
-      showCancelButton: true,
       confirmButtonText: "Hapus",
     });
     if (!r.isConfirmed) return;

--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "../auth/useAuth";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useTheme } from "../../theme/useTheme.jsx";
 import Swal from "sweetalert2";
+import confirmAlert from "../utils/confirmAlert";
 import {
   FaBell,
   FaMoon,
@@ -36,13 +37,11 @@ export default function Layout() {
   const notifRef = useRef();
 
   const handleLogout = async () => {
-    const r = await Swal.fire({
+    const r = await confirmAlert({
       title: "Logout?",
       text: "Anda yakin ingin logout?",
       icon: "warning",
-      showCancelButton: true,
       confirmButtonText: "Logout",
-      cancelButtonText: "Batal",
     });
     if (!r.isConfirmed) return;
     localStorage.removeItem("token");

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import axios from "axios";
 import Swal from "sweetalert2";
+import confirmAlert from "../utils/confirmAlert";
 import { Plus, Filter as FilterIcon, Eye } from "lucide-react";
 import Select from "react-select";
 import selectStyles from "../../utils/selectStyles";
@@ -395,15 +396,13 @@ export default function PenugasanPage() {
             <div className="flex justify-end space-x-2 pt-2">
               <Button
                 variant="secondary"
-                onClick={() => {
-                  Swal.fire({
+                onClick={async () => {
+                  const r = await confirmAlert({
                     text: "Batalkan penambahan penugasan?",
-                    showCancelButton: true,
                     confirmButtonText: "Ya",
                     cancelButtonText: "Tidak",
-                  }).then((r) => {
-                    if (r.isConfirmed) setShowForm(false);
                   });
+                  if (r.isConfirmed) setShowForm(false);
                 }}
               >
                 Batal

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
 import Swal from "sweetalert2";
+import confirmAlert from "../utils/confirmAlert";
 import { Pencil, Trash2 } from "lucide-react";
 import Select from "react-select";
 import selectStyles from "../../utils/selectStyles";
@@ -91,10 +92,9 @@ export default function KegiatanTambahanDetailPage() {
   };
 
   const remove = async () => {
-    const r = await Swal.fire({
+    const r = await confirmAlert({
       title: "Hapus kegiatan ini?",
       icon: "warning",
-      showCancelButton: true,
       confirmButtonText: "Hapus",
     });
     if (!r.isConfirmed) return;

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 import Swal from "sweetalert2";
+import confirmAlert from "../utils/confirmAlert";
 import { Plus, Eye, Pencil, Trash2 } from "lucide-react";
 import Table from "../../components/ui/Table";
 import { useNavigate } from "react-router-dom";
@@ -91,10 +92,9 @@ export default function KegiatanTambahanPage() {
   };
 
   const remove = async (item) => {
-    const r = await Swal.fire({
+    const r = await confirmAlert({
       title: "Hapus kegiatan ini?",
       icon: "warning",
-      showCancelButton: true,
       confirmButtonText: "Hapus",
     });
     if (!r.isConfirmed) return;

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 import Swal from "sweetalert2";
+import confirmAlert from "../utils/confirmAlert";
 import { Pencil, Plus, Trash2 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
@@ -70,10 +71,9 @@ export default function TeamsPage() {
   };
 
   const deleteTeam = async (id) => {
-    const r = await Swal.fire({
+    const r = await confirmAlert({
       title: "Hapus tim ini?",
       icon: "warning",
-      showCancelButton: true,
       confirmButtonText: "Hapus",
     });
     if (!r.isConfirmed) return;
@@ -233,11 +233,9 @@ export default function TeamsPage() {
               <Button
                 variant="secondary"
                 onClick={async () => {
-                  const r = await Swal.fire({
+                  const r = await confirmAlert({
                     title: "Batalkan perubahan?",
                     icon: "question",
-                    showCancelButton: true,
-                    confirmButtonText: "Ya",
                   });
                   if (r.isConfirmed) setShowForm(false);
                 }}

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 import Swal from "sweetalert2";
+import confirmAlert from "../../utils/confirmAlert";
 import { Pencil, Plus, Trash2 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
@@ -93,10 +94,9 @@ export default function UsersPage() {
   };
 
   const deleteUser = async (id) => {
-    const result = await Swal.fire({
+    const result = await confirmAlert({
       title: "Hapus pengguna ini?",
       icon: "warning",
-      showCancelButton: true,
       confirmButtonText: "Hapus",
     });
     if (!result.isConfirmed) return;
@@ -320,11 +320,9 @@ export default function UsersPage() {
               <Button
                 variant="secondary"
                 onClick={async () => {
-                  const r = await Swal.fire({
+                  const r = await confirmAlert({
                     title: "Batalkan perubahan?",
                     icon: "question",
-                    showCancelButton: true,
-                    confirmButtonText: "Ya",
                   });
                   if (r.isConfirmed) setShowForm(false);
                 }}

--- a/web/src/utils/alerts.js
+++ b/web/src/utils/alerts.js
@@ -1,4 +1,5 @@
 import Swal from "sweetalert2";
+import confirmAlert from "./confirmAlert.js";
 
 const baseOptions = {
   heightAuto: false,
@@ -21,13 +22,10 @@ export const showError = (title, text = "") => showAlert(title, text, "error");
 export const showWarning = (title, text = "") => showAlert(title, text, "warning");
 
 export const confirmDelete = (title = "Hapus item ini?") =>
-  Swal.fire({
+  confirmAlert({
     title,
     icon: "warning",
-    showCancelButton: true,
     confirmButtonText: "Hapus",
-    cancelButtonText: "Batal",
-    ...baseOptions,
   });
 
 export default {

--- a/web/src/utils/confirmAlert.js
+++ b/web/src/utils/confirmAlert.js
@@ -1,0 +1,20 @@
+import Swal from "sweetalert2";
+
+const baseOptions = {
+  heightAuto: false,
+  width: 400,
+};
+
+/**
+ * Display a confirmation alert with default buttons.
+ * @param {import('sweetalert2').SweetAlertOptions} options
+ */
+export default function confirmAlert(options = {}) {
+  return Swal.fire({
+    showCancelButton: true,
+    confirmButtonText: "Ya",
+    cancelButtonText: "Batal",
+    ...baseOptions,
+    ...options,
+  });
+}


### PR DESCRIPTION
## Summary
- add `confirmAlert` helper
- refactor pages to use the new confirm dialog wrapper
- reuse `confirmAlert` inside `alerts.js`

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_6874fafe093c832b81ab7d06f6da730a