### PR TITLE
Remove unused react-window dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,7 +18,6 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
         "react-select": "^5.10.2",
-        "react-window": "^1.8.11",
         "sweetalert2": "10.16.9"
       },
       "devDependencies": {
@@ -4466,29 +4465,6 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
-    },
-    "node_modules/react-window": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
-      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": ">=3.1.1 <6"
-      },
-      "engines": {
-        "node": ">8.0.0"
-      },
-      "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/react-window/node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "license": "MIT"
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,6 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
     "react-select": "^5.10.2",
-    "react-window": "^1.8.11",
     "sweetalert2": "10.16.9"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove `react-window` from the web dependencies
- regenerate lockfile without `react-window`

## Testing
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: Parsing error in eslint.config.js)*
- `npm test` in `api`


------
https://chatgpt.com/codex/tasks/task_b_68798834f71c832b9fd30553fa2cfb28