### PR TITLE
Refactor monthly monitoring average

### DIFF
--- a/api/test/monitoring.service.spec.ts
+++ b/api/test/monitoring.service.spec.ts
@@ -115,6 +115,37 @@ describe('MonitoringService aggregated', () => {
     ]);
   });
 
+  it('bulanan averages weekly progress', async () => {
+    const weekly = [
+      {
+        userId: 1,
+        nama: 'A',
+        weeks: [
+          { selesai: 1, total: 1, persen: 100 },
+          { selesai: 0, total: 1, persen: 0 },
+        ],
+      },
+      {
+        userId: 2,
+        nama: 'B',
+        weeks: [
+          { selesai: 1, total: 1, persen: 100 },
+          { selesai: 1, total: 1, persen: 100 },
+        ],
+      },
+    ];
+    const spy = jest
+      .spyOn(service, 'mingguanBulan')
+      .mockResolvedValue(weekly);
+
+    const res = await service.bulanan('2024');
+    expect(spy).toHaveBeenCalledTimes(12);
+    expect(res[0]).toEqual({ bulan: 'Januari', persen: 75 });
+
+    const resUser = await service.bulanan('2024', undefined, 1);
+    expect(resUser[0]).toEqual({ bulan: 'Januari', persen: 50 });
+  });
+
   it('bulananMatrix aggregates per month', async () => {
     prisma.penugasan.findMany.mockResolvedValue([
       {


### PR DESCRIPTION
## Summary
- calculate monthly progress based on weekly data
- add unit test for bulanan averaging logic

## Testing
- `npm --prefix api test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6878bfaf2910832b8ee567d70dcd8212