### PR TITLE
Add weekly assignment monitoring

### DIFF
--- a/web/src/components/dashboard/StatsSummary.jsx
+++ b/web/src/components/dashboard/StatsSummary.jsx
@@ -7,9 +7,11 @@ const StatsSummary = ({ weeklyData }) => {
   const today = weeklyData.detail?.find((d) => d.tanggal === todayStr) || {};
 
   const tugasHariIni = today.selesai || 0;
-  const tugasMingguIni = weeklyData.totalTugas || 0;
-  const selesai = weeklyData.totalSelesai || 0;
-  const belumSelesai = Math.max(tugasMingguIni - selesai, 0);
+  const pen = weeklyData.penugasan || {};
+  const tugasMingguIni = pen.total || 0;
+  const selesai = pen.selesai || 0;
+  const belumSelesai =
+    pen.belum !== undefined ? pen.belum : Math.max(tugasMingguIni - selesai, 0);
 
   const statStyle = "p-4 rounded-lg shadow text-center";
 

--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -70,12 +70,21 @@ const Dashboard = () => {
             .then((res) => res.data)
         );
 
-        const [dailyRes, weeklyArray, monthlyRes] = await Promise.all([
+        const tugasPromises = weekStarts.map((d) =>
+          axios
+            .get("/monitoring/penugasan/minggu", {
+              params: { minggu: formatISO(d), ...filters },
+            })
+            .then((res) => res.data)
+        );
+
+        const [dailyRes, weeklyArray, monthlyRes, tugasArray] = await Promise.all([
           axios.get("/monitoring/harian", { params: { tanggal, ...filters } }),
           Promise.all(weeklyPromises),
           axios.get("/monitoring/bulanan", {
             params: { year: String(year), ...filters },
           }),
+          Promise.all(tugasPromises),
         ]);
 
         const monthStart = new Date(year, month, 1);
@@ -106,6 +115,7 @@ const Dashboard = () => {
             totalSelesai,
             totalTugas,
             totalProgress,
+            penugasan: tugasArray[i],
           };
         });
 


### PR DESCRIPTION
## Summary
- show assignment counts for each week in dashboard
- support penugasanMinggu service and controller endpoint
- feed new weekly assignment data to dashboard stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6878f43df4f0832ba64bfa99429b810a