### PR TITLE
Fix daily report admin view

### DIFF
--- a/api/src/laporan/laporan.controller.ts
+++ b/api/src/laporan/laporan.controller.ts
@@ -24,6 +24,11 @@ import { AuthRequestUser } from "../common/auth-request-user.interface";
 export class LaporanController {
   constructor(private readonly laporanService: LaporanService) {}
 
+  @Get('all')
+  getAll() {
+    return this.laporanService.getAll();
+  }
+
   @Post()
   submit(@Body() body: SubmitLaporanDto, @Req() req: Request) {
     const u = req.user as AuthRequestUser;

--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -14,6 +14,16 @@ import { STATUS } from "../common/status.constants";
 export class LaporanService {
   constructor(private prisma: PrismaService) {}
 
+  getAll() {
+    return this.prisma.laporanHarian.findMany({
+      orderBy: { tanggal: 'desc' },
+      include: {
+        pegawai: true,
+        penugasan: { include: { kegiatan: true } },
+      },
+    });
+  }
+
   private async syncPenugasanStatus(penugasanId: number) {
     const latest = await this.prisma.laporanHarian.findFirst({
       where: { penugasanId },


### PR DESCRIPTION
## Summary
- add service and controller method to fetch all daily reports
- show all reports for admin in Laporan Harian page

## Testing
- `npm test` in `api`

------
https://chatgpt.com/codex/tasks/task_b_6878fda8ed60832b813b169222cc8a82