### PR TITLE
Add table cell/row utilities

### DIFF
--- a/web/src/components/ui/DataTable.jsx
+++ b/web/src/components/ui/DataTable.jsx
@@ -195,10 +195,7 @@ export default function DataTable({
             </tr>
           ) : (
             table.getRowModel().rows.map((row) => (
-              <tr
-                key={row.id}
-                className={`${tableStyles.row} border-t dark:border-gray-700 text-center`}
-              >
+              <tr key={row.id} className={tableStyles.row}>
                 {row.getVisibleCells().map((cell) => (
                   <td key={cell.id} className={tableStyles.cell}>
                     {flexRender(

--- a/web/src/components/ui/Table.module.css
+++ b/web/src/components/ui/Table.module.css
@@ -6,6 +6,20 @@
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
+.headerRow {
+  background-color: var(--th-bg);
+}
+
+.row {
+  text-align: center;
+}
+
+.cell {
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
+}
+
 :root {
   /* Default theme (dark root) */
   --table-bg: #111827;

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -198,10 +198,7 @@ export default function LaporanHarianPage() {
                 </tr>
               ) : (
                 paginated.map((item, idx) => (
-                  <tr
-                    key={item.id}
-                    className={`${tableStyles.row} border-t dark:border-gray-700 text-center`}
-                  >
+                  <tr key={item.id} className={tableStyles.row}>
                     <td className={tableStyles.cell}>
                       {(currentPage - 1) * pageSize + idx + 1}
                     </td>

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -205,10 +205,7 @@ export default function MasterKegiatanPage() {
             </tr>
           ) : (
             items.map((item, idx) => (
-              <tr
-                key={item.id}
-                className={`${tableStyles.row} border-t dark:border-gray-700 text-center`}
-              >
+              <tr key={item.id} className={tableStyles.row}>
                 <td className={tableStyles.cell}>
                   {(page - 1) * perPage + idx + 1}
                 </td>

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -504,10 +504,7 @@ export default function PenugasanDetailPage() {
                 </tr>
               ) : (
                 laporan.map((l, idx) => (
-                  <tr
-                    key={l.id}
-                    className={`${tableStyles.row} border-t dark:border-gray-700 text-center`}
-                  >
+                  <tr key={l.id} className={tableStyles.row}>
                     <td className={tableStyles.cell}>{idx + 1}</td>
                     <td className={tableStyles.cell}>{l.deskripsi}</td>
                     <td className={tableStyles.cell}>{formatDMY(l.tanggal)}</td>

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -206,14 +206,14 @@ export default function PenugasanPage() {
       <Table>
         <thead>
           <tr className={tableStyles.headerRow}>
-            <th className="px-1 py-1 sm:px-2 sm:py-2">No</th>
+            <th className={tableStyles.cell}>No</th>
             <th className={tableStyles.cell}>Kegiatan</th>
             <th className={tableStyles.cell}>Tim</th>
             <th className={tableStyles.cell}>Pegawai</th>
             <th className={tableStyles.cell}>Minggu</th>
             <th className={tableStyles.cell}>Bulan</th>
             <th className={tableStyles.cell}>Status</th>
-            <th className="px-1 py-1 sm:px-2 sm:py-2">Aksi</th>
+            <th className={tableStyles.cell}>Aksi</th>
           </tr>
         </thead>
         <tbody>
@@ -269,11 +269,8 @@ export default function PenugasanPage() {
             </tr>
           ) : (
             paginated.map((p, idx) => (
-              <tr
-                key={p.id}
-                className={`${tableStyles.row} border-t dark:border-gray-700 text-center`}
-              >
-                <td className="px-1 py-1 sm:px-2 sm:py-2">
+              <tr key={p.id} className={tableStyles.row}>
+                <td className={tableStyles.cell}>
                   {(currentPage - 1) * pageSize + idx + 1}
                 </td>
                 <td className={tableStyles.cell}>
@@ -290,7 +287,7 @@ export default function PenugasanPage() {
                 <td className={tableStyles.cell}>
                   <StatusBadge status={p.status} />
                 </td>
-                <td className="px-1 py-1 sm:px-2 sm:py-2">
+                <td className={tableStyles.cell}>
                   <Button
                     onClick={() => navigate(`/tugas-mingguan/${p.id}`)}
                     variant="icon"

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -248,10 +248,7 @@ export default function TugasTambahanPage() {
             </tr>
           ) : (
             paginatedItems.map((item, idx) => (
-              <tr
-                key={item.id}
-                className={`${tableStyles.row} border-t dark:border-gray-700 text-center`}
-              >
+              <tr key={item.id} className={tableStyles.row}>
                 <td className={tableStyles.cell}>
                   {(currentPage - 1) * pageSize + idx + 1}
                 </td>

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -155,10 +155,7 @@ export default function TeamsPage() {
             </tr>
           ) : (
             paginated.map((t, idx) => (
-              <tr
-                key={t.id}
-                className={`${tableStyles.row} border-t dark:border-gray-700 text-center`}
-              >
+              <tr key={t.id} className={tableStyles.row}>
                 <td className={tableStyles.cell}>
                   {(currentPage - 1) * pageSize + idx + 1}
                 </td>

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -198,10 +198,7 @@ export default function UsersPage() {
             </tr>
           ) : (
             paginated.map((u, idx) => (
-              <tr
-                key={u.id}
-                className={`${tableStyles.row} border-t dark:border-gray-700 text-center`}
-              >
+              <tr key={u.id} className={tableStyles.row}>
                 <td className={tableStyles.cell}>
                   {(currentPage - 1) * pageSize + idx + 1}
                 </td>


### PR DESCRIPTION
## Summary
- add `.headerRow`, `.row` and `.cell` styles for tables
- clean up table markup across pages to use those classes

## Testing
- `npm test` in `api`
- `npm run lint` *(fails: Parsing error and unused vars)*
- `npm run lint` in `web` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_b_6879c3553c84832ba9b3c8d70aa552fc