### PR TITLE
Add MonthYearPicker component and replace month/year filters

### DIFF
--- a/web/src/components/ui/MonthYearPicker.jsx
+++ b/web/src/components/ui/MonthYearPicker.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import Input from "./Input";
+import months from "../../utils/months";
+
+export default function MonthYearPicker({ month, year, onMonthChange, onYearChange }) {
+  return (
+    <div className="flex items-center gap-2">
+      <select
+        value={month}
+        onChange={(e) => onMonthChange(e.target.value)}
+        className="border rounded px-2 py-[4px] bg-white dark:bg-gray-700 dark:text-gray-200"
+      >
+        <option value="">Bulan</option>
+        {months.map((m, i) => (
+          <option key={i + 1} value={i + 1}>
+            {m}
+          </option>
+        ))}
+      </select>
+      <Input
+        type="number"
+        value={year}
+        onChange={(e) => onYearChange(parseInt(e.target.value, 10))}
+        className="w-24"
+      />
+    </div>
+  );
+}

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -19,6 +19,7 @@ import tableStyles from "../../components/ui/Table.module.css";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
+import MonthYearPicker from "../../components/ui/MonthYearPicker";
 import { ROLES } from "../../utils/roles";
 import months from "../../utils/months";
 import SearchInput from "../../components/SearchInput";
@@ -162,27 +163,17 @@ export default function PenugasanPage() {
             placeholder="Cari penugasan..."
             ariaLabel="Cari penugasan"
           />
-          <select
-            value={filterBulan}
-            onChange={(e) => {
-              setFilterBulan(e.target.value);
+          <MonthYearPicker
+            month={filterBulan}
+            year={filterTahun}
+            onMonthChange={(val) => {
+              setFilterBulan(val);
               setCurrentPage(1);
             }}
-            className="border rounded px-2 py-[4px] bg-white dark:bg-gray-700 dark:text-gray-200"
-          >
-            <option value="">Bulan</option>
-            {months.map((m, i) => (
-              <option key={i + 1} value={i + 1}>{m}</option>
-            ))}
-          </select>
-          <input
-            type="number"
-            value={filterTahun}
-            onChange={(e) => {
-              setFilterTahun(parseInt(e.target.value, 10));
+            onYearChange={(val) => {
+              setFilterTahun(val);
               setCurrentPage(1);
             }}
-            className="form-input w-24"
           />
           <button
             type="button"

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -12,13 +12,13 @@ import { useNavigate } from "react-router-dom";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
+import MonthYearPicker from "../../components/ui/MonthYearPicker";
 import Select from "react-select";
 import selectStyles from "../../utils/selectStyles";
 import { STATUS } from "../../utils/status";
 import Modal from "../../components/ui/Modal";
 import StatusBadge from "../../components/ui/StatusBadge";
 import SearchInput from "../../components/SearchInput";
-import months from "../../utils/months";
 import Pagination from "../../components/Pagination";
 
 
@@ -157,23 +157,11 @@ export default function KegiatanTambahanPage() {
           placeholder="Cari kegiatan..."
           ariaLabel="Cari kegiatan"
         />
-        <select
-          value={filterBulan}
-          onChange={(e) => setFilterBulan(e.target.value)}
-          className="border rounded px-2 py-[4px] bg-white dark:bg-gray-700 dark:text-gray-200"
-        >
-          <option value="">Bulan</option>
-          {months.map((m, i) => (
-            <option key={i + 1} value={i + 1}>
-              {m}
-            </option>
-          ))}
-        </select>
-        <input
-          type="number"
-          value={filterTahun}
-          onChange={(e) => setFilterTahun(parseInt(e.target.value, 10))}
-          className="form-input w-24"
+        <MonthYearPicker
+          month={filterBulan}
+          year={filterTahun}
+          onMonthChange={setFilterBulan}
+          onYearChange={setFilterTahun}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- create `MonthYearPicker` component to reuse month/year inputs
- use the new picker in `PenugasanPage` and `KegiatanTambahanPage`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6875386aa830832bb19e9f7087c7a15c