### PR TITLE
Fix holiday import for seed script

### DIFF
--- a/api/types/web-utils-holidays.d.ts
+++ b/api/types/web-utils-holidays.d.ts
@@ -1,0 +1,3 @@
+declare module "../../web/src/utils/holidays" {
+  export function getHolidays(year: number): string[];
+}


### PR DESCRIPTION
## Summary
- add a declaration for the holidays utility so TypeScript can resolve it
- load `getHolidays` with `require` in the seed script

## Testing
- `npm ci`
- `npm test`
- `npm run seed` *(fails at runtime because Prisma client wasn't generated, but TypeScript compilation succeeded)*

------
https://chatgpt.com/codex/tasks/task_b_6878be305cfc832bb5708143a1d4f104