### PR TITLE
Add weekly summary matrix

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -102,6 +102,7 @@ Server berjalan di: `http://localhost:3000`
 | GET    | `/monitoring/harian/all`   | Monitoring harian semua pegawai (query: `tanggal`, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/harian/bulan` | Rekap harian sebulan penuh per pegawai (query: `tanggal`, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/mingguan/all` | Monitoring mingguan semua pegawai (query: `minggu`, `teamId` opsional) | admin, pimpinan, ketua tim |
+| GET    | `/monitoring/mingguan/bulan` | Rekap mingguan per pegawai dalam sebulan (query: `tanggal`, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/bulanan/all`  | Monitoring bulanan semua pegawai (query: `year`, `teamId` opsional) | admin, pimpinan, ketua tim |
 
 ---

--- a/api/src/monitoring/monitoring.controller.ts
+++ b/api/src/monitoring/monitoring.controller.ts
@@ -167,6 +167,31 @@ export class MonitoringController {
     return this.monitoringService.mingguanAll(minggu, tId);
   }
 
+  @Get("mingguan/bulan")
+  async mingguanBulan(
+    @Query("tanggal") tanggal?: string,
+    @Req() req?: Request,
+    @Query("teamId") teamId?: string,
+  ) {
+    if (!tanggal) {
+      throw new BadRequestException("query 'tanggal' diperlukan");
+    }
+    const user = req?.user as any;
+    const role = user?.role;
+    const tId = teamId ? parseInt(teamId, 10) : undefined;
+
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
+      if (!tId) throw new ForbiddenException("bukan admin");
+      const member = await this.prisma.member.findFirst({
+        where: { teamId: tId, userId: user.userId },
+      });
+      if (!member || !member.is_leader)
+        throw new ForbiddenException("bukan ketua tim");
+    }
+
+    return this.monitoringService.mingguanBulan(tanggal, tId);
+  }
+
   @Get("bulanan")
   async bulanan(
     @Query("year") year?: string,

--- a/api/test/monitoring.service.spec.ts
+++ b/api/test/monitoring.service.spec.ts
@@ -62,4 +62,52 @@ describe('MonitoringService aggregated', () => {
     expect(res[0].detail[1]).toEqual({ tanggal: '2024-05-02', adaKegiatan: true });
     expect(res[1].detail[0]).toEqual({ tanggal: '2024-05-01', adaKegiatan: true });
   });
+
+  it('mingguanBulan aggregates per week', async () => {
+    prisma.laporanHarian.findMany.mockResolvedValue([
+      {
+        pegawaiId: 1,
+        tanggal: new Date('2024-05-02'),
+        status: STATUS.SELESAI_DIKERJAKAN,
+        pegawai: { nama: 'A' },
+      },
+      {
+        pegawaiId: 1,
+        tanggal: new Date('2024-05-08'),
+        status: STATUS.BELUM,
+        pegawai: { nama: 'A' },
+      },
+      {
+        pegawaiId: 2,
+        tanggal: new Date('2024-05-15'),
+        status: STATUS.SELESAI_DIKERJAKAN,
+        pegawai: { nama: 'B' },
+      },
+    ]);
+    const res = await service.mingguanBulan('2024-05-10');
+    expect(res).toEqual([
+      {
+        userId: 1,
+        nama: 'A',
+        weeks: [
+          { selesai: 1, total: 1, persen: 100 },
+          { selesai: 0, total: 1, persen: 0 },
+          { selesai: 0, total: 0, persen: 0 },
+          { selesai: 0, total: 0, persen: 0 },
+          { selesai: 0, total: 0, persen: 0 },
+        ],
+      },
+      {
+        userId: 2,
+        nama: 'B',
+        weeks: [
+          { selesai: 0, total: 0, persen: 0 },
+          { selesai: 0, total: 0, persen: 0 },
+          { selesai: 1, total: 1, persen: 100 },
+          { selesai: 0, total: 0, persen: 0 },
+          { selesai: 0, total: 0, persen: 0 },
+        ],
+      },
+    ]);
+  });
 });

--- a/web/src/pages/monitoring/WeeklyMatrix.jsx
+++ b/web/src/pages/monitoring/WeeklyMatrix.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek }) => {
+  if (!Array.isArray(data) || data.length === 0) return null;
+
+  const colorFor = (p) => {
+    if (p >= 80) return "green";
+    if (p >= 50) return "yellow";
+    return "red";
+  };
+
+  const progressColor = (p) => {
+    const c = colorFor(p);
+    return c === "green"
+      ? "bg-green-500"
+      : c === "yellow"
+      ? "bg-yellow-500"
+      : "bg-red-500";
+  };
+
+  return (
+    <div className="overflow-auto">
+      <table className="min-w-full text-xs border-collapse">
+        <thead>
+          <tr>
+            <th className="p-2 border text-left">Nama</th>
+            {weeks.map((_, i) => (
+              <th
+                key={i}
+                onClick={() => onSelectWeek && onSelectWeek(i)}
+                className="p-2 border text-center cursor-pointer"
+              >
+                Minggu {i + 1}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((u) => (
+            <tr key={u.userId} className="text-center">
+              <td className="p-2 border text-left whitespace-nowrap text-sm">
+                {u.nama}
+              </td>
+              {u.weeks.map((w, i) => (
+                <td key={i} className="p-1 border space-y-1">
+                  <div
+                    role="progressbar"
+                    aria-valuenow={w.persen}
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                    className="w-full bg-gray-200 dark:bg-gray-700 rounded h-2"
+                  >
+                    <div
+                      className={`${progressColor(w.persen)} h-2 rounded`}
+                      style={{ width: `${w.persen}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-medium">{w.persen}%</span>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default WeeklyMatrix;


### PR DESCRIPTION
## Summary
- support weekly progress matrix across a month via `/monitoring/mingguan/bulan`
- expose new API endpoint in controller and document in README
- implement WeeklyMatrix component and integrate into MonitoringPage
- add aggregation tests for the new service method

## Testing
- `npm install --prefix api`
- `npm test --prefix api`
- `npm install --prefix web`
- `npm run lint --prefix web`

------
https://chatgpt.com/codex/tasks/task_b_687682ecb01c832b87bd020c56ec7dd5