### PR TITLE
Remove month from week selector

### DIFF
--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -24,7 +24,7 @@ export default function MonitoringPage() {
   const [weekStarts, setWeekStarts] = useState([]);
 
   const [dailyData, setDailyData] = useState([]);
-  const [weeklyData, setWeeklyData] = useState([]);
+  const [, setWeeklyData] = useState([]);
   const [weeklyMonthData, setWeeklyMonthData] = useState([]);
   const [monthlyData, setMonthlyData] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -300,7 +300,7 @@ export default function MonitoringPage() {
 
   const weekOptions = weekStarts.map((d, i) => {
     return {
-      label: `Minggu ${i + 1} bulan ${months[monthIndex]}`,
+      label: `Minggu ${i + 1}`,
       value: i,
     };
   });


### PR DESCRIPTION
## Summary
- streamline week selection label
- silence unused state warning for weekly data

## Testing
- `npm --prefix web run lint`

------
https://chatgpt.com/codex/tasks/task_b_687692abd3c4832ba877a62aca0f4e97