### PR TITLE
Add monthly daily matrix view

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -100,6 +100,7 @@ Server berjalan di: `http://localhost:3000`
 | POST   | `/kegiatan-tambahan`       | Laporan kegiatan tambahan    | anggota tim |
 | GET    | `/monitoring/harian`       | Monitoring harian            | semua    |
 | GET    | `/monitoring/harian/all`   | Monitoring harian semua pegawai (query: `tanggal`, `teamId` opsional) | admin, pimpinan, ketua tim |
+| GET    | `/monitoring/harian/bulan` | Rekap harian sebulan penuh per pegawai (query: `tanggal`, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/mingguan/all` | Monitoring mingguan semua pegawai (query: `minggu`, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/bulanan/all`  | Monitoring bulanan semua pegawai (query: `year`, `teamId` opsional) | admin, pimpinan, ketua tim |
 

--- a/api/src/monitoring/monitoring.controller.ts
+++ b/api/src/monitoring/monitoring.controller.ts
@@ -82,6 +82,31 @@ export class MonitoringController {
     return this.monitoringService.harianAll(tanggal, tId);
   }
 
+  @Get("harian/bulan")
+  async harianBulan(
+    @Query("tanggal") tanggal?: string,
+    @Req() req?: Request,
+    @Query("teamId") teamId?: string,
+  ) {
+    if (!tanggal) {
+      throw new BadRequestException("query 'tanggal' diperlukan");
+    }
+    const user = req?.user as any;
+    const role = user?.role;
+    const tId = teamId ? parseInt(teamId, 10) : undefined;
+
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
+      if (!tId) throw new ForbiddenException("bukan admin");
+      const member = await this.prisma.member.findFirst({
+        where: { teamId: tId, userId: user.userId },
+      });
+      if (!member || !member.is_leader)
+        throw new ForbiddenException("bukan ketua tim");
+    }
+
+    return this.monitoringService.harianBulan(tanggal, tId);
+  }
+
   @Get("mingguan")
   async mingguan(
     @Query("minggu") minggu?: string,

--- a/api/test/monitoring.service.spec.ts
+++ b/api/test/monitoring.service.spec.ts
@@ -50,4 +50,16 @@ describe('MonitoringService aggregated', () => {
       { userId: 2, nama: 'B', selesai: 1, total: 1, persen: 100 },
     ]);
   });
+
+  it('harianBulan groups by user and marks days', async () => {
+    prisma.laporanHarian.findMany.mockResolvedValue([
+      { pegawaiId: 1, tanggal: new Date('2024-05-02'), pegawai: { nama: 'A' } },
+      { pegawaiId: 2, tanggal: new Date('2024-05-01'), pegawai: { nama: 'B' } },
+    ]);
+    const res = await service.harianBulan('2024-05-10');
+    expect(res.map((u) => u.nama)).toEqual(['A', 'B']);
+    expect(res[0].detail.length).toBe(31);
+    expect(res[0].detail[1]).toEqual({ tanggal: '2024-05-02', adaKegiatan: true });
+    expect(res[1].detail[0]).toEqual({ tanggal: '2024-05-01', adaKegiatan: true });
+  });
 });

--- a/web/README.md
+++ b/web/README.md
@@ -37,5 +37,7 @@ progress for all users using progress bars in three tabs:
 - **Weekly** – progress for a selected week
 - **Yearly** – monthly progress for a chosen year
 
+The Daily tab also includes a scrollable matrix table showing each user's activity for every day in the chosen month. Cells are color coded just like in the dashboard overview.
+
 When filtering results by team you may supply optional query parameters such as
 `teamId` to limit the data to a specific team.

--- a/web/src/pages/monitoring/DailyMatrix.jsx
+++ b/web/src/pages/monitoring/DailyMatrix.jsx
@@ -1,0 +1,63 @@
+import { getHolidays } from "../../utils/holidays";
+
+const DailyMatrix = ({ data = [] }) => {
+  if (!Array.isArray(data) || data.length === 0) return null;
+
+  const year = new Date(data[0].detail[0].tanggal).getFullYear();
+  const today = new Date().toISOString().slice(0, 10);
+  const HOLIDAYS = getHolidays(year);
+
+  const isWeekend = (iso) => {
+    const d = new Date(iso);
+    const g = d.getDay();
+    return g === 0 || g === 6;
+  };
+
+  const isHoliday = (iso) => HOLIDAYS.includes(iso);
+
+  const boxClass = (day) => {
+    if (day.adaKegiatan) {
+      return "bg-green-200 border-green-400 dark:bg-green-700 dark:border-green-500";
+    }
+    if (isWeekend(day.tanggal) || isHoliday(day.tanggal)) {
+      return "bg-blue-200 border-blue-400 dark:bg-blue-700 dark:border-blue-500";
+    }
+    if (day.tanggal < today) {
+      return "bg-yellow-200 border-yellow-400 dark:bg-yellow-700 dark:border-yellow-500";
+    }
+    return "bg-gray-100 dark:bg-gray-700";
+  };
+
+  const dayCount = data[0].detail.length;
+
+  return (
+    <div className="overflow-auto">
+      <table className="min-w-full text-xs border-collapse">
+        <thead>
+          <tr>
+            <th className="p-2 border text-left">Nama</th>
+            {Array.from({ length: dayCount }, (_, i) => (
+              <th key={i} className="p-1 border text-center">
+                {i + 1}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((u) => (
+            <tr key={u.userId} className="text-center">
+              <td className="p-2 border text-left whitespace-nowrap text-sm">
+                {u.nama}
+              </td>
+              {u.detail.map((day, i) => (
+                <td key={i} className={`p-1 border ${boxClass(day)}`}></td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default DailyMatrix;


### PR DESCRIPTION
## Summary
- backend: expose `/monitoring/harian/bulan` for monthly daily matrix
- frontend: add `DailyMatrix` component and display it in Monitoring page
- document new endpoint and UI
- test monthly aggregation

## Testing
- `npm --prefix api test`

------
https://chatgpt.com/codex/tasks/task_b_68767a81079c832b879c7ec62fe8dc7a