### PR TITLE
Document teamId usage and add service test

### DIFF
--- a/api/test/master-kegiatan.service.spec.ts
+++ b/api/test/master-kegiatan.service.spec.ts
@@ -1,0 +1,40 @@
+import { MasterKegiatanService } from '../src/kegiatan/master-kegiatan.service';
+
+describe('MasterKegiatanService findAll', () => {
+  const prisma = {
+    masterKegiatan: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  } as any;
+  const service = new MasterKegiatanService(prisma);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    prisma.$transaction.mockImplementation(async (actions: any[]) => {
+      const results = [];
+      for (const action of actions) {
+        results.push(await action);
+      }
+      return results;
+    });
+  });
+
+  it('returns items containing teamId', async () => {
+    prisma.masterKegiatan.findMany.mockResolvedValue([
+      { id: 1, teamId: 2, nama_kegiatan: 'Test' },
+    ]);
+    prisma.masterKegiatan.count.mockResolvedValue(1);
+
+    const result = await service.findAll({ page: 1, limit: 10, teamId: 2 });
+
+    expect(prisma.masterKegiatan.findMany).toHaveBeenCalledWith({
+      where: { teamId: 2 },
+      include: { team: true },
+      skip: 0,
+      take: 10,
+    });
+    expect(result.data[0]).toHaveProperty('teamId', 2);
+  });
+});

--- a/docs/manual-check-team-dropdown.md
+++ b/docs/manual-check-team-dropdown.md
@@ -1,0 +1,20 @@
+# Manual Check: Team Dropdown Filtering
+
+This project exposes a page at `/kegiatan-tambahan` where users can choose a team
+and then pick a master kegiatan. The kegiatan options are filtered based on the
+selected team using the `teamId` field.
+
+Steps:
+1. Install dependencies and run the development server:
+   ```bash
+   npm install --prefix api
+   npm install --prefix web
+   npm run dev --prefix web
+   ```
+2. Open `http://localhost:5173/tambahan` in a browser.
+3. Click **Tambah Kegiatan** to open the form.
+4. Select a team from the **Tim** dropdown.
+5. The **Kegiatan** dropdown now lists only master kegiatan where
+   `teamId` matches the chosen team.
+
+This confirms the frontend correctly filters by `teamId`.


### PR DESCRIPTION
## Summary
- add a unit test covering `MasterKegiatanService.findAll`
- document a manual check for the kegiatan dropdown filtering by team

## Testing
- `npm --prefix api test`

------
https://chatgpt.com/codex/tasks/task_b_68765b75f8b0832b94da277031eead48