### PR TITLE
Add status formatter helper and use across UI

### DIFF
--- a/web/src/components/ui/StatusBadge.jsx
+++ b/web/src/components/ui/StatusBadge.jsx
@@ -1,4 +1,4 @@
-import { STATUS } from "../../utils/status";
+import { STATUS, formatStatus } from "../../utils/status";
 
 const colorMap = {
   [STATUS.BELUM]: "bg-red-500 text-gray-100 dark:bg-red-600 dark:text-gray-100",
@@ -14,7 +14,7 @@ export default function StatusBadge({ status }) {
     "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200";
   return (
     <span className={`px-2 py-0.5 rounded text-xs font-medium ${cls}`}>
-      {status}
+      {formatStatus(status)}
     </span>
   );
 }

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 import { Pencil, Trash2, ExternalLink, X } from "lucide-react";
-import { showSuccess, showError, confirmDelete } from "../../utils/alerts";
+import { showSuccess, showError } from "../../utils/alerts";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
@@ -9,7 +9,7 @@ import tableStyles from "../../components/ui/Table.module.css";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
-import { STATUS } from "../../utils/status";
+import { STATUS, formatStatus } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
 import SearchInput from "../../components/SearchInput";
 import SelectDataShow from "../../components/ui/SelectDataShow";
@@ -52,17 +52,6 @@ export default function LaporanHarianPage() {
     }
   };
 
-  const openEdit = (item) => {
-    setForm({
-      id: item.id,
-      tanggal: item.tanggal.slice(0, 10),
-      deskripsi: item.deskripsi || "",
-      status: item.status,
-      bukti_link: item.bukti_link || "",
-      catatan: item.catatan || "",
-    });
-    setShowForm(true);
-  };
 
   const saveForm = async () => {
     try {
@@ -78,18 +67,6 @@ export default function LaporanHarianPage() {
     }
   };
 
-  const remove = async (id) => {
-    const r = await confirmDelete("Hapus laporan ini?");
-    if (!r.isConfirmed) return;
-    try {
-      await axios.delete(`/laporan-harian/${id}`);
-      fetchData();
-      showSuccess("Dihapus", "Laporan dihapus");
-    } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal menghapus");
-    }
-  };
 
   useEffect(() => {
     if (user) fetchData();
@@ -303,12 +280,12 @@ export default function LaporanHarianPage() {
                 onChange={(e) => setForm({ ...form, status: e.target.value })}
                 className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
               >
-                <option value={STATUS.BELUM}>{STATUS.BELUM}</option>
+                <option value={STATUS.BELUM}>{formatStatus(STATUS.BELUM)}</option>
                 <option value={STATUS.SEDANG_DIKERJAKAN}>
-                  {STATUS.SEDANG_DIKERJAKAN}
+                  {formatStatus(STATUS.SEDANG_DIKERJAKAN)}
                 </option>
                 <option value={STATUS.SELESAI_DIKERJAKAN}>
-                  {STATUS.SELESAI_DIKERJAKAN}
+                  {formatStatus(STATUS.SELESAI_DIKERJAKAN)}
                 </option>
               </select>
             </div>

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -13,7 +13,7 @@ import selectStyles from "../../utils/selectStyles";
 import { Pencil, Trash2, Plus, ExternalLink } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
-import { STATUS } from "../../utils/status";
+import { STATUS, formatStatus } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
@@ -627,12 +627,12 @@ export default function PenugasanDetailPage() {
                   required
                   className="w-full mt-1 rounded-md border px-4 py-2 bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
-                  <option value={STATUS.BELUM}>{STATUS.BELUM}</option>
+                  <option value={STATUS.BELUM}>{formatStatus(STATUS.BELUM)}</option>
                   <option value={STATUS.SEDANG_DIKERJAKAN}>
-                    {STATUS.SEDANG_DIKERJAKAN}
+                    {formatStatus(STATUS.SEDANG_DIKERJAKAN)}
                   </option>
                   <option value={STATUS.SELESAI_DIKERJAKAN}>
-                    {STATUS.SELESAI_DIKERJAKAN}
+                    {formatStatus(STATUS.SELESAI_DIKERJAKAN)}
                   </option>
                 </select>
               </div>

--- a/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
@@ -10,7 +10,7 @@ import {
 import { Pencil, Trash2 } from "lucide-react";
 import Select from "react-select";
 import selectStyles from "../../utils/selectStyles";
-import { STATUS } from "../../utils/status";
+import { STATUS, formatStatus } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
@@ -235,12 +235,12 @@ export default function TugasTambahanDetailPage() {
               onChange={(e) => setForm({ ...form, status: e.target.value })}
               className="w-full border rounded px-3 py-2 bg-white dark:bg-gray-700"
             >
-              <option value={STATUS.BELUM}>{STATUS.BELUM}</option>
+              <option value={STATUS.BELUM}>{formatStatus(STATUS.BELUM)}</option>
               <option value={STATUS.SEDANG_DIKERJAKAN}>
-                {STATUS.SEDANG_DIKERJAKAN}
+                {formatStatus(STATUS.SEDANG_DIKERJAKAN)}
               </option>
               <option value={STATUS.SELESAI_DIKERJAKAN}>
-                {STATUS.SELESAI_DIKERJAKAN}
+                {formatStatus(STATUS.SELESAI_DIKERJAKAN)}
               </option>
             </select>
           </div>

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -10,7 +10,7 @@ import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
 import MonthYearPicker from "../../components/ui/MonthYearPicker";
 import Select from "react-select";
-import { STATUS } from "../../utils/status";
+import { STATUS, formatStatus } from "../../utils/status";
 import Modal from "../../components/ui/Modal";
 import StatusBadge from "../../components/ui/StatusBadge";
 import SearchInput from "../../components/SearchInput";
@@ -448,12 +448,12 @@ export default function TugasTambahanPage() {
             focus:outline-none focus:ring-2 focus:ring-blue-500 
             shadow-sm transition duration-150 ease-in-out"
               >
-                <option value={STATUS.BELUM}>{STATUS.BELUM}</option>
+                <option value={STATUS.BELUM}>{formatStatus(STATUS.BELUM)}</option>
                 <option value={STATUS.SEDANG_DIKERJAKAN}>
-                  {STATUS.SEDANG_DIKERJAKAN}
+                  {formatStatus(STATUS.SEDANG_DIKERJAKAN)}
                 </option>
                 <option value={STATUS.SELESAI_DIKERJAKAN}>
-                  {STATUS.SELESAI_DIKERJAKAN}
+                  {formatStatus(STATUS.SELESAI_DIKERJAKAN)}
                 </option>
               </select>
             </div>

--- a/web/src/utils/status.js
+++ b/web/src/utils/status.js
@@ -4,4 +4,14 @@ export const STATUS = {
   SELESAI_DIKERJAKAN: "Selesai Dikerjakan",
 };
 
+export const STATUS_LABELS = {
+  [STATUS.BELUM]: "Belum",
+  [STATUS.SEDANG_DIKERJAKAN]: "Sedang",
+  [STATUS.SELESAI_DIKERJAKAN]: "Selesai",
+};
+
+export function formatStatus(status) {
+  return STATUS_LABELS[status] || status;
+}
+
 export default STATUS;


### PR DESCRIPTION
## Summary
- add `formatStatus` helper to shorten status labels
- show formatted status text in `StatusBadge`
- use `formatStatus` for status dropdown options
- clean up unused functions in `LaporanHarianPage`

## Testing
- `npm run lint` in `web`
- `npm test` in `api`


------
https://chatgpt.com/codex/tasks/task_b_6879c35afaa0832b9d3f9a9438de0c79