### PR TITLE
Fix README duplication

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,3 @@
-| GET    | `/monitoring/harian/all`   | Monitoring harian semua pegawai (query: `tanggal`, `teamId` opsional) | admin, pimpinan, ketua tim |
-| GET    | `/monitoring/mingguan/all` | Monitoring mingguan semua pegawai (query: `minggu`, `teamId` opsional) | admin, pimpinan, ketua tim |
-| GET    | `/monitoring/bulanan/all`  | Monitoring bulanan semua pegawai (query: `year`, `teamId` opsional) | admin, pimpinan, ketua tim |
 # 📦 SEMAKIN 6502 API (Backend)
 
 Ini adalah backend resmi dari aplikasi **SEMAKIN 6502** (Sistem Evaluasi dan Monitoring Kinerja), dibangun dengan **NestJS**, **Prisma ORM**, dan **MySQL**.


### PR DESCRIPTION
## Summary
- remove duplicate monitoring routes from the API README

## Testing
- `npx jest --runInBand` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68767177144c832b86f2ecf598b353a4