### PR TITLE
Fix cancel confirm in laporan modal

### DIFF
--- a/api/src/laporan/laporan.controller.ts
+++ b/api/src/laporan/laporan.controller.ts
@@ -24,8 +24,8 @@ export class LaporanController {
 
   @Post()
   submit(@Body() body: SubmitLaporanDto, @Req() req: Request) {
-    const userId = (req.user as any).userId;
-    return this.laporanService.submit({ ...body, pegawaiId: userId });
+    const u = req.user as any;
+    return this.laporanService.submit(body, u.userId, u.role);
   }
 
   @Get()

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -54,6 +54,10 @@ export default function PenugasanDetailPage() {
     catatan: "",
   });
 
+  const closeLaporanForm = useCallback(() => {
+    setShowLaporanForm(false);
+  }, []);
+
   const dateRef = useRef(null);
 
   const fetchDetail = useCallback(async () => {
@@ -142,6 +146,7 @@ export default function PenugasanDetailPage() {
         await axios.post("/laporan-harian", {
           ...laporanForm,
           penugasanId: parseInt(id, 10),
+          pegawaiId: item.pegawaiId,
         });
       }
 
@@ -526,7 +531,7 @@ export default function PenugasanDetailPage() {
 
       {showLaporanForm && (
         <Modal
-          onClose={() => setShowLaporanForm(false)}
+          onClose={closeLaporanForm}
           titleId="laporan-form-title"
         >
           <div className="space-y-6">
@@ -643,7 +648,14 @@ export default function PenugasanDetailPage() {
             <div className="flex justify-end gap-3 pt-4">
               <Button
                 variant="secondary"
-                onClick={() => setShowLaporanForm(false)}
+                onClick={async () => {
+                  const r = await confirmCancel(
+                    laporanForm.id
+                      ? "Batalkan perubahan?"
+                      : "Batalkan penambahan laporan?"
+                  );
+                  if (r.isConfirmed) setShowLaporanForm(false);
+                }}
               >
                 Batal
               </Button>


### PR DESCRIPTION
## Summary
- add confirmation when closing the daily report form
- allow admins or team leads to create reports for any assignee

## Testing
- `npm test` *(fails: missing script)*
- `cd api && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68784cbf87ec832ba97715982ac1d128