### PR TITLE
Add description field for daily reports

### DIFF
--- a/api/prisma/migrations/20250726000000_add_deskripsi_laporan_harian/migration.sql
+++ b/api/prisma/migrations/20250726000000_add_deskripsi_laporan_harian/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `LaporanHarian`
+  ADD COLUMN `deskripsi` VARCHAR(191);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -66,6 +66,7 @@ model LaporanHarian {
   penugasanId Int
   tanggal     DateTime
   status      String
+  deskripsi   String?
   bukti_link  String?
   catatan     String?
   pegawaiId   Int

--- a/api/src/laporan/dto/submit-laporan.dto.ts
+++ b/api/src/laporan/dto/submit-laporan.dto.ts
@@ -10,6 +10,9 @@ export class SubmitLaporanDto {
   @IsString()
   status!: string;
 
+  @IsString()
+  deskripsi!: string;
+
   @IsOptional()
   @IsString()
   bukti_link?: string;

--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -25,6 +25,7 @@ export class LaporanService {
         pegawaiId: data.pegawaiId,
         tanggal: new Date(data.tanggal),
         status: data.status,
+        deskripsi: data.deskripsi,
         bukti_link: data.bukti_link || undefined,
         catatan: data.catatan || undefined,
       },
@@ -89,6 +90,7 @@ export class LaporanService {
       data: {
         tanggal: new Date(data.tanggal),
         status: data.status,
+        deskripsi: data.deskripsi,
         bukti_link: data.bukti_link,
         catatan: data.catatan,
       },

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2, ExternalLink, X } from "lucide-react";
 import { showSuccess, showError, confirmDelete } from "../../utils/alerts";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
@@ -26,6 +26,7 @@ export default function LaporanHarianPage() {
   const [form, setForm] = useState({
     id: null,
     tanggal: new Date().toISOString().slice(0, 10),
+    deskripsi: "",
     status: STATUS.BELUM,
     bukti_link: "",
     catatan: "",
@@ -47,6 +48,7 @@ export default function LaporanHarianPage() {
     setForm({
       id: item.id,
       tanggal: item.tanggal.slice(0, 10),
+      deskripsi: item.deskripsi || "",
       status: item.status,
       bukti_link: item.bukti_link || "",
       catatan: item.catatan || "",
@@ -88,9 +90,10 @@ export default function LaporanHarianPage() {
   const filtered = laporan.filter((l) => {
     const peg = l.pegawai?.nama?.toLowerCase() || "";
     const keg = l.penugasan?.kegiatan?.nama_kegiatan?.toLowerCase() || "";
+    const desc = l.deskripsi?.toLowerCase() || "";
     const cat = l.catatan?.toLowerCase() || "";
     const stat = l.status.toLowerCase();
-    const txt = `${peg} ${keg} ${cat} ${stat}`;
+    const txt = `${peg} ${keg} ${desc} ${cat} ${stat}`;
     const matchQuery = txt.includes(query.toLowerCase());
     const matchDate = l.tanggal.slice(0, 10) === tanggal;
     return matchQuery && matchDate;
@@ -130,7 +133,8 @@ export default function LaporanHarianPage() {
                 <th className={tableStyles.cell}>No</th>
                 <th className={tableStyles.cell}>Kegiatan</th>
                 <th className={tableStyles.cell}>Tim</th>
-                <th className={tableStyles.cell}>Deskripsi</th>
+                <th className={tableStyles.cell}>Deskripsi Kegiatan</th>
+                <th className={tableStyles.cell}>Deskripsi Laporan</th>
                 <th className={tableStyles.cell}>Tanggal</th>
                 <th className={tableStyles.cell}>Status</th>
                 <th className={tableStyles.cell}>Bukti</th>
@@ -140,7 +144,7 @@ export default function LaporanHarianPage() {
             <tbody>
               {loading ? (
                 <tr>
-                  <td colSpan="8" className="py-10">
+                  <td colSpan="9" className="py-10">
                     <div className="flex flex-col items-center justify-center space-y-3">
                       <svg
                         className="animate-spin h-8 w-8 text-blue-600"
@@ -175,7 +179,7 @@ export default function LaporanHarianPage() {
               ) : filtered.length === 0 ? (
                 <tr>
                   <td
-                    colSpan="8"
+                    colSpan="9"
                     className="py-6 text-center text-gray-600 dark:text-gray-300"
                   >
                     <div className="flex flex-col items-center space-y-1">
@@ -204,6 +208,7 @@ export default function LaporanHarianPage() {
                     <td className={tableStyles.cell}>
                       {item.penugasan?.kegiatan?.deskripsi || "-"}
                     </td>
+                    <td className={tableStyles.cell}>{item.deskripsi}</td>
                     <td className={tableStyles.cell}>
                       {item.tanggal.slice(0, 10)}
                     </td>
@@ -211,8 +216,10 @@ export default function LaporanHarianPage() {
                       <StatusBadge status={item.status} />
                     </td>
                     <td className={tableStyles.cell}>
-                      {item.bukti_dukung ? (
-                        <Check className="w-4 h-4 text-green-600" />
+                    {item.bukti_link ? (
+                        <a href={item.bukti_link} target="_blank" rel="noreferrer">
+                          <ExternalLink size={16} className="mx-auto text-blue-600 dark:text-blue-400" />
+                        </a>
                       ) : (
                         <X className="w-4 h-4 text-red-600" />
                       )}
@@ -270,10 +277,10 @@ export default function LaporanHarianPage() {
             Edit Laporan Harian
           </h3>
           <div className="space-y-2">
-            <div>
-              <Label htmlFor="tanggal">
-                Tanggal<span className="text-red-500">*</span>
-              </Label>
+          <div>
+            <Label htmlFor="tanggal">
+              Tanggal<span className="text-red-500">*</span>
+            </Label>
               <Input
                 id="tanggal"
                 type="date"
@@ -281,10 +288,21 @@ export default function LaporanHarianPage() {
                 onChange={(e) => setForm({ ...form, tanggal: e.target.value })}
                 className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
               />
-            </div>
-            <div>
-              <Label htmlFor="status">
-                Status<span className="text-red-500">*</span>
+          </div>
+          <div>
+            <Label htmlFor="deskripsi">
+              Deskripsi <span className="text-red-500">*</span>
+            </Label>
+            <textarea
+              id="deskripsi"
+              value={form.deskripsi}
+              onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
+              className="form-input"
+            />
+          </div>
+          <div>
+            <Label htmlFor="status">
+              Status<span className="text-red-500">*</span>
               </Label>
               <select
                 id="status"

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -9,7 +9,7 @@ import {
 } from "../../utils/alerts";
 import Select from "react-select";
 import selectStyles from "../../utils/selectStyles";
-import { Pencil, Trash2, Plus } from "lucide-react";
+import { Pencil, Trash2, Plus, ExternalLink } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
 import { STATUS } from "../../utils/status";
@@ -47,6 +47,7 @@ export default function PenugasanDetailPage() {
   const [laporanForm, setLaporanForm] = useState({
     id: null,
     tanggal: new Date().toISOString().slice(0, 10),
+    deskripsi: "",
     status: STATUS.BELUM, // Belum, Sedang Dikerjakan, Selesai Dikerjakan
     bukti_link: "",
     catatan: "",
@@ -112,6 +113,7 @@ export default function PenugasanDetailPage() {
     setLaporanForm({
       id: null,
       tanggal: new Date().toISOString().slice(0, 10),
+      deskripsi: "",
       status: STATUS.BELUM,
       bukti_link: "",
       catatan: "",
@@ -143,6 +145,7 @@ export default function PenugasanDetailPage() {
     setLaporanForm({
       id: item.id,
       tanggal: item.tanggal.slice(0, 10),
+      deskripsi: item.deskripsi || "",
       status: item.status,
       bukti_link: item.bukti_link || "",
       catatan: item.catatan || "",
@@ -396,6 +399,7 @@ export default function PenugasanDetailPage() {
           <thead>
             <tr className={`${tableStyles.headerRow} text-sm`}>
               <th className={tableStyles.smallCell}>No</th>
+              <th className={tableStyles.smallCell}>Deskripsi</th>
               <th className={tableStyles.smallCell}>Tanggal</th>
               <th className={tableStyles.smallCell}>Status</th>
               <th className={tableStyles.smallCell}>Bukti</th>
@@ -406,7 +410,7 @@ export default function PenugasanDetailPage() {
           <tbody>
             {laporan.length === 0 ? (
               <tr>
-                <td colSpan="6" className="py-2 text-center">
+                <td colSpan="7" className="py-2 text-center">
                   Belum ada laporan
                 </td>
               </tr>
@@ -417,6 +421,7 @@ export default function PenugasanDetailPage() {
                   className={`${tableStyles.row} border-t dark:border-gray-700 text-center`}
                 >
                   <td className={tableStyles.smallCell}>{idx + 1}</td>
+                  <td className={tableStyles.smallCell}>{l.deskripsi}</td>
                   <td className={tableStyles.smallCell}>
                     {l.tanggal.slice(0, 10)}
                   </td>
@@ -429,9 +434,11 @@ export default function PenugasanDetailPage() {
                         href={l.bukti_link}
                         target="_blank"
                         rel="noreferrer"
-                        className="text-blue-600 underline dark:text-blue-400"
                       >
-                        Link
+                        <ExternalLink
+                          size={16}
+                          className="mx-auto text-blue-600 dark:text-blue-400"
+                        />
                       </a>
                     ) : (
                       "-"
@@ -472,10 +479,10 @@ export default function PenugasanDetailPage() {
             {laporanForm.id ? "Edit" : "Tambah"} Laporan Harian
           </h3>
           <div className="space-y-2">
-            <div>
-              <Label htmlFor="laporanTanggal">
-                Tanggal <span className="text-red-500">*</span>
-              </Label>
+          <div>
+            <Label htmlFor="laporanTanggal">
+              Tanggal <span className="text-red-500">*</span>
+            </Label>
               <Input
                 id="laporanTanggal"
                 type="date"
@@ -487,11 +494,24 @@ export default function PenugasanDetailPage() {
                 onFocus={() => dateRef.current?.showPicker()}
                 className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700 dark:text-white"
               />
-            </div>
-            <div>
-              <Label htmlFor="laporanStatus">
-                Status <span className="text-red-500">*</span>
-              </Label>
+          </div>
+          <div>
+            <Label htmlFor="laporanDeskripsi">
+              Deskripsi <span className="text-red-500">*</span>
+            </Label>
+            <textarea
+              id="laporanDeskripsi"
+              value={laporanForm.deskripsi}
+              onChange={(e) =>
+                setLaporanForm({ ...laporanForm, deskripsi: e.target.value })
+              }
+              className="form-input"
+            />
+          </div>
+          <div>
+            <Label htmlFor="laporanStatus">
+              Status <span className="text-red-500">*</span>
+            </Label>
               <select
                 id="laporanStatus"
                 value={laporanForm.status}


### PR DESCRIPTION
## Summary
- support description text in daily reports
- update Prisma schema and add migration
- include description in backend DTOs and services
- add description field to daily report forms
- show an icon for proof links

## Testing
- `npm test` in `api` *(fails: eslint parserOptions.project error)*
- `npm test` in `api` after install → tests pass
- `npm test --prefix web` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6877366ac9d0832baecb53d2a2b96444