### PR TITLE
Fix week start calculation

### DIFF
--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -31,10 +31,12 @@ const Dashboard = () => {
       const month = monthIndex;
 
       // determine start dates for each week in the month
-      const monthStart = new Date(year, month, 1);
+      const firstOfMonth = new Date(year, month, 1);
       const monthEnd = new Date(year, month + 1, 0);
+      const firstMonday = new Date(firstOfMonth);
+      firstMonday.setDate(firstOfMonth.getDate() - ((firstOfMonth.getDay() + 6) % 7));
       const weekStarts = [];
-      for (let d = new Date(monthStart); d <= monthEnd; d.setDate(d.getDate() + 7)) {
+      for (let d = new Date(firstMonday); d <= monthEnd; d.setDate(d.getDate() + 7)) {
         weekStarts.push(new Date(d));
       }
 


### PR DESCRIPTION
## Summary
- compute weekStarts from the Monday on or before the first of the month

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm test` in `api` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_b_6875c6e4971c832b96228892ebf407eb