### PR TITLE
Add optional bulan filter for bulananAll

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -103,7 +103,7 @@ Server berjalan di: `http://localhost:3000`
 | GET    | `/monitoring/harian/bulan` | Rekap harian sebulan penuh per pegawai (query: `tanggal`, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/mingguan/all` | Monitoring mingguan semua pegawai (query: `minggu`, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/mingguan/bulan` | Rekap mingguan per pegawai dalam sebulan (query: `tanggal`, `teamId` opsional) | admin, pimpinan, ketua tim |
-| GET    | `/monitoring/bulanan/all`  | Monitoring bulanan semua pegawai (query: `year`, `teamId` opsional) | admin, pimpinan, ketua tim |
+| GET    | `/monitoring/bulanan/all`  | Monitoring bulanan semua pegawai (query: `year`, `bulan` opsional, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/bulanan/matrix` | Matriks bulanan per user (query: `year`, `teamId` opsional) | admin, pimpinan, ketua tim |
 
 Format hasil: array per pengguna, masing-masing memiliki array 12 objek bulan.

--- a/api/src/monitoring/monitoring.controller.ts
+++ b/api/src/monitoring/monitoring.controller.ts
@@ -232,6 +232,7 @@ export class MonitoringController {
     @Query("year") year?: string,
     @Req() req?: Request,
     @Query("teamId") teamId?: string,
+    @Query("bulan") bulan?: string,
   ) {
     if (!year) {
       throw new BadRequestException("query 'year' diperlukan");
@@ -249,7 +250,7 @@ export class MonitoringController {
         throw new ForbiddenException("bukan ketua tim");
     }
 
-    return this.monitoringService.bulananAll(year, tId);
+    return this.monitoringService.bulananAll(year, tId, bulan);
   }
 
   @Get("bulanan/matrix")

--- a/api/test/monitoring.service.spec.ts
+++ b/api/test/monitoring.service.spec.ts
@@ -38,15 +38,19 @@ describe('MonitoringService aggregated', () => {
     ]);
   });
 
-  it('bulananAll aggregates and can filter by month', async () => {
+  it('bulananAll aggregates and passes bulan filter', async () => {
     prisma.penugasan.findMany.mockResolvedValue([
       { pegawaiId: 2, bulan: '1', status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'B' } },
-      { pegawaiId: 1, bulan: '2', status: STATUS.BELUM, pegawai: { nama: 'A' } },
+      { pegawaiId: 1, bulan: '1', status: STATUS.BELUM, pegawai: { nama: 'A' } },
       { pegawaiId: 1, bulan: '1', status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'A' } },
     ]);
-    const res = await service.bulananAll('2024', undefined, '1');
+    const res = await service.bulananAll('2024', 3, '1');
+    expect(prisma.penugasan.findMany).toHaveBeenCalledWith({
+      where: { tahun: 2024, bulan: '1', kegiatan: { teamId: 3 } },
+      include: { pegawai: true },
+    });
     expect(res).toEqual([
-      { userId: 1, nama: 'A', selesai: 1, total: 1, persen: 100 },
+      { userId: 1, nama: 'A', selesai: 1, total: 2, persen: 50 },
       { userId: 2, nama: 'B', selesai: 1, total: 1, persen: 100 },
     ]);
   });


### PR DESCRIPTION
## Summary
- accept `bulan` query in `MonitoringController.bulananAll`
- pass month param to `MonitoringService.bulananAll`
- test month filtering and prisma query usage
- document `bulan` parameter in API docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6876f0883a2c832ba90057488860a518