### PR TITLE
Add notification API and integrate with layout

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { KegiatanModule } from "./kegiatan/kegiatan.module";
 import { LaporanModule } from "./laporan/laporan.module";
 import { MonitoringModule } from "./monitoring/monitoring.module";
 import { RolesModule } from "./roles/roles.module";
+import { NotificationsModule } from "./notifications/notifications.module";
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { RolesModule } from "./roles/roles.module";
     LaporanModule,
     MonitoringModule,
     RolesModule,
+    NotificationsModule,
   ],
   providers: [PrismaService],
   exports: [PrismaService],

--- a/api/src/notifications/notifications.controller.ts
+++ b/api/src/notifications/notifications.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post } from "@nestjs/common";
+import { NotificationsService } from "./notifications.service";
+
+@Controller("notifications")
+export class NotificationsController {
+  constructor(private readonly service: NotificationsService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Post("read-all")
+  markAllAsRead() {
+    this.service.markAllAsRead();
+    return { message: "ok" };
+  }
+}

--- a/api/src/notifications/notifications.module.ts
+++ b/api/src/notifications/notifications.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { NotificationsController } from "./notifications.controller";
+import { NotificationsService } from "./notifications.service";
+
+@Module({
+  controllers: [NotificationsController],
+  providers: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/api/src/notifications/notifications.service.ts
+++ b/api/src/notifications/notifications.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from "@nestjs/common";
+
+interface Notification {
+  id: number;
+  text: string;
+  read: boolean;
+}
+
+@Injectable()
+export class NotificationsService {
+  private notifications: Notification[] = [
+    { id: 1, text: "Laporan harian belum dikirim", read: false },
+    { id: 2, text: "Penugasan baru tersedia", read: false },
+    { id: 3, text: "Tim Anda telah diperbarui", read: false },
+  ];
+
+  findAll() {
+    return this.notifications;
+  }
+
+  markAllAsRead() {
+    this.notifications = this.notifications.map((n) => ({ ...n, read: true }));
+  }
+}


### PR DESCRIPTION
## Summary
- add a small `notifications` module on the backend
- register the module in `app.module`
- load notifications from API in the layout
- mark all notifications as read via backend

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6879d0fa6fe0832b8812e21af7c57916