### PR TITLE
Update dashboard week logic

### DIFF
--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -24,21 +24,19 @@ const Dashboard = () => {
       const month = monthIndex;
 
       // determine start dates for each week in the month
-      const firstOfMonth = new Date(year, month, 1);
+      const monthStart = new Date(year, month, 1);
       const monthEnd = new Date(year, month + 1, 0);
-      const firstMonday = new Date(firstOfMonth);
-      firstMonday.setDate(firstOfMonth.getDate() - ((firstOfMonth.getDay() + 6) % 7));
       const weekStarts = [];
-      for (let d = new Date(firstMonday); d <= monthEnd; d.setDate(d.getDate() + 7)) {
+      for (let d = new Date(monthStart); d <= monthEnd; d.setDate(d.getDate() + 7)) {
         weekStarts.push(new Date(d));
       }
 
-      let currentIndex = 0;
-      weekStarts.forEach((w, idx) => {
-        const end = new Date(w);
-        end.setDate(w.getDate() + 6);
-        if (today >= w && today <= end) currentIndex = idx;
+      let currentIndex = weekStarts.findIndex((start) => {
+        const end = new Date(start);
+        end.setDate(start.getDate() + 6);
+        return today >= start && today <= end;
       });
+      if (currentIndex === -1) currentIndex = 0;
 
       try {
         const filters = {};


### PR DESCRIPTION
## Summary
- calculate weekly ranges starting from month start
- match index calculation to new week logic

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: ESLint found 616 errors)*
- `npm test` in `web` *(fails: missing script)*
- `npm test` in `api` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6875b1014020832b817040c200812f52