### PR TITLE
Add monthly matrix monitoring endpoint

### DIFF
--- a/api/src/monitoring/monitoring.controller.ts
+++ b/api/src/monitoring/monitoring.controller.ts
@@ -251,4 +251,29 @@ export class MonitoringController {
 
     return this.monitoringService.bulananAll(year, tId);
   }
+
+  @Get("bulanan/matrix")
+  async bulananMatrix(
+    @Query("year") year?: string,
+    @Req() req?: Request,
+    @Query("teamId") teamId?: string,
+  ) {
+    if (!year) {
+      throw new BadRequestException("query 'year' diperlukan");
+    }
+    const user = req?.user as any;
+    const role = user?.role;
+    const tId = teamId ? parseInt(teamId, 10) : undefined;
+
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
+      if (!tId) throw new ForbiddenException("bukan admin");
+      const member = await this.prisma.member.findFirst({
+        where: { teamId: tId, userId: user.userId },
+      });
+      if (!member || !member.is_leader)
+        throw new ForbiddenException("bukan ketua tim");
+    }
+
+    return this.monitoringService.bulananMatrix(year, tId);
+  }
 }

--- a/api/src/monitoring/monitoring.module.ts
+++ b/api/src/monitoring/monitoring.module.ts
@@ -8,4 +8,5 @@ import { PrismaService } from "../prisma.service";
   providers: [PrismaService, MonitoringService],
   exports: [MonitoringService],
 })
+// Module providing monitoring related services
 export class MonitoringModule {}

--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -380,6 +380,46 @@ export class MonitoringService {
       }))
       .sort((a, b) => a.nama.localeCompare(b.nama));
   }
+
+  async bulananMatrix(year: string, teamId?: number) {
+    const yr = parseInt(year, 10);
+    if (isNaN(yr)) throw new BadRequestException("year tidak valid");
+
+    const where: any = { tahun: yr };
+    if (teamId) where.kegiatan = { teamId };
+
+    const tugas = await this.prisma.penugasan.findMany({
+      where,
+      include: { pegawai: true },
+    });
+
+    const byUser: Record<
+      number,
+      { nama: string; perMonth: Record<number, { selesai: number; total: number }> }
+    > = {};
+
+    for (const t of tugas) {
+      const idx = parseInt(t.bulan, 10) - 1;
+      if (!byUser[t.pegawaiId])
+        byUser[t.pegawaiId] = { nama: t.pegawai.nama, perMonth: {} };
+      if (!byUser[t.pegawaiId].perMonth[idx])
+        byUser[t.pegawaiId].perMonth[idx] = { selesai: 0, total: 0 };
+      byUser[t.pegawaiId].perMonth[idx].total += 1;
+      if (t.status === STATUS.SELESAI_DIKERJAKAN)
+        byUser[t.pegawaiId].perMonth[idx].selesai += 1;
+    }
+
+    return Object.entries(byUser)
+      .map(([id, v]) => {
+        const months = MONTHS.map((_, i) => {
+          const m = v.perMonth[i] || { selesai: 0, total: 0 };
+          const persen = m.total ? Math.round((m.selesai / m.total) * 100) : 0;
+          return { selesai: m.selesai, total: m.total, persen };
+        });
+        return { userId: Number(id), nama: v.nama, months };
+      })
+      .sort((a, b) => a.nama.localeCompare(b.nama));
+  }
 }
 
 function monthName(date: Date) {

--- a/api/test/monitoring.service.spec.ts
+++ b/api/test/monitoring.service.spec.ts
@@ -110,4 +110,49 @@ describe('MonitoringService aggregated', () => {
       },
     ]);
   });
+
+  it('bulananMatrix aggregates per month', async () => {
+    prisma.penugasan.findMany.mockResolvedValue([
+      {
+        pegawaiId: 1,
+        bulan: '1',
+        status: STATUS.SELESAI_DIKERJAKAN,
+        pegawai: { nama: 'A' },
+      },
+      {
+        pegawaiId: 1,
+        bulan: '2',
+        status: STATUS.BELUM,
+        pegawai: { nama: 'A' },
+      },
+      {
+        pegawaiId: 2,
+        bulan: '1',
+        status: STATUS.SELESAI_DIKERJAKAN,
+        pegawai: { nama: 'B' },
+      },
+    ]);
+
+    const res = await service.bulananMatrix('2024');
+    const zero = { selesai: 0, total: 0, persen: 0 };
+    expect(res).toEqual([
+      {
+        userId: 1,
+        nama: 'A',
+        months: [
+          { selesai: 1, total: 1, persen: 100 },
+          { selesai: 0, total: 1, persen: 0 },
+          ...Array(10).fill(zero),
+        ],
+      },
+      {
+        userId: 2,
+        nama: 'B',
+        months: [
+          { selesai: 1, total: 1, persen: 100 },
+          ...Array(11).fill(zero),
+        ],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- implement `bulananMatrix` in MonitoringService for monthly per-user stats
- expose `GET /monitoring/bulanan/matrix`
- document service export in `MonitoringModule`
- test the new method

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687699ada080832bba157dc00bff8ce6