### PR TITLE
Handle team fetch fallback

### DIFF
--- a/api/src/teams/teams.controller.ts
+++ b/api/src/teams/teams.controller.ts
@@ -31,6 +31,12 @@ export class TeamsController {
     return this.teamsService.findByLeader(user.userId);
   }
 
+  @Get("member")
+  findMemberTeams(@Req() req: Request) {
+    const { user } = req as any;
+    return this.teamsService.findByMember(user.userId);
+  }
+
   @Get(":id")
   @Roles(ROLES.ADMIN)
   findOne(@Param("id", ParseIntPipe) id: number) {

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -60,7 +60,10 @@ export default function MasterKegiatanPage() {
 
   const fetchTeams = useCallback(async () => {
     try {
-      const res = await axios.get("/teams");
+      let res = await axios.get("/teams");
+      if (Array.isArray(res.data) && res.data.length === 0) {
+        res = await axios.get("/teams/member");
+      }
       setTeams(res.data);
     } catch (err) {
       console.error("Gagal mengambil tim", err);

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -56,7 +56,14 @@ export default function PenugasanPage() {
       const penugasanReq = axios.get(
         `/penugasan?bulan=${filterBulan || ""}&tahun=${filterTahun || ""}`
       );
-      const teamsReq = axios.get("/teams");
+      const teamsReq = axios
+        .get("/teams")
+        .then(async (res) => {
+          if (Array.isArray(res.data) && res.data.length === 0) {
+            return axios.get("/teams/member");
+          }
+          return res;
+        });
 
       let usersReq;
       if (canManage) {

--- a/web/src/pages/tambahan/KegiatanTambahanPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanPage.jsx
@@ -44,7 +44,14 @@ export default function KegiatanTambahanPage() {
       const [tRes, kRes, teamRes] = await Promise.all([
         axios.get("/kegiatan-tambahan"),
         axios.get("/master-kegiatan?limit=1000"),
-        axios.get("/teams"),
+        axios
+          .get("/teams")
+          .then(async (res) => {
+            if (Array.isArray(res.data) && res.data.length === 0) {
+              return axios.get("/teams/member");
+            }
+            return res;
+          }),
       ]);
       setItems(tRes.data);
       setKegiatan(kRes.data.data || kRes.data);

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -38,7 +38,10 @@ export default function TeamsPage() {
   const fetchTeams = async () => {
     try {
       setLoading(true);
-      const res = await axios.get("/teams");
+      let res = await axios.get("/teams");
+      if (Array.isArray(res.data) && res.data.length === 0) {
+        res = await axios.get("/teams/member");
+      }
       setTeams(res.data);
     } catch (err) {
       console.error("Gagal mengambil tim", err);


### PR DESCRIPTION
## Summary
- expose `/teams/member` API to list teams where the logged user is a member
- fall back to `/teams/member` when `/teams` returns an empty array

## Testing
- `npm test` in `api`
- `npm run lint` in `web`

------
https://chatgpt.com/codex/tasks/task_b_687663933910832ba3d8cbe4fdbb669d