### PR TITLE
Fix master kegiatan list for admins

### DIFF
--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -84,7 +84,7 @@ export default function PenugasanDetailPage() {
     axios
       .get(`/laporan-harian/penugasan/${id}`)
       .then((r) => setLaporan(r.data));
-    axios.get("/master-kegiatan").then((r) => {
+    axios.get("/master-kegiatan?limit=1000").then((r) => {
       const kData = r.data.data || r.data;
       const sorted = [...kData].sort((a, b) =>
         a.nama_kegiatan.localeCompare(b.nama_kegiatan)

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -79,7 +79,7 @@ export default function PenugasanPage() {
 
       let kRes;
       if (user?.role === ROLES.ADMIN) {
-        kRes = await axios.get("/master-kegiatan");
+        kRes = await axios.get("/master-kegiatan?limit=1000");
       } else {
         const tId = tRes.data[0]?.id;
         if (tId) {


### PR DESCRIPTION
## Summary
- fetch all master kegiatan for admins when creating/editing penugasan

## Testing
- `npm install` in `api`
- `npm test` in `api`


------
https://chatgpt.com/codex/tasks/task_b_687850d9f31c832b8438b571d11bcf0f