### PR TITLE
Fix weekly overview date range

### DIFF
--- a/web/src/components/dashboard/WeeklyOverview.jsx
+++ b/web/src/components/dashboard/WeeklyOverview.jsx
@@ -1,3 +1,5 @@
+import months from "../../utils/months";
+
 const WeeklyOverview = ({ data }) => {
   if (!data) return null;
 
@@ -6,7 +8,11 @@ const WeeklyOverview = ({ data }) => {
     return `${d}-${m}-${y}`;
   };
 
-  const rangeText = data.tanggal.split(" - ").map(formatDate).join(" - ");
+  const [startIso, endIso] = data.tanggal.split(" - ");
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  const monthName = months[start.getMonth()];
+  const rangeText = `${start.getDate()} - ${end.getDate()} ${monthName} ${start.getFullYear()}`;
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
## Summary
- show Indonesian month names in weekly overview by importing `months`
- improve date range text calculation for the weekly overview component

## Testing
- `npm run lint`
- `node -e 'const months=require("./web/src/utils/months.js").default;const data={tanggal:"2024-05-01 - 2024-05-07"};const [startIso,endIso]=data.tanggal.split(" - ");const start=new Date(startIso);const end=new Date(endIso);const monthName=months[start.getMonth()];const rangeText=`${start.getDate()} - ${end.getDate()} ${monthName} ${start.getFullYear()}`;console.log(rangeText);'`

------
https://chatgpt.com/codex/tasks/task_b_687543ef306c832ba745537989ad63a4