### PR TITLE
Fix weekly start alignment

### DIFF
--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -47,6 +47,8 @@ export class MonitoringService {
 
   async mingguan(minggu: string, teamId?: number, userId?: number) {
     const start = new Date(minggu);
+    const offset = (start.getDay() + 6) % 7; // days since Monday
+    start.setDate(start.getDate() - offset);
     if (isNaN(start.getTime()))
       throw new BadRequestException("minggu tidak valid");
 


### PR DESCRIPTION
## Summary
- align weekly reports to Monday
- rebuild API

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_687544ec5b8c832ba148e7290570c29c