### PR TITLE
Implement typed request user

### DIFF
--- a/api/src/auth/jwt.strategy.ts
+++ b/api/src/auth/jwt.strategy.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { ExtractJwt, Strategy } from "passport-jwt";
+import { AuthRequestUser } from "../common/auth-request-user.interface";
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -12,7 +13,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: any) {
+  async validate(payload: any): Promise<AuthRequestUser> {
     return { userId: payload.sub, role: payload.role };
   }
 }

--- a/api/src/common/auth-request-user.interface.ts
+++ b/api/src/common/auth-request-user.interface.ts
@@ -1,0 +1,4 @@
+export interface AuthRequestUser {
+  userId: number;
+  role: import("./roles.constants").Role;
+}

--- a/api/src/kegiatan/master-kegiatan.controller.ts
+++ b/api/src/kegiatan/master-kegiatan.controller.ts
@@ -11,6 +11,7 @@ import {
   ParseIntPipe,
 } from "@nestjs/common";
 import { Request } from "express";
+import { AuthRequestUser } from "../common/auth-request-user.interface";
 import { MasterKegiatanService } from "./master-kegiatan.service";
 import { CreateMasterKegiatanDto } from "./dto/create-master-kegiatan.dto";
 import { UpdateMasterKegiatanDto } from "./dto/update-master-kegiatan.dto";
@@ -27,7 +28,7 @@ export class MasterKegiatanController {
     @Body() body: CreateMasterKegiatanDto,
     @Req() req: Request,
   ) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     return this.masterService.create(body, u.userId, u.role);
   }
 
@@ -48,13 +49,13 @@ export class MasterKegiatanController {
     @Body() body: UpdateMasterKegiatanDto,
     @Req() req: Request,
   ) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     return this.masterService.update(id, body, u.userId, u.role);
   }
 
   @Delete(":id")
   remove(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     return this.masterService.remove(id, u.userId, u.role);
   }
 }

--- a/api/src/kegiatan/penugasan.controller.ts
+++ b/api/src/kegiatan/penugasan.controller.ts
@@ -15,6 +15,7 @@ import { Request } from "express";
 import { PenugasanService } from "./penugasan.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
+import { AuthRequestUser } from "../common/auth-request-user.interface";
 import { AssignPenugasanDto } from "./dto/assign-penugasan.dto";
 import { AssignPenugasanBulkDto } from "./dto/assign-penugasan-bulk.dto";
 
@@ -25,13 +26,13 @@ export class PenugasanController {
 
   @Post()
   assign(@Body() body: AssignPenugasanDto, @Req() req: Request) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     return this.penugasanService.assign(body, u.userId, u.role);
   }
 
   @Post("bulk")
   assignBulk(@Body() body: AssignPenugasanBulkDto, @Req() req: Request) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     return this.penugasanService.assignBulk(body, u.userId, u.role);
   }
 
@@ -41,7 +42,7 @@ export class PenugasanController {
     @Query("bulan") bulan?: string,
     @Query("tahun") tahun?: string,
   ) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     const filter: any = {};
     if (bulan) filter.bulan = bulan;
     if (tahun) filter.tahun = parseInt(tahun, 10);
@@ -50,7 +51,7 @@ export class PenugasanController {
 
   @Get(":id")
   detail(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     return this.penugasanService.findOne(id, u.role, u.userId);
   }
 
@@ -60,13 +61,13 @@ export class PenugasanController {
     @Body() body: AssignPenugasanDto,
     @Req() req: Request,
   ) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     return this.penugasanService.update(id, body, u.userId, u.role);
   }
 
   @Delete(":id")
   remove(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     return this.penugasanService.remove(id, u.userId, u.role);
   }
 }

--- a/api/src/laporan/laporan.controller.ts
+++ b/api/src/laporan/laporan.controller.ts
@@ -17,6 +17,7 @@ import { LaporanService } from "./laporan.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { SubmitLaporanDto } from "./dto/submit-laporan.dto";
 import { UpdateLaporanDto } from "./dto/update-laporan.dto";
+import { AuthRequestUser } from "../common/auth-request-user.interface";
 
 @Controller("laporan-harian")
 @UseGuards(JwtAuthGuard)
@@ -25,7 +26,7 @@ export class LaporanController {
 
   @Post()
   submit(@Body() body: SubmitLaporanDto, @Req() req: Request) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     return this.laporanService.submit(body, u.userId, u.role);
   }
 
@@ -41,7 +42,7 @@ export class LaporanController {
 
   @Get("mine")
   myReports(@Req() req: Request) {
-    const userId = (req.user as any).userId;
+    const userId = (req.user as AuthRequestUser).userId;
     return this.laporanService.getByUser(userId);
   }
 
@@ -51,7 +52,7 @@ export class LaporanController {
     @Res() res: Response,
     @Query("format") format = "xlsx",
   ) {
-    const userId = (req.user as any).userId;
+    const userId = (req.user as AuthRequestUser).userId;
     const buf = await this.laporanService.export(userId, format);
     if (format === "pdf") {
       res.setHeader("Content-Type", "application/pdf");
@@ -75,13 +76,13 @@ export class LaporanController {
     @Body() body: UpdateLaporanDto,
     @Req() req: Request,
   ) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     return this.laporanService.update(id, body, u.userId, u.role);
   }
 
   @Delete(":id")
   remove(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
-    const u = req.user as any;
+    const u = req.user as AuthRequestUser;
     return this.laporanService.remove(id, u.userId, u.role);
   }
 }

--- a/api/src/laporan/tugas-tambahan.controller.ts
+++ b/api/src/laporan/tugas-tambahan.controller.ts
@@ -15,6 +15,7 @@ import { TambahanService } from "./tugas-tambahan.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { AddTambahanDto } from "./dto/add-tambahan.dto";
 import { UpdateTambahanDto } from "./dto/update-tambahan.dto";
+import { AuthRequestUser } from "../common/auth-request-user.interface";
 
 @Controller("tugas-tambahan")
 @UseGuards(JwtAuthGuard)
@@ -23,19 +24,19 @@ export class TambahanController {
 
   @Post()
   add(@Body() body: AddTambahanDto, @Req() req: Request) {
-    const userId = (req.user as any).userId;
+    const userId = (req.user as AuthRequestUser).userId;
     return this.tambahanService.add({ ...body, userId });
   }
 
   @Get()
   getByUser(@Req() req: Request) {
-    const userId = (req.user as any).userId;
+    const userId = (req.user as AuthRequestUser).userId;
     return this.tambahanService.getByUser(userId);
   }
 
   @Get(":id")
   detail(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
-    const userId = (req.user as any).userId;
+    const userId = (req.user as AuthRequestUser).userId;
     return this.tambahanService.getOne(id, userId);
   }
 
@@ -45,13 +46,13 @@ export class TambahanController {
     @Body() body: UpdateTambahanDto,
     @Req() req: Request,
   ) {
-    const userId = (req.user as any).userId;
+    const userId = (req.user as AuthRequestUser).userId;
     return this.tambahanService.update(id, body, userId);
   }
 
   @Delete(":id")
   remove(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
-    const userId = (req.user as any).userId;
+    const userId = (req.user as AuthRequestUser).userId;
     return this.tambahanService.remove(id, userId);
   }
 }

--- a/api/src/monitoring/monitoring.controller.ts
+++ b/api/src/monitoring/monitoring.controller.ts
@@ -13,6 +13,7 @@ import { RolesGuard } from "../common/guards/roles.guard";
 import { PrismaService } from "../prisma.service";
 import { Request } from "express";
 import { ROLES } from "../common/roles.constants";
+import { AuthRequestUser } from "../common/auth-request-user.interface";
 
 @Controller("monitoring")
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -32,7 +33,7 @@ export class MonitoringController {
     if (!tanggal) {
       throw new BadRequestException("query 'tanggal' diperlukan");
     }
-    const user = req?.user as any;
+    const user = req?.user as AuthRequestUser;
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
     let uId = userId ? parseInt(userId, 10) : undefined;
@@ -66,7 +67,7 @@ export class MonitoringController {
     if (!tanggal) {
       throw new BadRequestException("query 'tanggal' diperlukan");
     }
-    const user = req?.user as any;
+    const user = req?.user as AuthRequestUser;
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
@@ -91,7 +92,7 @@ export class MonitoringController {
     if (!tanggal) {
       throw new BadRequestException("query 'tanggal' diperlukan");
     }
-    const user = req?.user as any;
+    const user = req?.user as AuthRequestUser;
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
@@ -117,7 +118,7 @@ export class MonitoringController {
     if (!minggu) {
       throw new BadRequestException("query 'minggu' diperlukan");
     }
-    const user = req?.user as any;
+    const user = req?.user as AuthRequestUser;
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
     let uId = userId ? parseInt(userId, 10) : undefined;
@@ -151,7 +152,7 @@ export class MonitoringController {
     if (!minggu) {
       throw new BadRequestException("query 'minggu' diperlukan");
     }
-    const user = req?.user as any;
+    const user = req?.user as AuthRequestUser;
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
@@ -176,7 +177,7 @@ export class MonitoringController {
     if (!tanggal) {
       throw new BadRequestException("query 'tanggal' diperlukan");
     }
-    const user = req?.user as any;
+    const user = req?.user as AuthRequestUser;
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
@@ -202,7 +203,7 @@ export class MonitoringController {
     if (!year) {
       throw new BadRequestException("query 'year' diperlukan");
     }
-    const user = req?.user as any;
+    const user = req?.user as AuthRequestUser;
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
     let uId = userId ? parseInt(userId, 10) : undefined;
@@ -237,7 +238,7 @@ export class MonitoringController {
     if (!year) {
       throw new BadRequestException("query 'year' diperlukan");
     }
-    const user = req?.user as any;
+    const user = req?.user as AuthRequestUser;
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
@@ -262,7 +263,7 @@ export class MonitoringController {
     if (!year) {
       throw new BadRequestException("query 'year' diperlukan");
     }
-    const user = req?.user as any;
+    const user = req?.user as AuthRequestUser;
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 

--- a/api/src/teams/teams.controller.ts
+++ b/api/src/teams/teams.controller.ts
@@ -16,6 +16,7 @@ import { RolesGuard } from "../common/guards/roles.guard";
 import { Roles } from "../common/guards/roles.decorator";
 import { Request } from "express";
 import { ROLES } from "../common/roles.constants";
+import { AuthRequestUser } from "../common/auth-request-user.interface";
 
 @Controller("teams")
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -24,7 +25,7 @@ export class TeamsController {
 
   @Get()
   findAll(@Req() req: Request) {
-    const { user } = req as any;
+    const user = req.user as AuthRequestUser;
     if (user.role === ROLES.ADMIN) {
       return this.teamsService.findAll();
     }
@@ -33,7 +34,7 @@ export class TeamsController {
 
   @Get("member")
   findMemberTeams(@Req() req: Request) {
-    const { user } = req as any;
+    const user = req.user as AuthRequestUser;
     return this.teamsService.findByMember(user.userId);
   }
 


### PR DESCRIPTION
## Summary
- add `AuthRequestUser` interface for user objects on authenticated requests
- use `AuthRequestUser` instead of `any` in controllers and JWT strategy

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878e8b2f5d4832ba1563372444994ec