### PR TITLE
Limit CORS via env variable

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -6,3 +6,4 @@ DB_NAME=semakin_6502
 # JWT secret for signing tokens (required)
 JWT_SECRET=your_jwt_secret_here
 JWT_EXPIRES_IN=1d
+CORS_ORIGIN=http://localhost:5173

--- a/api/README.md
+++ b/api/README.md
@@ -54,8 +54,11 @@ Buat file `.env` dan isi (nilai `JWT_SECRET` wajib diisi, server akan gagal star
 ```
 DATABASE_URL="mysql://root:password@localhost:3306/semakin_6502"
 JWT_SECRET="your_jwt_secret_here"  # wajib diisi
+CORS_ORIGIN="http://localhost:5173"   # asal domain yang diizinkan
 ```
 Jika `JWT_SECRET` tidak diatur, aplikasi akan langsung keluar dengan error.
+`CORS_ORIGIN` opsional, isi dengan satu atau beberapa origin (pisahkan koma)
+untuk membatasi akses CORS.
 
 4. **Setup database**
 ```bash

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -4,7 +4,13 @@ import { AppModule } from "./app.module";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.enableCors();
+
+  const origins = (process.env.CORS_ORIGIN || "")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  await app.enableCors(origins.length ? { origin: origins } : {});
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
   await app.listen(3000);
 }


### PR DESCRIPTION
## Summary
- limit API CORS to origins listed in `CORS_ORIGIN`
- document `CORS_ORIGIN` in README and `.env.example`

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878e8b1dba4832b83ab72c4dcc110e1