### PR TITLE
Define reusable form-input class

### DIFF
--- a/web/src/assets/styles/index.css
+++ b/web/src/assets/styles/index.css
@@ -10,4 +10,8 @@
   .add-button {
     @apply flex items-center gap-2;
   }
+
+  .form-input {
+    @apply w-full border rounded px-3 py-2 bg-white text-gray-900 dark:bg-gray-700 dark:text-gray-200;
+  }
 }

--- a/web/src/pages/auth/LoginPage.jsx
+++ b/web/src/pages/auth/LoginPage.jsx
@@ -63,7 +63,7 @@ export default function LoginPage() {
               placeholder="Email atau Username"
               value={form.identifier ?? ""}
               onChange={(e) => setForm({ ...form, identifier: e.target.value })}
-              className="w-full px-4 py-2 border border-zinc-300 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-zinc-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-600"
+              className="form-input"
             />
           </div>
 
@@ -78,7 +78,7 @@ export default function LoginPage() {
                 placeholder="********"
                 value={form.password ?? ""}
                 onChange={(e) => setForm({ ...form, password: e.target.value })}
-                className="w-full px-4 py-2 border border-zinc-300 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-zinc-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-600"
+                className="form-input"
               />
               <button
                 type="button"

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -117,7 +117,7 @@ export default function LaporanHarianPage() {
               setTanggal(e.target.value);
               setCurrentPage(1);
             }}
-            className="border rounded px-3 py-1 bg-white dark:bg-gray-700"
+            className="form-input"
           />
         </div>
         <SearchInput
@@ -301,7 +301,7 @@ export default function LaporanHarianPage() {
                   onChange={(e) =>
                     setForm({ ...form, catatan: e.target.value })
                   }
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                  className="form-input"
                 />
               </div>
             </div>

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -310,7 +310,7 @@ export default function MasterKegiatanPage() {
                 onChange={(e) =>
                   setForm({ ...form, deskripsi: e.target.value })
                 }
-                className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                className="form-input"
               />
               </div>
             <div className="flex justify-end space-x-2 pt-2">

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -290,7 +290,7 @@ export default function PenugasanDetailPage() {
               id="deskripsi"
               value={form.deskripsi}
               onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
-              className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+              className="form-input"
             />
           </div>
           <div className="grid grid-cols-3 gap-2">
@@ -490,7 +490,7 @@ export default function PenugasanDetailPage() {
                   onChange={(e) =>
                     setLaporanForm({ ...laporanForm, catatan: e.target.value })
                   }
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                  className="form-input"
                 />
               </div>
             </div>

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -182,7 +182,7 @@ export default function PenugasanPage() {
               setFilterTahun(parseInt(e.target.value, 10));
               setCurrentPage(1);
             }}
-            className="w-20 border rounded px-2 py-[4px] bg-white dark:bg-gray-700 dark:text-gray-200"
+            className="form-input"
           />
           <button
             type="button"
@@ -359,7 +359,7 @@ export default function PenugasanPage() {
                 id="deskripsi"
                 value={form.deskripsi}
                 onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
-                className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                className="form-input"
               />
               </div>
               <div className="grid grid-cols-3 gap-2">

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -223,7 +223,7 @@ export default function KegiatanTambahanDetailPage() {
               id="deskripsi"
               value={form.deskripsi}
               onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
-              className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+              className="form-input"
             />
           </div>
           <div>

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -237,7 +237,7 @@ export default function KegiatanTambahanPage() {
                   id="deskripsi"
                   value={form.deskripsi}
                   onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
-                  className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
+                  className="form-input"
                 />
               </div>
               <div>


### PR DESCRIPTION
## Summary
- add `.form-input` to global Tailwind layer
- use the new class for inputs and textareas across pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6875194d201c832b8fb7e715fb97c1e3