### PR TITLE
Add month and week selection to dashboard

### DIFF
--- a/web/src/components/dashboard/MonitoringTabs.jsx
+++ b/web/src/components/dashboard/MonitoringTabs.jsx
@@ -3,11 +3,15 @@ import DailyOverview from "./DailyOverview";
 import WeeklyOverview from "./WeeklyOverview";
 import MonthlyOverview from "./MonthlyOverview";
 
+import months from "../../utils/months";
+
 const MonitoringTabs = ({
   dailyData,
   weeklyList = [],
   weekIndex = 0,
   onWeekChange,
+  monthIndex = 0,
+  onMonthChange,
   monthlyData,
 }) => {
   const [tab, setTab] = useState("harian");
@@ -19,19 +23,32 @@ const MonitoringTabs = ({
       case "mingguan":
         return (
           <div className="space-y-3">
-            {weeklyList.length > 1 && (
+            <div className="flex space-x-2">
               <select
                 className="border rounded-md px-2 py-1 bg-gray-100 dark:bg-gray-700"
-                value={weekIndex}
-                onChange={(e) => onWeekChange?.(parseInt(e.target.value, 10))}
+                value={monthIndex}
+                onChange={(e) => onMonthChange?.(parseInt(e.target.value, 10))}
               >
-                {weeklyList.map((w, i) => (
+                {months.map((m, i) => (
                   <option key={i} value={i}>
-                    Minggu {w.minggu}
+                    {m}
                   </option>
                 ))}
               </select>
-            )}
+              {weeklyList.length > 0 && (
+                <select
+                  className="border rounded-md px-2 py-1 bg-gray-100 dark:bg-gray-700"
+                  value={weekIndex}
+                  onChange={(e) => onWeekChange?.(parseInt(e.target.value, 10))}
+                >
+                  {weeklyList.map((w, i) => (
+                    <option key={i} value={i}>
+                      Minggu {w.minggu}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
             <WeeklyOverview data={weeklyList[weekIndex]} />
           </div>
         );
@@ -40,7 +57,16 @@ const MonitoringTabs = ({
       default:
         return null;
     }
-  }, [tab, dailyData, weeklyList, weekIndex, onWeekChange, monthlyData]);
+  }, [
+    tab,
+    dailyData,
+    weeklyList,
+    weekIndex,
+    onWeekChange,
+    monthIndex,
+    onMonthChange,
+    monthlyData,
+  ]);
 
   const handleTabClick = useCallback((t) => setTab(t), []);
 

--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -11,6 +11,7 @@ const Dashboard = () => {
   const [dailyData, setDailyData] = useState([]);
   const [weeklyList, setWeeklyList] = useState([]);
   const [weekIndex, setWeekIndex] = useState(0);
+  const [monthIndex, setMonthIndex] = useState(new Date().getMonth());
   const [monthlyData, setMonthlyData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
@@ -20,7 +21,7 @@ const Dashboard = () => {
       const today = new Date();
       const tanggal = today.toISOString().split("T")[0];
       const year = today.getFullYear();
-      const month = today.getMonth();
+      const month = monthIndex;
 
       // determine start dates for each week in the month
       const firstOfMonth = new Date(year, month, 1);
@@ -79,7 +80,7 @@ const Dashboard = () => {
     };
 
     fetchAllData();
-  }, [user?.id, user?.role, user?.teamId]);
+  }, [user?.id, user?.role, user?.teamId, monthIndex]);
 
   if (loading) {
     return (
@@ -112,6 +113,8 @@ const Dashboard = () => {
         weeklyList={weeklyList}
         weekIndex={weekIndex}
         onWeekChange={setWeekIndex}
+        monthIndex={monthIndex}
+        onMonthChange={setMonthIndex}
         monthlyData={monthlyData}
       />
 


### PR DESCRIPTION
## Summary
- add month selection state in Dashboard
- refresh weekly monitoring data when month changes
- include month and week dropdowns in MonitoringTabs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68752f942528832ba4f644d18a2d7375