### PR TITLE
Update seeding for random daily reports

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,5 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import { hashPassword } from "../src/common/hash";
+import { STATUS } from "../src/common/status.constants";
+import { getHolidays } from "../../web/src/utils/holidays";
 
 const prisma = new PrismaClient();
 
@@ -487,23 +489,45 @@ async function main() {
 
   if (penugasans.length) {
     const laporanRows: any[] = [];
+    const selesaiIds = new Set<number>();
+    const holidays = new Set(getHolidays(2025));
+
     for (const p of penugasans) {
       const info = months.find((m) => m.bulan === p.bulan);
       if (!info) continue;
       const start = 1 + (p.minggu - 1) * 7;
       const end = Math.min(start + 6, info.days);
+
       for (let d = start; d <= end; d++) {
         const date = new Date(Date.UTC(info.year, info.monthIndex, d));
+        const day = date.getDay();
+        const dateStr = date.toISOString().slice(0, 10);
+        if (day === 0 || day === 6 || holidays.has(dateStr)) continue;
+        if (Math.random() < 0.5) continue;
+
+        const status =
+          Math.random() < 0.5
+            ? STATUS.SEDANG_DIKERJAKAN
+            : STATUS.SELESAI_DIKERJAKAN;
+
+        if (status === STATUS.SELESAI_DIKERJAKAN) selesaiIds.add(p.id);
+
         laporanRows.push({
           penugasanId: p.id,
           pegawaiId: p.pegawaiId,
           tanggal: date.toISOString(),
-          status: "Belum Dikerjakan",
+          status,
         });
       }
     }
     if (laporanRows.length) {
       await prisma.laporanHarian.createMany({ data: laporanRows, skipDuplicates: true });
+    }
+    if (selesaiIds.size) {
+      await prisma.penugasan.updateMany({
+        where: { id: { in: Array.from(selesaiIds) } },
+        data: { status: STATUS.SELESAI_DIKERJAKAN },
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- generate daily reports only on weekdays that are not holidays
- randomly choose if a report is created and its status
- mark assignments finished when any report is finished

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6878be305cfc832bb5708143a1d4f104