### PR TITLE
Fix month display and date format

### DIFF
--- a/web/src/components/ui/Table.module.css
+++ b/web/src/components/ui/Table.module.css
@@ -1,0 +1,5 @@
+.headerRow { @apply bg-gray-200 dark:bg-gray-900 text-gray-700 dark:text-gray-200 text-center text-sm uppercase; }
+.row       { @apply odd:bg-gray-100 dark:odd:bg-gray-700 text-gray-700 dark:text-gray-200; }
+.cell      { @apply px-2 py-1 sm:px-4 sm:py-2; }
+.smallCell { @apply px-1 py-0.5 sm:px-2 sm:py-1; }
+

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -60,6 +60,11 @@ export default function PenugasanDetailPage() {
 
   const dateRef = useRef(null);
 
+  const formatDMY = (iso) => {
+    const [y, m, d] = iso.slice(0, 10).split("-");
+    return `${d}-${m}-${y}`;
+  };
+
   const fetchDetail = useCallback(async () => {
     try {
       const res = await axios.get(`/penugasan/${id}`);
@@ -287,7 +292,7 @@ export default function PenugasanDetailPage() {
             <div className="text-sm text-gray-500 dark:text-gray-400">
               Bulan
             </div>
-            <div className="font-medium">{item.bulan}</div>
+            <div className="font-medium">{months[item.bulan - 1]}</div>
           </div>
           <div>
             <div className="text-sm text-gray-500 dark:text-gray-400">
@@ -297,7 +302,7 @@ export default function PenugasanDetailPage() {
           </div>
           <div className="sm:col-span-2 lg:col-span-3">
             <div className="text-sm text-gray-500 dark:text-gray-400">
-              Deskripsi
+              Deskripsi Penugasan
             </div>
             <div className="font-medium">{item.deskripsi || "-"}</div>
           </div>
@@ -363,7 +368,7 @@ export default function PenugasanDetailPage() {
             />
           </div>
           <div>
-            <Label htmlFor="deskripsi">Deskripsi</Label>
+            <Label htmlFor="deskripsi">Deskripsi Penugasan</Label>
             <textarea
               id="deskripsi"
               value={form.deskripsi}
@@ -427,7 +432,18 @@ export default function PenugasanDetailPage() {
               variant="secondary"
               onClick={async () => {
                 const r = await confirmCancel("Batalkan perubahan?");
-                if (r.isConfirmed) setEditing(false);
+                if (r.isConfirmed) {
+                  setForm({
+                    kegiatanId: item.kegiatanId,
+                    pegawaiId: item.pegawaiId,
+                    deskripsi: item.deskripsi || "",
+                    minggu: item.minggu,
+                    bulan: item.bulan,
+                    tahun: item.tahun,
+                    status: item.status,
+                  });
+                  setEditing(false);
+                }
               }}
             >
               Batal
@@ -447,7 +463,7 @@ export default function PenugasanDetailPage() {
             className="flex items-center gap-2 px-4 py-2"
           >
             <Plus size={18} />
-            <span>Tambah Laporan</span>
+            <span className="hidden sm:inline">Tambah Laporan</span>
           </Button>
         </div>
         <div className="overflow-x-auto rounded-lg border dark:border-gray-700">
@@ -481,7 +497,7 @@ export default function PenugasanDetailPage() {
                   >
                     <td className="py-3 px-4">{idx + 1}</td>
                     <td className="py-3 px-4">{l.deskripsi}</td>
-                    <td className="py-3 px-4">{l.tanggal.slice(0, 10)}</td>
+                    <td className="py-3 px-4">{formatDMY(l.tanggal)}</td>
                     <td className="py-3 px-4">
                       <StatusBadge status={l.status} />
                     </td>


### PR DESCRIPTION
## Summary
- show month names instead of numbers on assignment detail page
- rename `Deskripsi` label to `Deskripsi Penugasan`
- format laporan dates as `dd-mm-yyyy`

## Testing
- `npm run lint` in web *(fails: cannot find package '@eslint/js')*
- `npm run lint` in api *(fails: cannot find module '@eslint/eslintrc')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_687749573a84832bbfcd615eade48ce6