### PR TITLE
Add accessible IDs for modal headings

### DIFF
--- a/web/src/components/ui/Modal.jsx
+++ b/web/src/components/ui/Modal.jsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useRef, useState } from "react";
 
-export default function Modal({ onClose, children, widthClass = "w-full max-w-md" }) {
+export default function Modal({
+  onClose,
+  children,
+  widthClass = "w-full max-w-md",
+  titleId,
+  descriptionId,
+}) {
   const containerRef = useRef(null);
   const [visible, setVisible] = useState(false);
   const [closing, setClosing] = useState(false);
@@ -45,6 +51,8 @@ export default function Modal({ onClose, children, widthClass = "w-full max-w-md
       onClick={handleClose}
       role="dialog"
       aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
     >
       <div
         ref={containerRef}

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -243,8 +243,9 @@ export default function LaporanHarianPage() {
             onClose={() => {
               setShowForm(false);
             }}
+            titleId="laporan-harian-form-title"
           >
-            <h3 className="text-lg font-semibold">Edit Laporan Harian</h3>
+            <h3 id="laporan-harian-form-title" className="text-lg font-semibold">Edit Laporan Harian</h3>
             <div className="space-y-2">
               <div>
                 <Label htmlFor="tanggal">

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -263,8 +263,9 @@ export default function MasterKegiatanPage() {
             setShowForm(false);
             setEditing(null);
           }}
+          titleId="master-kegiatan-form-title"
         >
-          <h2 className="text-xl font-semibold mb-2">
+          <h2 id="master-kegiatan-form-title" className="text-xl font-semibold mb-2">
             {editing ? "Edit Kegiatan" : "Tambah Kegiatan"}
           </h2>
           <div className="space-y-2">

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -423,8 +423,11 @@ export default function PenugasanDetailPage() {
       </div>
 
       {showLaporanForm && (
-        <Modal onClose={() => setShowLaporanForm(false)}>
-            <h3 className="text-lg font-semibold">
+        <Modal
+          onClose={() => setShowLaporanForm(false)}
+          titleId="laporan-form-title"
+        >
+            <h3 id="laporan-form-title" className="text-lg font-semibold">
               {laporanForm.id ? "Edit" : "Tambah"} Laporan Harian
             </h3>
             <div className="space-y-2">

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -282,8 +282,9 @@ export default function PenugasanPage() {
           onClose={() => {
             setShowForm(false);
           }}
+          titleId="penugasan-form-title"
         >
-          <h2 className="text-xl font-semibold mb-2">Tambah Penugasan</h2>
+          <h2 id="penugasan-form-title" className="text-xl font-semibold mb-2">Tambah Penugasan</h2>
           <div className="space-y-2">
             <div>
               <Label htmlFor="kegiatanId">

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -194,8 +194,9 @@ export default function KegiatanTambahanPage() {
             setShowForm(false);
             setEditing(null);
           }}
+          titleId="kegiatan-tambahan-modal-title"
         >
-          <h2 className="text-xl font-semibold mb-2">
+          <h2 id="kegiatan-tambahan-modal-title" className="text-xl font-semibold mb-2">
             {editing ? "Edit Kegiatan" : "Tambah Kegiatan"}
           </h2>
           <div className="space-y-2">

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -216,8 +216,9 @@ export default function TeamsPage() {
           onClose={() => {
             setShowForm(false);
           }}
+          titleId="team-form-title"
         >
-          <h2 className="text-xl font-semibold mb-2">
+          <h2 id="team-form-title" className="text-xl font-semibold mb-2">
             {editingTeam ? "Edit Tim" : "Tambah Tim"}
           </h2>
           <div className="space-y-2">

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -260,8 +260,9 @@ export default function UsersPage() {
           onClose={() => {
             setShowForm(false);
           }}
+          titleId="user-form-title"
         >
-          <h2 className="text-xl font-semibold mb-2">
+          <h2 id="user-form-title" className="text-xl font-semibold mb-2">
             {editingUser ? "Edit Pengguna" : "Tambah Pengguna"}
           </h2>
           <div className="space-y-2">


### PR DESCRIPTION
## Summary
- add `titleId`/`descriptionId` props to `Modal`
- wire props to `aria-labelledby` and `aria-describedby`
- give each modal heading a unique ID and pass it to the modal

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_6875194d0c14832b988eb5e58ffe94c5