### PR TITLE
Fix dark mode contrast for gray text

### DIFF
--- a/web/src/components/dashboard/DailyOverview.jsx
+++ b/web/src/components/dashboard/DailyOverview.jsx
@@ -38,7 +38,7 @@ const DailyOverview = ({ data = [] }) => {
       <h2 className="text-lg font-semibold mb-3 text-blue-600">
         Kalender Aktivitas Harian
       </h2>
-      <div className="flex flex-wrap justify-end gap-2 mb-2 text-xs text-gray-500">
+      <div className="flex flex-wrap justify-end gap-2 mb-2 text-xs text-gray-500 dark:text-gray-400">
         <div className="flex items-center gap-1">
           <span className="inline-block w-3 h-3 bg-green-400 rounded-sm"></span>
           Ada Laporan

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -190,7 +190,7 @@ export default function LaporanHarianPage() {
               ))}
               {laporan.length === 0 && (
                 <tr>
-                  <td colSpan={6} className="text-center py-4 text-gray-500 dark:text-gray-300">
+                  <td colSpan={6} className="text-center py-4 text-gray-500 dark:text-gray-300 dark:text-gray-400">
                     Tidak ada laporan
                   </td>
                 </tr>

--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -201,7 +201,7 @@ export default function Layout() {
                   ) : (
                     <>
                       <div className="font-semibold">{user?.nama}</div>
-                      <div className="text-xs capitalize text-gray-500 dark:text-gray-300">
+                      <div className="text-xs capitalize text-gray-500 dark:text-gray-300 dark:text-gray-400">
                         {user?.role === ROLES.PIMPINAN
                           ? "Pimpinan"
                           : `${

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -325,7 +325,7 @@ export default function MasterKegiatanPage() {
                 Batal
               </Button>
               <Button onClick={saveItem}>Simpan</Button>
-              <p className="text-xs text-gray-500 ml-2 self-center">
+              <p className="text-xs text-gray-500 ml-2 self-center dark:text-gray-400">
                 * wajib diisi
               </p>
             </div>

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -204,35 +204,35 @@ export default function PenugasanDetailPage() {
       {!editing ? (
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
           <div>
-            <div className="text-sm text-gray-500">Kegiatan</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Kegiatan</div>
             <div className="font-medium">{item.kegiatan?.nama_kegiatan}</div>
           </div>
           <div>
-            <div className="text-sm text-gray-500">Tim</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Tim</div>
             <div className="font-medium">{item.kegiatan?.team?.nama_tim}</div>
           </div>
           <div>
-            <div className="text-sm text-gray-500">Pegawai</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Pegawai</div>
             <div className="font-medium">{item.pegawai?.nama}</div>
           </div>
           <div>
-            <div className="text-sm text-gray-500">Minggu</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Minggu</div>
             <div className="font-medium">{item.minggu}</div>
           </div>
           <div>
-            <div className="text-sm text-gray-500">Bulan</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Bulan</div>
             <div className="font-medium">{item.bulan}</div>
           </div>
           <div>
-            <div className="text-sm text-gray-500">Tahun</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Tahun</div>
             <div className="font-medium">{item.tahun}</div>
           </div>
           <div className="sm:col-span-2 lg:col-span-3">
-            <div className="text-sm text-gray-500">Deskripsi</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Deskripsi</div>
             <div className="font-medium">{item.deskripsi || "-"}</div>
           </div>
           <div>
-            <div className="text-sm text-gray-500">Status</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Status</div>
             <div className="font-medium">
               <StatusBadge status={item.status} />
             </div>

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -138,30 +138,30 @@ export default function KegiatanTambahanDetailPage() {
       {!editing ? (
         <div className="space-y-2 bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
           <div>
-            <div className="text-sm text-gray-500">Nama</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Nama</div>
             <div className="font-medium">{item.nama}</div>
           </div>
           <div>
-            <div className="text-sm text-gray-500">Tim</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Tim</div>
             <div className="font-medium">{item.kegiatan.team?.nama_tim || "-"}</div>
           </div>
           <div>
-            <div className="text-sm text-gray-500">Tanggal</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Tanggal</div>
             <div className="font-medium">{item.tanggal.slice(0, 10)}</div>
           </div>
           <div>
-            <div className="text-sm text-gray-500">Deskripsi</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Deskripsi</div>
             <div className="font-medium">{item.deskripsi || "-"}</div>
           </div>
           <div>
-            <div className="text-sm text-gray-500">Status</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">Status</div>
             <div className="font-medium">
               <StatusBadge status={item.status} />
             </div>
           </div>
           {item.tanggal_selesai && (
             <div>
-              <div className="text-sm text-gray-500">Tanggal Selesai</div>
+              <div className="text-sm text-gray-500 dark:text-gray-400">Tanggal Selesai</div>
               <div className="font-medium">
                 {item.tanggal_selesai.slice(0, 10)}
                 {item.tanggal_selesai_akhir &&
@@ -171,7 +171,7 @@ export default function KegiatanTambahanDetailPage() {
           )}
           {item.bukti_link && (
             <div>
-              <div className="text-sm text-gray-500">Bukti</div>
+              <div className="text-sm text-gray-500 dark:text-gray-400">Bukti</div>
               <a
                 href={item.bukti_link}
                 target="_blank"

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -335,7 +335,7 @@ export default function UsersPage() {
               <Button onClick={saveUser}>
                 Simpan
               </Button>
-              <p className="text-xs text-gray-500 ml-2 self-center">
+              <p className="text-xs text-gray-500 ml-2 self-center dark:text-gray-400">
                 * wajib diisi
               </p>
             </div>


### PR DESCRIPTION
## Summary
- tweak text color on user menu in header
- update informational text across pages to support dark mode
- run linter and build to ensure clean code

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6875bc576af8832b8fdd414f11e962fc