### PR TITLE
Fix weekly list display

### DIFF
--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -65,8 +65,10 @@ const Dashboard = () => {
           axios.get("/monitoring/bulanan", { params: { year: String(year), ...filters } }),
         ]);
 
+        const normalized = weeklyArray.map((w, i) => ({ ...w, minggu: i + 1 }));
+
         setDailyData(dailyRes.data);
-        setWeeklyList(weeklyArray);
+        setWeeklyList(normalized);
         setWeekIndex(currentIndex);
         setMonthlyData(monthlyRes.data);
       } catch (error) {


### PR DESCRIPTION
## Summary
- map API responses for weeks so that the `minggu` property counts up sequentially

## Testing
- `npm run lint` in `web`

------
https://chatgpt.com/codex/tasks/task_b_687542f7ddb4832bafd375c63a7efeec