### PR TITLE
docs: note npm install before linting

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -11,6 +11,17 @@ Currently, two official plugins are available:
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
 
+## Linting
+
+Install dependencies before running ESLint:
+
+```bash
+npm install
+npm run lint
+```
+
+The lint script relies on dev dependencies installed by `npm install`.
+
 ## Environment Variables
 
 Create a `.env` file based on `.env.example` and set the API base URL used by axios:


### PR DESCRIPTION
## Summary
- document that linting requires dev dependencies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6879d0ebfc7c832b8a690d90eca1c3ea