### PR TITLE
Remove unused weekly data state

### DIFF
--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -24,7 +24,6 @@ export default function MonitoringPage() {
   const [year, setYear] = useState(new Date().getFullYear());
 
   const [dailyData, setDailyData] = useState([]);
-  const [setWeeklyData] = useState([]);
   const [weeklyMonthData, setWeeklyMonthData] = useState([]);
   const [monthlyData, setMonthlyData] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -190,10 +189,9 @@ export default function MonitoringPage() {
       try {
         setLoading(true);
         const minggu = weekStarts[weekIndex].toISOString().slice(0, 10);
-        const res = await axios.get("/monitoring/mingguan/all", {
+        await axios.get("/monitoring/mingguan/all", {
           params: { minggu, teamId: teamId || undefined },
         });
-        setWeeklyData(mergeProgressWithUsers(res.data));
       } catch (err) {
         console.error(err);
       } finally {


### PR DESCRIPTION
## Summary
- clean up `MonitoringPage` by removing unused weekly data state and setter
- update the weekly fetch to avoid unused variable warnings

## Testing
- `npm test` within `api`
- `npm run lint` within `web`
- `npm run lint` within `api` *(fails: parserOptions project not found)*

------
https://chatgpt.com/codex/tasks/task_b_68790084ad60832b9ee91991b9dcbc02