### PR TITLE
Filter admin from monitoring tables

### DIFF
--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -86,7 +86,8 @@ export default function MonitoringPage() {
     const fetchUsers = async () => {
       try {
         const res = await axios.get("/users");
-        const sorted = res.data.sort((a, b) => a.nama.localeCompare(b.nama));
+        const filtered = res.data.filter((u) => u.role !== "admin");
+        const sorted = filtered.sort((a, b) => a.nama.localeCompare(b.nama));
         setAllUsers(sorted);
       } catch (err) {
         console.error("Gagal mengambil pengguna", err);
@@ -113,7 +114,9 @@ export default function MonitoringPage() {
     if (teamId) {
       const t = teams.find((tm) => tm.id === parseInt(teamId, 10));
       if (t) {
-        const mem = t.members.map((m) => m.user);
+        const mem = t.members
+          .map((m) => m.user)
+          .filter((u) => u.role !== "admin");
         const sorted = mem.sort((a, b) => a.nama.localeCompare(b.nama));
         setUsers(sorted);
       }


### PR DESCRIPTION
## Summary
- ignore `admin` role users when fetching `/users`
- remove admins from team member list

## Testing
- `npm run lint` in `web`
- `npm run lint` *(fails: Parsing error)* in `api`
- `npm test` in `api`


------
https://chatgpt.com/codex/tasks/task_b_687687dbd8a8832b955712f129accba3