### PR TITLE
Add documentation for showColumnFilters option

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -76,3 +76,4 @@ const columns = [
 - `onRowSelectionChange` – callback receiving the current row selection state
 - `showPagination` – toggle built-in pagination controls
 - `selectable` – include checkbox column for row selection
+- `showColumnFilters` – whether to display per-column filter dropdowns (default `true`); disabling it hides the filters


### PR DESCRIPTION
## Summary
- document new `showColumnFilters` option in the DataTable docs

## Testing
- `npm test` within `api`
- `npm run lint` within `web`


------
https://chatgpt.com/codex/tasks/task_b_6879cd65b7c8832ba50d5f259716bf28