### PR TITLE
Add confirmCancel to detail pages

### DIFF
--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -1,7 +1,12 @@
 import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
-import { showSuccess, showError, confirmDelete } from "../../utils/alerts";
+import {
+  showSuccess,
+  showError,
+  confirmDelete,
+  confirmCancel,
+} from "../../utils/alerts";
 import Select from "react-select";
 import selectStyles from "../../utils/selectStyles";
 import { Pencil, Trash2 } from "lucide-react";
@@ -346,7 +351,13 @@ export default function PenugasanDetailPage() {
             </div>
           </div>
           <div className="flex justify-end space-x-2 pt-2">
-            <Button variant="secondary" onClick={() => setEditing(false)}>
+            <Button
+              variant="secondary"
+              onClick={async () => {
+                const r = await confirmCancel("Batalkan perubahan?");
+                if (r.isConfirmed) setEditing(false);
+              }}
+            >
               Batal
             </Button>
             <Button onClick={save}>Simpan</Button>

--- a/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/KegiatanTambahanDetailPage.jsx
@@ -5,6 +5,7 @@ import {
   showSuccess,
   showError,
   confirmDelete,
+  confirmCancel,
 } from "../../utils/alerts";
 import { Pencil, Trash2 } from "lucide-react";
 import Select from "react-select";
@@ -244,7 +245,13 @@ export default function KegiatanTambahanDetailPage() {
             </select>
           </div>
           <div className="flex justify-end space-x-2 pt-2">
-            <Button variant="secondary" onClick={() => setEditing(false)}>
+            <Button
+              variant="secondary"
+              onClick={async () => {
+                const r = await confirmCancel("Batalkan perubahan?");
+                if (r.isConfirmed) setEditing(false);
+              }}
+            >
               Batal
             </Button>
             <Button onClick={save}>Simpan</Button>


### PR DESCRIPTION
## Summary
- prompt users to confirm cancellation on detail page forms

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68772b835988832bb0ec181f6f1523aa