### PR TITLE
Add column filter visibility prop

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -76,3 +76,4 @@ const columns = [
 - `onRowSelectionChange` – callback receiving the current row selection state
 - `showPagination` – toggle built-in pagination controls
 - `selectable` – include checkbox column for row selection
+- `showColumnFilters` – toggle per-column filter inputs

--- a/web/src/components/ui/DataTable.jsx
+++ b/web/src/components/ui/DataTable.jsx
@@ -68,6 +68,7 @@ export default function DataTable({
   data,
   initialPageSize = 10,
   showGlobalFilter = true,
+  showColumnFilters = true,
   initialSorting = [],
   onRowSelectionChange,
   showPagination = true,
@@ -171,18 +172,23 @@ export default function DataTable({
                         <ArrowUpDown size={12} className="text-gray-400" />
                       ))}
                   </div>
-                  {header.column.getCanFilter() && (
-                    <div className="mt-1" onClick={(e) => e.stopPropagation()}>
-                      {(() => {
-                        const FilterComp = header.column.columnDef.meta?.Filter;
-                        return FilterComp ? (
-                          <FilterComp column={header.column} />
-                        ) : (
-                          <DefaultColumnFilter column={header.column} />
-                        );
-                      })()}
-                    </div>
-                  )}
+                  {showColumnFilters &&
+                    header.column.getCanFilter() && (
+                      <div
+                        className="mt-1"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {(() => {
+                          const FilterComp =
+                            header.column.columnDef.meta?.Filter;
+                          return FilterComp ? (
+                            <FilterComp column={header.column} />
+                          ) : (
+                            <DefaultColumnFilter column={header.column} />
+                          );
+                        })()}
+                      </div>
+                    )}
                 </th>
               ))}
             </tr>

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -222,6 +222,7 @@ export default function UsersPage() {
           columns={columns}
           data={paginated}
           showGlobalFilter={false}
+          showColumnFilters={false}
           showPagination={false}
           selectable={false}
         />


### PR DESCRIPTION
## Summary
- add `showColumnFilters` prop to `DataTable`
- hide column filter inputs based on the prop
- document `showColumnFilters` in README
- disable column filters in `UsersPage`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6879cd63ddc0832ba1e36f95bd448236