### PR TITLE
Fix kegiatan dropdown disabled until team selected

### DIFF
--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -348,12 +348,17 @@ export default function KegiatanTambahanPage() {
                     zIndex: 9999,
                   }),
                 }}
-                options={kegiatan
-                  .filter((k) => !form.teamId || k.teamId === form.teamId)
-                  .map((k) => ({
-                    value: k.id,
-                    label: k.nama_kegiatan,
-                  }))}
+                isDisabled={!form.teamId}
+                options={
+                  form.teamId
+                    ? kegiatan
+                        .filter((k) => k.teamId === form.teamId)
+                        .map((k) => ({
+                          value: k.id,
+                          label: k.nama_kegiatan,
+                        }))
+                    : []
+                }
                 value={
                   form.kegiatanId
                     ? {


### PR DESCRIPTION
## Summary
- disable additional activity select when no team chosen
- filter select options by current team

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6876514542b4832b8f26c61566a8ffb9