### PR TITLE
Fix duplicate dependency

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -31,8 +31,7 @@
     "passport-jwt": "^4.0.1",
     "pdfkit": "^0.15.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.0",
-    "cookie-parser": "^1.4.6"
+    "rxjs": "^7.8.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",


### PR DESCRIPTION
## Summary
- remove redundant `cookie-parser` declaration
- run `npm install` to keep lockfile in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68798832af10832bb0130066a6a3169f