### PR TITLE
Exclude admin and pimpinan from monitoring and assignments

### DIFF
--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -103,7 +103,9 @@ export default function MonitoringPage() {
     const fetchUsers = async () => {
       try {
         const res = await axios.get("/users");
-        const filtered = res.data.filter((u) => u.role !== "admin");
+        const filtered = res.data.filter(
+          (u) => u.role !== "admin" && u.role !== "pimpinan"
+        );
         const sorted = filtered.sort((a, b) => a.nama.localeCompare(b.nama));
         setAllUsers(sorted);
       } catch (err) {
@@ -133,7 +135,7 @@ export default function MonitoringPage() {
       if (t) {
         const mem = t.members
           .map((m) => m.user)
-          .filter((u) => u.role !== "admin");
+          .filter((u) => u.role !== "admin" && u.role !== "pimpinan");
         const sorted = mem.sort((a, b) => a.nama.localeCompare(b.nama));
         setUsers(sorted);
       }

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -272,7 +272,9 @@ export default function PenugasanDetailPage() {
               styles={selectStyles}
               menuPortalTarget={document.body}
               options={users
-                .filter((u) => u.role !== ROLES.ADMIN)
+                .filter(
+                  (u) => u.role !== ROLES.ADMIN && u.role !== ROLES.PIMPINAN
+                )
                 .map((u) => ({ value: u.id, label: u.nama }))}
               value={{
                 value: form.pegawaiId,

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -361,7 +361,9 @@ export default function PenugasanPage() {
                 styles={selectStyles}
                 menuPortalTarget={document.body}
                 options={users
-                  .filter((u) => u.role !== ROLES.ADMIN)
+                  .filter(
+                    (u) => u.role !== ROLES.ADMIN && u.role !== ROLES.PIMPINAN
+                  )
                   .map((u) => ({ value: u.id, label: `${u.nama}` }))}
                 value={form.pegawaiIds
                   .map((id) => {
@@ -386,7 +388,9 @@ export default function PenugasanPage() {
                   setForm({
                     ...form,
                     pegawaiIds: users
-                      .filter((u) => u.role !== ROLES.ADMIN)
+                      .filter(
+                        (u) => u.role !== ROLES.ADMIN && u.role !== ROLES.PIMPINAN
+                      )
                       .map((u) => u.id),
                   })
                 }


### PR DESCRIPTION
## Summary
- filter out `admin` and `pimpinan` roles when fetching users for monitoring
- exclude `admin` and `pimpinan` from penugasan dropdowns

## Testing
- `npm test --prefix api` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68770e4a496c832b8c60daca9c625459