### PR TITLE
Add PORT config

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -3,6 +3,8 @@ DB_PORT=3306
 DB_USER=root
 DB_PASS=yourpassword
 DB_NAME=semakin_6502
+# Server port (optional, defaults to 3000)
+PORT=3000
 # JWT secret for signing tokens (required)
 JWT_SECRET=your_jwt_secret_here
 JWT_EXPIRES_IN=1d

--- a/api/README.md
+++ b/api/README.md
@@ -54,6 +54,7 @@ Buat file `.env` dan isi (nilai `JWT_SECRET` wajib diisi, server akan gagal star
 ```
 DATABASE_URL="mysql://root:password@localhost:3306/semakin_6502"
 JWT_SECRET="your_jwt_secret_here"  # wajib diisi
+PORT=3000  # opsional, default 3000
 ```
 Jika `JWT_SECRET` tidak diatur, aplikasi akan langsung keluar dengan error.
 
@@ -74,7 +75,7 @@ node prisma/seed.js
 npm run start:dev
 ```
 
-Server berjalan di: `http://localhost:3000`
+Server berjalan di: `http://localhost:${PORT}` (default 3000)
 
 ---
 

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -6,6 +6,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   await app.enableCors();
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
-  await app.listen(3000);
+  const port = process.env.PORT || 3000;
+  await app.listen(port);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- add optional PORT variable in `.env.example`
- use `process.env.PORT` in NestJS bootstrap
- document PORT usage in backend README

## Testing
- `npm test` in `api`
- `npm run lint` in `web`

------
https://chatgpt.com/codex/tasks/task_b_6878e8b51da0832bb1269eb3400facee