### PR TITLE
Fix Pagination dark mode style

### DIFF
--- a/web/src/components/Pagination.jsx
+++ b/web/src/components/Pagination.jsx
@@ -33,7 +33,7 @@ export default function Pagination({ currentPage, totalPages, onPageChange }) {
             onClick={() => onPageChange(p)}
             className={`px-3 py-1 rounded-full ${
               currentPage === p
-                ? "bg-blue-600 text-white"
+                ? "bg-blue-600 text-white dark:bg-blue-700"
                 : "border bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
             }`}
           >


### PR DESCRIPTION
## Summary
- tweak active button styling in Pagination for dark mode

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_6875bc5ec490832bbfeff09cdfc193c4