### PR TITLE
Fix seed script status strings

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -436,7 +436,12 @@ async function main() {
       const info = months[i % months.length];
       const day = ((m.userId + i) % info.days) + 1;
       const date = new Date(Date.UTC(info.year, info.monthIndex, day));
-      const status = i === 0 ? "Belum" : i === 1 ? "Sedang Dikerjakan" : "Selesai Dikerjakan";
+      const status =
+        i === 0
+          ? STATUS.BELUM
+          : i === 1
+          ? STATUS.SEDANG_DIKERJAKAN
+          : STATUS.SELESAI_DIKERJAKAN;
       tambahanRows.push({
         nama: k.nama_kegiatan,
         tanggal: date.toISOString(),
@@ -475,7 +480,7 @@ async function main() {
             bulan: info.bulan,
             tahun: info.year,
             deskripsi: `Tugas ${k.nama_kegiatan}`,
-            status: "Belum",
+            status: STATUS.BELUM,
           });
         }
       }


### PR DESCRIPTION
## Summary
- use `STATUS` constants instead of raw strings in `seed.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687893705230832bbb4cb0d5e40760d0