### PR TITLE
Fix DataTable cell rendering

### DIFF
--- a/web/src/components/ui/DataTable.jsx
+++ b/web/src/components/ui/DataTable.jsx
@@ -204,7 +204,7 @@ export default function DataTable({
                 {row.getVisibleCells().map((cell) => (
                   <td key={cell.id} className={tableStyles.cell}>
                     {flexRender(
-                      cell.column.columnDef.cell || cell.column.columnDef.header,
+                      cell.column.columnDef.cell,
                       cell.getContext()
                     )}
                   </td>


### PR DESCRIPTION
## Summary
- render row cells using their `cell` renderer without fallback to header

## Testing
- `npm run lint` in `web`
- `npm test` in `api`
- `npm run lint` in `api` *(fails: parserOptions.project not found)*

------
https://chatgpt.com/codex/tasks/task_b_6879cd5e2590832ba2931e107ab49e9e