### PR TITLE
Update harianBulan counts

### DIFF
--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -192,22 +192,29 @@ export class MonitoringService {
       include: { pegawai: true },
     });
 
-    const byUser: Record<number, { nama: string; dates: Set<string> }> = {};
+    const byUser: Record<
+      number,
+      { nama: string; counts: Record<string, number> }
+    > = {};
     for (const r of records) {
       const dateStr = r.tanggal.toISOString().slice(0, 10);
       if (!byUser[r.pegawaiId])
-        byUser[r.pegawaiId] = { nama: r.pegawai.nama, dates: new Set() };
-      byUser[r.pegawaiId].dates.add(dateStr);
+        byUser[r.pegawaiId] = { nama: r.pegawai.nama, counts: {} };
+      byUser[r.pegawaiId].counts[dateStr] =
+        (byUser[r.pegawaiId].counts[dateStr] || 0) + 1;
     }
 
     return Object.entries(byUser)
       .map(([id, v]) => {
-        const detail = [] as { tanggal: string; adaKegiatan: boolean }[];
+        const detail = [] as { tanggal: string; count: number }[];
         for (let d = 1; d <= end.getDate(); d++) {
           const dateStr = `${year}-${String(month + 1).padStart(2, "0")}-${String(
             d,
           ).padStart(2, "0")}`;
-          detail.push({ tanggal: dateStr, adaKegiatan: v.dates.has(dateStr) });
+          detail.push({
+            tanggal: dateStr,
+            count: v.counts[dateStr] || 0,
+          });
         }
         return { userId: Number(id), nama: v.nama, detail };
       })

--- a/api/test/monitoring.service.spec.ts
+++ b/api/test/monitoring.service.spec.ts
@@ -79,16 +79,17 @@ describe('MonitoringService aggregated', () => {
     ]);
   });
 
-  it('harianBulan groups by user and marks days', async () => {
+  it('harianBulan groups by user and counts records', async () => {
     prisma.laporanHarian.findMany.mockResolvedValue([
+      { pegawaiId: 1, tanggal: new Date('2024-05-02'), pegawai: { nama: 'A' } },
       { pegawaiId: 1, tanggal: new Date('2024-05-02'), pegawai: { nama: 'A' } },
       { pegawaiId: 2, tanggal: new Date('2024-05-01'), pegawai: { nama: 'B' } },
     ]);
     const res = await service.harianBulan('2024-05-10');
     expect(res.map((u) => u.nama)).toEqual(['A', 'B']);
     expect(res[0].detail.length).toBe(31);
-    expect(res[0].detail[1]).toEqual({ tanggal: '2024-05-02', adaKegiatan: true });
-    expect(res[1].detail[0]).toEqual({ tanggal: '2024-05-01', adaKegiatan: true });
+    expect(res[0].detail[1]).toEqual({ tanggal: '2024-05-02', count: 2 });
+    expect(res[1].detail[0]).toEqual({ tanggal: '2024-05-01', count: 1 });
   });
 
   it('mingguanBulan aggregates per week', async () => {

--- a/web/src/pages/monitoring/DailyMatrix.jsx
+++ b/web/src/pages/monitoring/DailyMatrix.jsx
@@ -4,7 +4,7 @@ export const DailyMatrixRow = ({ user, boxClass, style }) => (
   <tr className="text-center" style={style}>
     <td className="p-2 border text-left whitespace-nowrap text-sm">{user.nama}</td>
     {user.detail.map((day, i) => (
-      <td key={i} className={`p-1 border ${boxClass(day)}`}></td>
+      <td key={i} className={`p-1 border ${boxClass(day)}`}>{day.count || ""}</td>
     ))}
   </tr>
 );
@@ -25,7 +25,7 @@ const DailyMatrix = ({ data = [] }) => {
   const isHoliday = (iso) => HOLIDAYS.includes(iso);
 
   const boxClass = (day) => {
-    if (day.adaKegiatan) {
+    if (day.count > 0) {
       return "bg-green-200 border-green-400 dark:bg-green-700 dark:border-green-500";
     }
     if (isWeekend(day.tanggal) || isHoliday(day.tanggal)) {


### PR DESCRIPTION
## Summary
- compute daily counts per user in `harianBulan`
- display the count inside daily matrix boxes
- update unit test expectations for the new `count` field

## Testing
- `npm --prefix api test` *(fails: Property 'laporanHarian' does not exist on type 'PrismaService')*

------
https://chatgpt.com/codex/tasks/task_b_68790087debc832baedce65e8bae4dbd