### PR TITLE
Expose holidays util to frontend

### DIFF
--- a/web/src/components/dashboard/DailyOverview.jsx
+++ b/web/src/components/dashboard/DailyOverview.jsx
@@ -1,4 +1,4 @@
-import { getHolidays } from "../../../../api/src/utils/holidays";
+import { getHolidays } from "../../utils/holidays";
 import Legend from "../ui/Legend";
 
 const DailyOverview = ({ data = [] }) => {

--- a/web/src/pages/monitoring/DailyMatrix.jsx
+++ b/web/src/pages/monitoring/DailyMatrix.jsx
@@ -1,4 +1,4 @@
-import { getHolidays } from "../../../../api/src/utils/holidays";
+import { getHolidays } from "../../utils/holidays";
 
 export const DailyMatrixRow = ({ user, boxClass, style }) => (
   <tr className="text-center" style={style}>

--- a/web/src/utils/holidays.js
+++ b/web/src/utils/holidays.js
@@ -1,0 +1,13 @@
+export const getHolidays = (year) => [
+  `${year}-01-01`,
+  `${year}-02-10`,
+  `${year}-03-28`,
+  `${year}-03-29`,
+  `${year}-05-01`,
+  `${year}-05-02`,
+  `${year}-08-17`,
+  `${year}-12-25`,
+  `${year}-12-26`,
+];
+
+export default getHolidays;


### PR DESCRIPTION
## Summary
- copy `getHolidays` utility into the web project
- update imports in dashboard and monitoring components

## Testing
- `npm run lint` in `web`
- `npm test` in `api`


------
https://chatgpt.com/codex/tasks/task_b_6878fab086a8832ba0928adf8005b58f