### PR TITLE
Ensure unique Member entries

### DIFF
--- a/api/prisma/migrations/20250727000000_add_member_unique/migration.sql
+++ b/api/prisma/migrations/20250727000000_add_member_unique/migration.sql
@@ -1,0 +1,2 @@
+-- Add unique constraint on Member userId and teamId
+CREATE UNIQUE INDEX `Member_userId_teamId_key` ON `Member`(`userId`, `teamId`);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -35,6 +35,7 @@ model Member {
   is_leader Boolean
   user      User    @relation(fields: [userId], references: [id])
   team      Team    @relation(fields: [teamId], references: [id])
+  @@unique([userId, teamId])
 }
 
 model MasterKegiatan {

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -384,6 +384,7 @@ async function main() {
     }
   }
 
+  const memberRows: any[] = [];
   for (const u of rawUsers) {
     const role = roleMap[u.role] || "anggota";
     const user = await prisma.user.upsert({
@@ -400,14 +401,16 @@ async function main() {
 
     const teamId = teamMap.get(u.team);
     if (teamId) {
-      await prisma.member.create({
-        data: {
-          userId: user.id,
-          teamId,
-          is_leader: role !== "anggota",
-        },
+      memberRows.push({
+        userId: user.id,
+        teamId,
+        is_leader: role !== "anggota",
       });
     }
+  }
+
+  if (memberRows.length) {
+    await prisma.member.createMany({ data: memberRows, skipDuplicates: true });
   }
 
   // seed penugasan for June and July 2025


### PR DESCRIPTION
## Summary
- add a composite unique constraint on `(userId, teamId)` in Prisma schema
- update seed script to insert members via `createMany` with `skipDuplicates`
- add migration for the new Member index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6878bfad79b4832ba43754b21f1f0ea0