### PR TITLE
Implement penugasan weekly aggregation

### DIFF
--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -140,23 +140,19 @@ export class MonitoringService {
 
     for (let i = 0; i < MONTHS.length; i++) {
       const first = new Date(Date.UTC(yr, i, 1));
-      const weekly = await this.mingguanBulan(
+      const weeks = await this.penugasanBulan(
         first.toISOString().slice(0, 10),
         teamId,
+        userId,
       );
 
-      const users = weekly.filter((u) => !userId || u.userId === userId);
-      if (users.length === 0) {
+      if (weeks.length === 0) {
         results.push({ bulan: MONTHS[i], persen: 0 });
         continue;
       }
 
-      const avgPerUser = users.map((u) => {
-        const total = u.weeks.reduce((sum, w) => sum + w.persen, 0);
-        return u.weeks.length ? total / u.weeks.length : 0;
-      });
       const bulanAvg =
-        avgPerUser.reduce((sum, v) => sum + v, 0) / avgPerUser.length;
+        weeks.reduce((sum, w) => sum + w.persen, 0) / weeks.length;
       results.push({ bulan: MONTHS[i], persen: Math.round(bulanAvg) });
     }
 
@@ -385,6 +381,55 @@ export class MonitoringService {
     }
 
     return { total: tugas.length, selesai, belum };
+  }
+
+  async penugasanBulan(
+    tanggal: string,
+    teamId?: number,
+    userId?: number,
+  ) {
+    const base = new Date(tanggal);
+    if (isNaN(base.getTime()))
+      throw new BadRequestException("tanggal tidak valid");
+
+    const year = base.getFullYear();
+    const month = base.getMonth();
+
+    const monthStart = new Date(year, month, 1);
+    const monthEnd = new Date(year, month + 1, 0);
+
+    const firstMonday = new Date(monthStart);
+    firstMonday.setDate(monthStart.getDate() - ((monthStart.getDay() + 6) % 7));
+    const weekStarts: Date[] = [];
+    for (let d = new Date(firstMonday); d <= monthEnd; d.setDate(d.getDate() + 7)) {
+      weekStarts.push(new Date(d));
+    }
+
+    const where: any = {
+      tahun: year,
+      bulan: String(month + 1),
+    };
+    if (teamId) where.kegiatan = { teamId };
+    if (userId) where.pegawaiId = userId;
+
+    const tugas = await this.prisma.penugasan.findMany({
+      where,
+      select: { minggu: true, status: true },
+    });
+
+    const perWeek: Record<number, { selesai: number; total: number }> = {};
+    for (const t of tugas) {
+      const idx = t.minggu - 1;
+      if (!perWeek[idx]) perWeek[idx] = { selesai: 0, total: 0 };
+      perWeek[idx].total += 1;
+      if (t.status === STATUS.SELESAI_DIKERJAKAN) perWeek[idx].selesai += 1;
+    }
+
+    return weekStarts.map((_, i) => {
+      const w = perWeek[i] || { selesai: 0, total: 0 };
+      const persen = w.total ? Math.round((w.selesai / w.total) * 100) : 0;
+      return { minggu: i + 1, selesai: w.selesai, total: w.total, persen };
+    });
   }
 
   async bulananAll(year: string, teamId?: number, bulan?: string) {

--- a/api/test/monitoring.service.spec.ts
+++ b/api/test/monitoring.service.spec.ts
@@ -115,35 +115,44 @@ describe('MonitoringService aggregated', () => {
     ]);
   });
 
+  it('penugasanBulan aggregates per week', async () => {
+    prisma.penugasan.findMany.mockResolvedValue([
+      { minggu: 1, status: STATUS.SELESAI_DIKERJAKAN },
+      { minggu: 1, status: STATUS.BELUM },
+      { minggu: 3, status: STATUS.SELESAI_DIKERJAKAN },
+    ]);
+
+    const res = await service.penugasanBulan('2024-05-10');
+    expect(prisma.penugasan.findMany).toHaveBeenCalledWith({
+      where: { tahun: 2024, bulan: '5' },
+      select: { minggu: true, status: true },
+    });
+    const zero = { selesai: 0, total: 0, persen: 0 };
+    expect(res).toEqual([
+      { minggu: 1, selesai: 1, total: 2, persen: 50 },
+      { minggu: 2, ...zero },
+      { minggu: 3, selesai: 1, total: 1, persen: 100 },
+      { minggu: 4, ...zero },
+      { minggu: 5, ...zero },
+    ]);
+  });
+
   it('bulanan averages weekly progress', async () => {
-    const weekly = [
-      {
-        userId: 1,
-        nama: 'A',
-        weeks: [
-          { selesai: 1, total: 1, persen: 100 },
-          { selesai: 0, total: 1, persen: 0 },
-        ],
-      },
-      {
-        userId: 2,
-        nama: 'B',
-        weeks: [
-          { selesai: 1, total: 1, persen: 100 },
-          { selesai: 1, total: 1, persen: 100 },
-        ],
-      },
+    const weeks = [
+      { minggu: 1, selesai: 1, total: 1, persen: 100 },
+      { minggu: 2, selesai: 0, total: 1, persen: 0 },
+      { minggu: 3, selesai: 1, total: 1, persen: 100 },
     ];
     const spy = jest
-      .spyOn(service, 'mingguanBulan')
-      .mockResolvedValue(weekly);
+      .spyOn(service, 'penugasanBulan')
+      .mockResolvedValue(weeks);
 
     const res = await service.bulanan('2024');
     expect(spy).toHaveBeenCalledTimes(12);
-    expect(res[0]).toEqual({ bulan: 'Januari', persen: 75 });
+    expect(res[0]).toEqual({ bulan: 'Januari', persen: 67 });
 
     const resUser = await service.bulanan('2024', undefined, 1);
-    expect(resUser[0]).toEqual({ bulan: 'Januari', persen: 50 });
+    expect(resUser[0]).toEqual({ bulan: 'Januari', persen: 67 });
   });
 
   it('bulananMatrix aggregates per month', async () => {


### PR DESCRIPTION
## Summary
- aggregate weekly counts of `Penugasan` for a given month
- compute monthly progress from these weekly values
- adjust monitoring tests to cover new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6878faae43ac832bb9a0e50841a8fb35