### PR TITLE
Add permission message for deleting assignments

### DIFF
--- a/api/src/kegiatan/penugasan.service.ts
+++ b/api/src/kegiatan/penugasan.service.ts
@@ -181,7 +181,10 @@ export class PenugasanService {
       const leader = await this.prisma.member.findFirst({
         where: { teamId: existing.kegiatan.teamId, userId, is_leader: true },
       });
-      if (!leader) throw new ForbiddenException("bukan ketua tim kegiatan ini");
+      if (!leader)
+        throw new ForbiddenException(
+          "hanya admin atau ketua tim yang dapat menghapus penugasan"
+        );
     }
     await this.prisma.penugasan.delete({ where: { id } });
     return { success: true };

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -166,7 +166,15 @@ export default function PenugasanDetailPage() {
       navigate(-1);
     } catch (err) {
       console.error(err);
-      showError("Error", "Gagal menghapus");
+      if (err?.response?.status === 403) {
+        showError(
+          "Tidak diizinkan",
+          "Hanya admin atau ketua tim yang dapat menghapus penugasan."
+        );
+      } else {
+        const msg = err?.response?.data?.message || "Gagal menghapus";
+        showError("Error", msg);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- show a clearer warning when deleting a penugasan without sufficient rights
- return a detailed message from the API when the user lacks permission

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68772b71141c832bb14adf357ac699cb