### PR TITLE
Add sidebar toggle

### DIFF
--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -22,7 +22,7 @@ export default function Layout() {
   const { user, setToken, setUser } = useAuth();
   const location = useLocation();
 
-  const [mobileOpen, setMobileOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(true);
   const [notifCount, setNotifCount] = useState(3);
   const [notifications, setNotifications] = useState([
     { id: 1, text: "Laporan harian belum dikirim", read: false },
@@ -87,18 +87,18 @@ export default function Layout() {
     <div className="h-screen overflow-hidden flex text-gray-800 dark:text-gray-100 bg-gray-100 dark:bg-gray-900">
       {/* Sidebar */}
       <div
-        className={`fixed md:static top-0 left-0 z-40 h-full transition-transform duration-300 ${
-          mobileOpen ? "translate-x-0" : "-translate-x-full"
-        } md:translate-x-0 w-64`}
+        className={`fixed md:static top-0 left-0 z-40 h-full overflow-hidden transition-all duration-300 w-64 ${
+          sidebarOpen ? "translate-x-0 md:w-64" : "-translate-x-full md:w-0"
+        } md:translate-x-0`}
       >
-        <Sidebar setMobileOpen={setMobileOpen} />
+        <Sidebar setSidebarOpen={setSidebarOpen} />
       </div>
 
       {/* Overlay untuk mobile */}
-      {mobileOpen && (
+      {sidebarOpen && (
         <div
           className="fixed inset-0 bg-black opacity-30 z-30 md:hidden"
-          onClick={() => setMobileOpen(false)}
+          onClick={() => setSidebarOpen(false)}
         />
       )}
 
@@ -108,11 +108,11 @@ export default function Layout() {
         <div className="flex items-center justify-between gap-2 p-4 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 flex-shrink-0">
           <div className="flex items-center space-x-3">
             <button
-              className="md:hidden text-xl text-gray-700 dark:text-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ring-blue-500"
-              onClick={() => setMobileOpen(!mobileOpen)}
-              aria-label={mobileOpen ? "Close menu" : "Open menu"}
+              className={`text-xl text-gray-700 dark:text-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ring-blue-500 ${sidebarOpen ? "hidden" : ""}`}
+              onClick={() => setSidebarOpen(true)}
+              aria-label="Open menu"
             >
-              {mobileOpen ? <FaTimes /> : <FaBars />}
+              <FaBars />
             </button>
             <div className="text-lg sm:text-xl font-semibold capitalize truncate max-w-[200px] sm:max-w-xs">
               {getPageTitle()}

--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -1,5 +1,6 @@
 import { NavLink } from "react-router-dom";
 import { useAuth } from "../auth/useAuth";
+import { FaTimes } from "react-icons/fa";
 import {
   LayoutDashboard,
   ClipboardList,
@@ -12,7 +13,7 @@ import {
 } from "lucide-react";
 import { ROLES } from "../../utils/roles";
 
-export default function Sidebar({ setMobileOpen }) {
+export default function Sidebar({ setSidebarOpen }) {
   const { user } = useAuth();
 
   const mainLinks = [
@@ -45,7 +46,7 @@ export default function Sidebar({ setMobileOpen }) {
       <NavLink
         key={link.to}
         to={link.to}
-        onClick={() => setMobileOpen(false)}
+        onClick={() => setSidebarOpen(false)}
         className={({ isActive }) =>
           `flex items-center gap-3 px-4 py-2 rounded transition-all ${
             isActive
@@ -61,7 +62,14 @@ export default function Sidebar({ setMobileOpen }) {
   };
 
   return (
-    <aside className="h-full w-64 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 p-4 shadow-md overflow-y-auto flex flex-col">
+    <aside className="relative h-full w-64 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 p-4 shadow-md overflow-y-auto flex flex-col">
+      <button
+        className="md:hidden absolute top-2 right-2 text-xl text-gray-700 dark:text-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ring-blue-500"
+        onClick={() => setSidebarOpen(false)}
+        aria-label="Close menu"
+      >
+        <FaTimes />
+      </button>
       <div className="text-2xl font-bold text-blue-600 dark:text-blue-400 mb-6 text-center">
         SEMAKIN 6502
       </div>

--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -580,6 +580,7 @@ export default function MonitoringPage() {
                 <MonthlyMatrix data={monthlyData} />
               ) : (
                 <div className="text-center py-4">Tidak ada data</div>
+              ))}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add a `sidebarOpen` state to control layout sidebar
- hide/show sidebar on any screen
- close sidebar when navigation links are clicked
- move close button inside sidebar and default it open
- fix MonitoringPage parse error

## Testing
- `npm install --no-progress`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6877048767cc832b9a0d96174e3498a3