### PR TITLE
Add legend component to monitoring

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -37,7 +37,11 @@ progress for all users using progress bars in three tabs:
 - **Weekly** – progress for a selected week
 - **Yearly** – monthly progress for a chosen year
 
-The Daily tab also includes a scrollable matrix table showing each user's activity for every day in the chosen month. Cells are color coded just like in the dashboard overview.
+The Daily tab also includes a scrollable matrix table showing each user's activity for every day in the chosen month. Cells are color coded just like in the dashboard overview:
+
+- **Hijau** – ada tugas pada hari tersebut
+- **Kuning** – tidak ada tugas
+- **Biru** – akhir pekan atau hari libur
 
 When filtering results by team you may supply optional query parameters such as
 `teamId` to limit the data to a specific team.

--- a/web/src/components/dashboard/DailyOverview.jsx
+++ b/web/src/components/dashboard/DailyOverview.jsx
@@ -1,4 +1,5 @@
 import { getHolidays } from "../../utils/holidays";
+import Legend from "../ui/Legend";
 
 const DailyOverview = ({ data = [] }) => {
   if (!Array.isArray(data)) return <p>Data tidak tersedia</p>;
@@ -38,20 +39,7 @@ const DailyOverview = ({ data = [] }) => {
       <h2 className="text-lg font-semibold mb-3 text-blue-600 dark:text-blue-400">
         Kalender Aktivitas Harian
       </h2>
-      <div className="flex flex-wrap justify-end gap-2 mb-2 text-xs text-gray-500 dark:text-gray-400">
-        <div className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 bg-green-400 rounded-sm"></span>
-          Ada Laporan
-        </div>
-        <div className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 bg-yellow-400 rounded-sm"></span>
-          Tidak Ada Laporan
-        </div>
-        <div className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 bg-blue-400 rounded-sm"></span>
-          Hari Libur/Akhir Pekan
-        </div>
-      </div>
+      <Legend className="mb-2" />
       <div className="grid grid-cols-4 sm:grid-cols-7 gap-2">
         {data.map((day, index) => {
           const dayName = new Date(day.tanggal).toLocaleDateString("id-ID", {

--- a/web/src/components/ui/Legend.jsx
+++ b/web/src/components/ui/Legend.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+export default function Legend({ className = "" }) {
+  return (
+    <div
+      className={`flex flex-wrap justify-end gap-2 text-xs text-gray-500 dark:text-gray-400 ${className}`.trim()}
+    >
+      <div className="flex items-center gap-1">
+        <span className="inline-block w-3 h-3 bg-green-400 rounded-sm"></span>
+        Ada Tugas
+      </div>
+      <div className="flex items-center gap-1">
+        <span className="inline-block w-3 h-3 bg-yellow-400 rounded-sm"></span>
+        Tidak Ada
+      </div>
+      <div className="flex items-center gap-1">
+        <span className="inline-block w-3 h-3 bg-blue-400 rounded-sm"></span>
+        Akhir Pekan/Libur
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -6,6 +6,7 @@ import months from "../../utils/months";
 import DateFilter from "../../components/ui/DateFilter";
 import Table from "../../components/ui/Table";
 import tableStyles from "../../components/ui/Table.module.css";
+import Legend from "../../components/ui/Legend";
 import DailyMatrix from "./DailyMatrix";
 import WeeklyMatrix from "./WeeklyMatrix";
 import { useAuth } from "../auth/useAuth";
@@ -465,7 +466,12 @@ export default function MonitoringPage() {
           <div>Memuat...</div>
         ) : (
           <div>
-            {tab === 'harian' && <DailyMatrix data={dailyData} />}
+            {tab === 'harian' && (
+              <>
+                <Legend className="mb-2" />
+                <DailyMatrix data={dailyData} />
+              </>
+            )}
             {tab === 'mingguan' && (
               <>
                 <WeeklyMatrix


### PR DESCRIPTION
## Summary
- add reusable `Legend` component for color codes
- replace hardcoded legend in `DailyOverview`
- show legend above the daily matrix on the monitoring page
- document the colors in the monitoring section of the README

## Testing
- `npm run lint --prefix web`
- `npm test --prefix api`


------
https://chatgpt.com/codex/tasks/task_b_687687f653c0832b8efdd1c0202ddb14