### PR TITLE
Fix ESLint prefer-const in monitoring

### DIFF
--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -107,10 +107,10 @@ export class MonitoringService {
       persen: number;
     }[];
 
-    let totalSelesai = tugas.filter(
+    const totalSelesai = tugas.filter(
       (t: { status: string }) => t.status === STATUS.SELESAI_DIKERJAKAN,
     ).length;
-    let totalTugas = tugas.length;
+    const totalTugas = tugas.length;
     for (let i = 0; i < 7; i++) {
       const d = new Date(start);
       d.setDate(start.getDate() + i);


### PR DESCRIPTION
## Summary
- convert `totalSelesai` and `totalTugas` from `let` to `const`

## Testing
- `npx eslint src/monitoring/monitoring.service.ts`


------
https://chatgpt.com/codex/tasks/task_b_6879d0ebe200832b8e67d29c920742db