### PR TITLE
Fix dark mode text colors for users page

### DIFF
--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -147,17 +147,17 @@ export default function UsersPage() {
           placeholder="Cari pengguna..."
           ariaLabel="Cari pengguna"
         />
-        <select
+          <select
             value={roleFilter}
             onChange={(e) => {
               setRoleFilter(e.target.value);
               setCurrentPage(1);
             }}
-            className="border rounded px-3 py-2 bg-white text-gray-900"
+            className="border rounded px-3 py-2 bg-white text-gray-900 dark:bg-gray-700 dark:text-gray-200"
           >
-            <option value="">Semua Role</option>
+            <option value="" className="text-gray-900 dark:text-gray-200">Semua Role</option>
             {roles.map((r) => (
-              <option key={r.id} value={r.name} className="text-gray-900">
+              <option key={r.id} value={r.name} className="text-gray-900 dark:text-gray-200">
                 {r.name}
               </option>
             ))}


### PR DESCRIPTION
## Summary
- update select and option components in UsersPage to show text clearly in dark mode

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm test` in `api` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_687536d51cec832bb676aaeb3d1a58f6