### PR TITLE
Improve monthly monitoring progress

### DIFF
--- a/web/src/components/dashboard/MonthlyOverview.jsx
+++ b/web/src/components/dashboard/MonthlyOverview.jsx
@@ -1,5 +1,4 @@
 const MonthlyOverview = ({ data = [] }) => {
-
   return (
     <div>
       <h2 className="text-lg font-semibold mb-3 text-blue-600">
@@ -9,16 +8,18 @@ const MonthlyOverview = ({ data = [] }) => {
         {data.map((item, index) => (
           <div
             key={index}
-            className={`p-3 rounded-lg text-center font-medium ${
-              item.adaAktivitas
-                ? "bg-blue-50 dark:bg-blue-900"
-                : "bg-gray-100 dark:bg-gray-700"
-            }`}
+            className="p-3 rounded-lg bg-blue-50 dark:bg-blue-900 text-center"
           >
-            <div>{item.tanggal}</div>
-            {item.adaAktivitas && (
-              <div className="text-blue-600 dark:text-blue-300 text-sm mt-1">✔</div>
-            )}
+            <div className="font-medium">{item.bulan}</div>
+            <div className="text-sm text-blue-700 dark:text-blue-300">
+              {item.persen}%
+            </div>
+            <div className="w-full h-2 bg-gray-300 dark:bg-gray-600 rounded-full mt-1">
+              <div
+                className="h-2 bg-blue-500 rounded-full"
+                style={{ width: `${item.persen}%` }}
+              />
+            </div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- compute monthly progress percentages in the monitoring service
- render monthly overview using progress bars and percentage values

## Testing
- `npm run lint` within web (passes)
- `npm run build` within api (passes)
- `npm test` within api *(fails: jest not found)*
- `npm run lint` within api *(fails: numerous lint errors)*
- `npm run build` within web (passes)
- `npm test` within web *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68753177419c832bab8baa0c0e3140b1