### PR TITLE
Improve weekly task form defaults

### DIFF
--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -17,7 +17,6 @@ import { STATUS } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
-import tableStyles from "../../components/ui/Table.module.css";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -25,6 +25,22 @@ import months from "../../utils/months";
 import SearchInput from "../../components/SearchInput";
 import SelectDataShow from "../../components/ui/SelectDataShow";
 
+const EXCLUDED_TB_NAMES = [
+  "Ayu Pinta Gabina Siregar",
+  "Elly Astutik",
+];
+
+const getCurrentWeek = () => {
+  const today = new Date();
+  const firstOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  const firstMonday = new Date(firstOfMonth);
+  firstMonday.setDate(
+    firstOfMonth.getDate() - ((firstOfMonth.getDay() + 6) % 7)
+  );
+  const diff = Math.floor((today - firstMonday) / (1000 * 60 * 60 * 24));
+  return Math.floor(diff / 7) + 1;
+};
+
 export default function PenugasanPage() {
   const { user } = useAuth();
   const canManage = [ROLES.ADMIN, ROLES.KETUA, ROLES.PIMPINAN].includes(
@@ -40,7 +56,7 @@ export default function PenugasanPage() {
     kegiatanId: "",
     pegawaiIds: [],
     deskripsi: "",
-    minggu: 1,
+    minggu: getCurrentWeek(),
     bulan: new Date().getMonth() + 1,
     tahun: new Date().getFullYear(),
   });
@@ -115,7 +131,7 @@ export default function PenugasanPage() {
       kegiatanId: "",
       pegawaiIds: [],
       deskripsi: "",
-      minggu: 1,
+      minggu: getCurrentWeek(),
       bulan: new Date().getMonth() + 1,
       tahun: new Date().getFullYear(),
     });
@@ -371,7 +387,10 @@ export default function PenugasanPage() {
                 menuPortalTarget={document.body}
                 options={users
                   .filter(
-                    (u) => u.role !== ROLES.ADMIN && u.role !== ROLES.PIMPINAN
+                    (u) =>
+                      u.role !== ROLES.ADMIN &&
+                      u.role !== ROLES.PIMPINAN &&
+                      !EXCLUDED_TB_NAMES.includes(u.nama)
                   )
                   .map((u) => ({ value: u.id, label: `${u.nama}` }))}
                 value={form.pegawaiIds
@@ -400,7 +419,9 @@ export default function PenugasanPage() {
                     pegawaiIds: users
                       .filter(
                         (u) =>
-                          u.role !== ROLES.ADMIN && u.role !== ROLES.PIMPINAN
+                          u.role !== ROLES.ADMIN &&
+                          u.role !== ROLES.PIMPINAN &&
+                          !EXCLUDED_TB_NAMES.includes(u.nama)
                       )
                       .map((u) => u.id),
                   })
@@ -431,7 +452,7 @@ export default function PenugasanPage() {
                   type="number"
                   value={form.minggu}
                   min="1"
-                  max="5"
+                  max="6"
                   onChange={(e) =>
                     setForm({ ...form, minggu: parseInt(e.target.value, 10) })
                   }


### PR DESCRIPTION
## Summary
- skip select-all for employees on tugas belajar
- add helper to auto-select current week in tugas form
- set max week to 6
- remove unused import causing lint failure

## Testing
- `npm test` in `api`
- `npm run lint` in `web`


------
https://chatgpt.com/codex/tasks/task_b_687875123804832bb5cde3663390a1da