### PR TITLE
Check assignment reports before delete

### DIFF
--- a/api/src/kegiatan/penugasan.service.ts
+++ b/api/src/kegiatan/penugasan.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   ForbiddenException,
   NotFoundException,
+  BadRequestException,
 } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 import { ROLES } from "../common/roles.constants";
@@ -186,6 +187,13 @@ export class PenugasanService {
           "hanya admin atau ketua tim yang dapat menghapus penugasan"
         );
     }
+    const count = await this.prisma.laporanHarian.count({
+      where: { penugasanId: id },
+    });
+    if (count > 0)
+      throw new BadRequestException(
+        "hapus laporan harian penugasan ini terlebih dahulu"
+      );
     await this.prisma.penugasan.delete({ where: { id } });
     return { success: true };
   }

--- a/api/test/penugasan.service.spec.ts
+++ b/api/test/penugasan.service.spec.ts
@@ -1,0 +1,27 @@
+import { PenugasanService } from '../src/kegiatan/penugasan.service';
+import { BadRequestException } from '@nestjs/common';
+
+const prisma = {
+  penugasan: { findUnique: jest.fn(), delete: jest.fn() },
+  member: { findFirst: jest.fn() },
+  laporanHarian: { count: jest.fn() },
+} as any;
+
+const service = new PenugasanService(prisma);
+
+describe('PenugasanService remove', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('throws BadRequestException when laporan harian exists', async () => {
+    prisma.penugasan.findUnique.mockResolvedValue({ id: 1, kegiatan: { teamId: 2 } });
+    prisma.member.findFirst.mockResolvedValue({ id: 1 });
+    prisma.laporanHarian.count.mockResolvedValue(1);
+
+    const action = service.remove(1, 1, 'admin');
+    await expect(action).rejects.toThrow(BadRequestException);
+    await expect(action).rejects.toThrow('hapus laporan harian penugasan ini terlebih dahulu');
+    expect(prisma.penugasan.delete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- avoid deleting assignments that still have `LaporanHarian`
- throw an error if reports are present
- test `PenugasanService.remove` against this case

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687869ceedbc832b80fa66e1094ef079