### PR TITLE
Add sorting and selection to DataTable

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -54,6 +54,8 @@ located in `src/components/ui`. It provides:
 - Global search across all columns
 - Optional per-column filters
 - Built-in pagination with a page size selector
+- Column sorting with visual indicators
+- Optional row selection with checkboxes
 
 Example usage:
 
@@ -67,3 +69,8 @@ const columns = [
 
 <DataTable columns={columns} data={data} />;
 ```
+
+### Additional Props
+
+- `initialSorting` – array of sorting rules, e.g. `[{ id: 'name', desc: true }]`
+- `onRowSelectionChange` – callback receiving the current row selection state

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -159,6 +159,7 @@ export default function TeamsPage() {
         <DataTable
           columns={columns}
           data={teams}
+          initialSorting={[{ id: "nama_tim", desc: false }]}
         />
       )}
 

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -24,6 +24,7 @@ export default function UsersPage() {
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editingUser, setEditingUser] = useState(null);
+  const [_rowSelection, setRowSelection] = useState({});
   const [form, setForm] = useState({
     nama: "",
     email: "",
@@ -187,7 +188,12 @@ export default function UsersPage() {
           <Spinner className="h-6 w-6 mx-auto" />
         </div>
       ) : (
-        <DataTable columns={columns} data={users} />
+        <DataTable
+          columns={columns}
+          data={users}
+          initialSorting={[{ id: "nama", desc: false }]}
+          onRowSelectionChange={setRowSelection}
+        />
       )}
 
       {showForm && (


### PR DESCRIPTION
## Summary
- enhance DataTable with sorting and row selection capabilities
- show sort indicators and add checkbox column
- configure TeamsPage and UsersPage to use initial sorting
- document new DataTable props and features

## Testing
- `npm run lint` within `web`
- `npm test --silent` within `api`

------
https://chatgpt.com/codex/tasks/task_b_6879ae0d6b04832b82f201f63c634b8c