### PR TITLE
Set SweetAlert button colors

### DIFF
--- a/web/src/utils/confirmAlert.js
+++ b/web/src/utils/confirmAlert.js
@@ -3,6 +3,8 @@ import Swal from "sweetalert2";
 const baseOptions = {
   heightAuto: false,
   width: 400,
+  confirmButtonColor: "#2563eb",
+  cancelButtonColor: "#d1d5db",
 };
 
 /**


### PR DESCRIPTION
## Summary
- define default colors for SweetAlert confirm/cancel buttons
- confirm that all confirmCancel and confirmDelete usages await the result

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68752fe0a578832bb53f64bc7385d498