### PR TITLE
Add dark mode text classes

### DIFF
--- a/web/src/components/dashboard/DailyOverview.jsx
+++ b/web/src/components/dashboard/DailyOverview.jsx
@@ -35,7 +35,7 @@ const DailyOverview = ({ data = [] }) => {
   };
   return (
     <div>
-      <h2 className="text-lg font-semibold mb-3 text-blue-600">
+      <h2 className="text-lg font-semibold mb-3 text-blue-600 dark:text-blue-400">
         Kalender Aktivitas Harian
       </h2>
       <div className="flex flex-wrap justify-end gap-2 mb-2 text-xs text-gray-500 dark:text-gray-400">

--- a/web/src/components/dashboard/MonthlyOverview.jsx
+++ b/web/src/components/dashboard/MonthlyOverview.jsx
@@ -1,7 +1,7 @@
 const MonthlyOverview = ({ data = [] }) => {
   return (
     <div>
-      <h2 className="text-lg font-semibold mb-3 text-blue-600">
+      <h2 className="text-lg font-semibold mb-3 text-blue-600 dark:text-blue-400">
         Capaian Kinerja Bulanan
       </h2>
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">

--- a/web/src/components/dashboard/WeeklyOverview.jsx
+++ b/web/src/components/dashboard/WeeklyOverview.jsx
@@ -18,7 +18,7 @@ const WeeklyOverview = ({ data }) => {
   return (
     <div className="space-y-4">
       <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
-        <h2 className="text-xl font-semibold text-blue-600 mb-1">
+        <h2 className="text-xl font-semibold text-blue-600 dark:text-blue-400 mb-1">
           Progress Mingguan
         </h2>
         <div className="mt-2">

--- a/web/src/components/ui/Button.jsx
+++ b/web/src/components/ui/Button.jsx
@@ -18,7 +18,7 @@ export default function Button({
       "bg-gray-200 hover:bg-gray-300 text-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white",
     danger: "bg-red-600 hover:bg-red-700 text-white",
     warning: "bg-yellow-500 hover:bg-yellow-600 text-white",
-    icon: "text-blue-600 hover:underline",
+    icon: "text-blue-600 hover:underline dark:text-blue-400",
   };
   return (
     <button

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -159,7 +159,7 @@ export default function LaporanHarianPage() {
                         href={item.bukti_link}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-blue-600 underline"
+                        className="text-blue-600 underline dark:text-blue-400"
                       >
                         Lihat
                       </a>

--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -136,7 +136,7 @@ export default function Layout() {
                     <span>Notifikasi</span>
                     <button
                       onClick={markAllAsRead}
-                      className="text-xs text-blue-600 hover:underline"
+                      className="text-xs text-blue-600 hover:underline dark:text-blue-400"
                     >
                       Tandai sudah dibaca
                     </button>
@@ -228,7 +228,7 @@ export default function Layout() {
                   </button>
                   <button
                     onClick={handleLogout}
-                    className="flex items-center w-full px-4 py-2 text-sm text-red-600 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    className="flex items-center w-full px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700"
                   >
                     <FaSignOutAlt className="mr-2" /> Logout
                   </button>

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -388,7 +388,7 @@ export default function PenugasanDetailPage() {
                         href={l.bukti_link}
                         target="_blank"
                         rel="noreferrer"
-                        className="text-blue-600 underline"
+                        className="text-blue-600 underline dark:text-blue-400"
                       >
                         Link
                       </a>

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -176,7 +176,7 @@ export default function KegiatanTambahanDetailPage() {
                 href={item.bukti_link}
                 target="_blank"
                 rel="noreferrer"
-                className="text-blue-600 underline"
+                className="text-blue-600 underline dark:text-blue-400"
               >
                 Link
               </a>


### PR DESCRIPTION
## Summary
- add dark mode text utilities for blue and red text
- ensure notifications and links have dark styles

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: cannot find config)*

------
https://chatgpt.com/codex/tasks/task_b_6875c184d3ec832ba0521e03b1157cc5