### PR TITLE
Add reusable Input component

### DIFF
--- a/web/src/components/ui/Input.jsx
+++ b/web/src/components/ui/Input.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import styles from "./Input.module.css";
+
+export default function Input({ className = "", ...props }) {
+  return <input className={`${styles.input} ${className}`.trim()} {...props} />;
+}

--- a/web/src/components/ui/Input.module.css
+++ b/web/src/components/ui/Input.module.css
@@ -1,0 +1,3 @@
+.input {
+  @apply w-full border rounded px-3 py-2 bg-white text-gray-900 dark:bg-gray-700 dark:text-gray-200;
+}

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -6,6 +6,7 @@ import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
 import Button from "../../components/ui/Button";
+import Input from "../../components/ui/Input";
 import { STATUS } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
 import SearchInput from "../../components/SearchInput";
@@ -246,7 +247,7 @@ export default function LaporanHarianPage() {
                 <label htmlFor="tanggal" className="block text-sm mb-1">
                   Tanggal<span className="text-red-500">*</span>
                 </label>
-                <input
+                <Input
                   id="tanggal"
                   type="date"
                   value={form.tanggal}
@@ -278,7 +279,7 @@ export default function LaporanHarianPage() {
               {form.status === STATUS.SELESAI_DIKERJAKAN && (
                 <div>
                   <label htmlFor="bukti_link" className="block text-sm mb-1">Link Bukti</label>
-                  <input
+                  <Input
                     id="bukti_link"
                     type="text"
                     value={form.bukti_link}

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -13,6 +13,7 @@ import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
 import Button from "../../components/ui/Button";
+import Input from "../../components/ui/Input";
 import { ROLES } from "../../utils/roles";
 import SearchInput from "../../components/SearchInput";
 
@@ -288,7 +289,7 @@ export default function MasterKegiatanPage() {
               <label htmlFor="namaKegiatan" className="block text-sm mb-1">
                 Nama Kegiatan <span className="text-red-500">*</span>
               </label>
-              <input
+              <Input
                 id="namaKegiatan"
                 type="text"
                 value={form.nama_kegiatan}

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -16,6 +16,7 @@ import StatusBadge from "../../components/ui/StatusBadge";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
 import Button from "../../components/ui/Button";
+import Input from "../../components/ui/Input";
 import months from "../../utils/months";
 
 
@@ -293,7 +294,7 @@ export default function PenugasanDetailPage() {
           <div className="grid grid-cols-3 gap-2">
             <div>
               <label htmlFor="minggu" className="block text-sm mb-1">Minggu</label>
-              <input
+              <Input
                 id="minggu"
                 type="number"
                 value={form.minggu}
@@ -324,7 +325,7 @@ export default function PenugasanDetailPage() {
             </div>
             <div>
               <label htmlFor="tahun" className="block text-sm mb-1">Tahun</label>
-              <input
+              <Input
                 id="tahun"
                 type="number"
                 value={form.tahun}
@@ -429,7 +430,7 @@ export default function PenugasanDetailPage() {
                 <label htmlFor="laporanTanggal" className="block text-sm mb-1">
                   Tanggal<span className="text-red-500">*</span>
                 </label>
-                <input
+                <Input
                   id="laporanTanggal"
                   type="date"
                   value={laporanForm.tanggal}
@@ -465,7 +466,7 @@ export default function PenugasanDetailPage() {
                   <label htmlFor="buktiLink" className="block text-sm mb-1">
                     Link Bukti <span className="text-red-500">*</span>
                   </label>
-                  <input
+                  <Input
                     id="buktiLink"
                     type="text"
                     value={laporanForm.bukti_link}

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -11,6 +11,7 @@ import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
 import Button from "../../components/ui/Button";
+import Input from "../../components/ui/Input";
 import { ROLES } from "../../utils/roles";
 import months from "../../utils/months";
 import SearchInput from "../../components/SearchInput";
@@ -356,7 +357,7 @@ export default function PenugasanPage() {
               <div className="grid grid-cols-3 gap-2">
                 <div>
                   <label htmlFor="minggu" className="block text-sm mb-1">Minggu</label>
-                  <input
+                  <Input
                     id="minggu"
                     type="number"
                     value={form.minggu}
@@ -383,7 +384,7 @@ export default function PenugasanPage() {
                 </div>
                 <div>
                   <label htmlFor="tahun" className="block text-sm mb-1">Tahun</label>
-                  <input
+                  <Input
                     id="tahun"
                     type="number"
                     value={form.tahun}

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -8,6 +8,7 @@ import selectStyles from "../../utils/selectStyles";
 import { STATUS } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
 import Button from "../../components/ui/Button";
+import Input from "../../components/ui/Input";
 
 
 export default function KegiatanTambahanDetailPage() {
@@ -209,7 +210,7 @@ export default function KegiatanTambahanDetailPage() {
           </div>
           <div>
             <label htmlFor="tanggal" className="block text-sm mb-1">Tanggal</label>
-            <input
+            <Input
               id="tanggal"
               type="date"
               value={form.tanggal}
@@ -256,7 +257,7 @@ export default function KegiatanTambahanDetailPage() {
         <div className="space-y-2">
           <div>
             <label htmlFor="tanggalMulai" className="block text-sm mb-1">Tanggal Mulai</label>
-            <input
+            <Input
               id="tanggalMulai"
               type="date"
               value={laporanForm.tanggal_selesai}
@@ -268,7 +269,7 @@ export default function KegiatanTambahanDetailPage() {
           </div>
           <div>
             <label htmlFor="tanggalAkhir" className="block text-sm mb-1">Tanggal Akhir</label>
-            <input
+            <Input
               id="tanggalAkhir"
               type="date"
               value={laporanForm.tanggal_selesai_akhir}
@@ -280,7 +281,7 @@ export default function KegiatanTambahanDetailPage() {
           </div>
           <div>
             <label htmlFor="buktiLink" className="block text-sm mb-1">Link Bukti</label>
-            <input
+            <Input
               id="buktiLink"
               type="text"
               value={laporanForm.bukti_link}

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -5,6 +5,7 @@ import { Plus, Eye, Pencil, Trash2 } from "lucide-react";
 import Table from "../../components/ui/Table";
 import { useNavigate } from "react-router-dom";
 import Button from "../../components/ui/Button";
+import Input from "../../components/ui/Input";
 import Select from "react-select";
 import selectStyles from "../../utils/selectStyles";
 import { STATUS } from "../../utils/status";
@@ -221,7 +222,7 @@ export default function KegiatanTambahanPage() {
               </div>
               <div>
                 <label htmlFor="tanggal" className="block text-sm mb-1">Tanggal</label>
-                <input
+                <Input
                   id="tanggal"
                   type="date"
                   value={form.tanggal}

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -7,6 +7,7 @@ import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
 import Button from "../../components/ui/Button";
+import Input from "../../components/ui/Input";
 import { ROLES } from "../../utils/roles";
 import SearchInput from "../../components/SearchInput";
 
@@ -218,7 +219,7 @@ export default function TeamsPage() {
           <div className="space-y-2">
             <div>
               <label htmlFor="namaTim" className="block text-sm mb-1">Nama Tim</label>
-              <input
+              <Input
                 id="namaTim"
                 type="text"
                 value={form.nama_tim}

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -7,6 +7,7 @@ import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
 import Button from "../../components/ui/Button";
+import Input from "../../components/ui/Input";
 import SearchInput from "../../components/SearchInput";
 import Spinner from "../../components/Spinner";
 import { ROLES } from "../../utils/roles";
@@ -264,7 +265,7 @@ export default function UsersPage() {
               <label htmlFor="nama" className="block text-sm mb-1">
                 Nama <span className="text-red-500">*</span>
               </label>
-              <input
+              <Input
                 id="nama"
                 type="text"
                 value={form.nama}
@@ -276,7 +277,7 @@ export default function UsersPage() {
               <label htmlFor="email" className="block text-sm mb-1">
                 Email <span className="text-red-500">*</span>
               </label>
-              <input
+              <Input
                 id="email"
                 type="email"
                 value={form.email}
@@ -288,7 +289,7 @@ export default function UsersPage() {
               <label htmlFor="password" className="block text-sm mb-1">
                 Password <span className="text-red-500">*</span>
               </label>
-              <input
+              <Input
                 id="password"
                 type="password"
                 value={form.password}


### PR DESCRIPTION
## Summary
- add `<Input>` component with common styling via `@apply`
- swap hard-coded input tags for `<Input>` across multiple pages

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: missing eslint packages & lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_6874fae901f8832b99a0fbc81f9eb838