### PR TITLE
Improve axios error handling

### DIFF
--- a/web/src/pages/auth/LoginPage.jsx
+++ b/web/src/pages/auth/LoginPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import axios from "axios";
 import { useAuth } from "./useAuth";
+import { handleAxiosError } from "../../utils/alerts";
 import Button from "../../components/ui/Button";
 import { Eye, EyeOff } from "lucide-react";
 import { useNavigate } from "react-router-dom";
@@ -28,6 +29,7 @@ export default function LoginPage() {
     } catch (err) {
       console.error("Login failed:", err?.response?.data || err.message);
       setError("Login gagal. Periksa data login Anda.");
+      handleAxiosError(err, "Login gagal");
 
       // hanya kosongkan password
       setForm((prev) => ({ ...prev, password: "" }));

--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -5,6 +5,7 @@ import axios from "axios";
 import React, { useEffect, useState } from "react";
 import { ROLES } from "../../utils/roles";
 import Button from "../../components/ui/Button";
+import { handleAxiosError } from "../../utils/alerts";
 
 const Dashboard = () => {
   const { user } = useAuth();
@@ -127,7 +128,7 @@ const Dashboard = () => {
         if (error?.response && [401, 403].includes(error.response.status)) {
           setErrorMsg("Anda tidak memiliki akses untuk melihat monitoring.");
         }
-        console.error("Gagal mengambil data monitoring:", error);
+        handleAxiosError(error, "Gagal mengambil data monitoring");
       } finally {
         setLoading(false);
       }

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 import { Pencil, Trash2, ExternalLink, X } from "lucide-react";
-import { showSuccess, showError } from "../../utils/alerts";
+import { showSuccess, handleAxiosError } from "../../utils/alerts";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import Table from "../../components/ui/Table";
@@ -46,7 +46,7 @@ export default function LaporanHarianPage() {
       const res = await axios.get(url);
       setLaporan(res.data);
     } catch (err) {
-      console.error("Gagal mengambil laporan", err);
+      handleAxiosError(err, "Gagal mengambil laporan");
     } finally {
       setLoading(false);
     }
@@ -62,8 +62,7 @@ export default function LaporanHarianPage() {
       fetchData();
       showSuccess("Berhasil", "Laporan diperbarui");
     } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal menyimpan");
+      handleAxiosError(err, "Gagal menyimpan");
     }
   };
 

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -2,9 +2,9 @@ import { useEffect, useState, useCallback } from "react";
 import axios from "axios";
 import {
   showSuccess,
-  showError,
   showWarning,
   confirmDelete,
+  handleAxiosError,
 } from "../../utils/alerts";
 import { Pencil, Plus, Trash2 } from "lucide-react";
 import Spinner from "../../components/Spinner";
@@ -52,7 +52,7 @@ export default function MasterKegiatanPage() {
       setItems(res.data.data);
       setLastPage(res.data.lastPage);
     } catch (err) {
-      console.error("Gagal mengambil master kegiatan", err);
+      handleAxiosError(err, "Gagal mengambil master kegiatan");
     } finally {
       setLoading(false);
     }
@@ -66,7 +66,7 @@ export default function MasterKegiatanPage() {
       }
       setTeams(res.data);
     } catch (err) {
-      console.error("Gagal mengambil tim", err);
+      handleAxiosError(err, "Gagal mengambil tim");
     }
   }, []);
 
@@ -107,8 +107,7 @@ export default function MasterKegiatanPage() {
       fetchItems();
       showSuccess("Berhasil", "Kegiatan disimpan");
     } catch (err) {
-      console.error("Gagal menyimpan kegiatan", err);
-      showError("Error", "Gagal menyimpan kegiatan");
+      handleAxiosError(err, "Gagal menyimpan kegiatan");
     }
   };
 
@@ -120,7 +119,7 @@ export default function MasterKegiatanPage() {
       fetchItems();
       showSuccess("Dihapus", "Kegiatan berhasil dihapus");
     } catch (err) {
-      console.error("Gagal menghapus kegiatan", err);
+      handleAxiosError(err, "Gagal menghapus kegiatan");
     }
   };
 

--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -9,6 +9,7 @@ import WeeklyMatrix from "./WeeklyMatrix";
 import MonthlyMatrix from "../../components/monitoring/MonthlyMatrix";
 import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
+import { handleAxiosError } from "../../utils/alerts";
 
 export default function MonitoringPage() {
   const [tab, setTab] = useState("harian");
@@ -108,7 +109,7 @@ export default function MonitoringPage() {
         const sorted = filtered.sort((a, b) => a.nama.localeCompare(b.nama));
         setAllUsers(sorted);
       } catch (err) {
-        console.error("Gagal mengambil pengguna", err);
+        handleAxiosError(err, "Gagal mengambil pengguna");
       }
     };
     fetchUsers();
@@ -121,7 +122,7 @@ export default function MonitoringPage() {
           const res = await axios.get("/teams");
           setTeams(res.data);
         } catch (err) {
-          console.error("Gagal mengambil tim", err);
+          handleAxiosError(err, "Gagal mengambil tim");
         }
       }
     };
@@ -175,7 +176,7 @@ export default function MonitoringPage() {
         });
         setDailyData(mergeMatrixWithUsers(res.data));
       } catch (err) {
-        console.error(err);
+        handleAxiosError(err, "Gagal mengambil monitoring harian");
       } finally {
         setLoading(false);
       }
@@ -193,7 +194,7 @@ export default function MonitoringPage() {
           params: { minggu, teamId: teamId || undefined },
         });
       } catch (err) {
-        console.error(err);
+        handleAxiosError(err, "Gagal mengambil monitoring mingguan");
       } finally {
         setLoading(false);
       }
@@ -213,7 +214,7 @@ export default function MonitoringPage() {
         });
         setWeeklyMonthData(mergeWeeklyMonthWithUsers(res.data));
       } catch (err) {
-        console.error(err);
+        handleAxiosError(err, "Gagal mengambil monitoring mingguan per bulan");
       } finally {
         setLoading(false);
       }
@@ -233,7 +234,7 @@ export default function MonitoringPage() {
         });
         setMonthlyData(mergeMonthlyMatrixWithUsers(res.data));
       } catch (err) {
-        console.error(err);
+        handleAxiosError(err, "Gagal mengambil monitoring bulanan");
       } finally {
         setLoading(false);
       }

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -7,6 +7,7 @@ import {
   showWarning,
   confirmDelete,
   confirmCancel,
+  handleAxiosError,
 } from "../../utils/alerts";
 import Select from "react-select";
 import selectStyles from "../../utils/selectStyles";
@@ -79,8 +80,7 @@ export default function PenugasanDetailPage() {
         status: res.data.status,
       });
     } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal mengambil data");
+      handleAxiosError(err, "Gagal mengambil data");
     }
   }, [id]);
 
@@ -114,8 +114,7 @@ export default function PenugasanDetailPage() {
       setEditing(false);
       fetchDetail();
     } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal memperbarui");
+      handleAxiosError(err, "Gagal memperbarui");
     }
   };
 
@@ -165,8 +164,7 @@ export default function PenugasanDetailPage() {
         fetchDetail();
       }, 200);
     } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal menyimpan laporan");
+      handleAxiosError(err, "Gagal menyimpan laporan");
     }
   };
 
@@ -192,8 +190,7 @@ export default function PenugasanDetailPage() {
       fetchDetail();
       showSuccess("Dihapus", "Laporan dihapus");
     } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal menghapus laporan");
+      handleAxiosError(err, "Gagal menghapus laporan");
     }
   };
 
@@ -205,7 +202,6 @@ export default function PenugasanDetailPage() {
       showSuccess("Dihapus", "Penugasan dihapus");
       navigate(-1);
     } catch (err) {
-      console.error(err);
       if (err?.response?.status === 403) {
         showError(
           "Tidak diizinkan",
@@ -215,6 +211,7 @@ export default function PenugasanDetailPage() {
         const msg = err?.response?.data?.message || "Gagal menghapus";
         showError("Error", msg);
       }
+      handleAxiosError(err, "Gagal menghapus penugasan");
     }
   };
 

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -2,9 +2,9 @@ import { useEffect, useState, useCallback, useMemo } from "react";
 import axios from "axios";
 import {
   showSuccess,
-  showError,
   showWarning,
   confirmCancel,
+  handleAxiosError,
 } from "../../utils/alerts";
 import { Plus, Filter as FilterIcon, Eye } from "lucide-react";
 import Select from "react-select";
@@ -116,7 +116,7 @@ export default function PenugasanPage() {
       );
       setKegiatan(sortedKegiatan);
     } catch (err) {
-      console.error("Gagal mengambil data penugasan", err);
+      handleAxiosError(err, "Gagal mengambil data penugasan");
     } finally {
       setLoading(false);
     }
@@ -149,8 +149,7 @@ export default function PenugasanPage() {
       fetchData();
       showSuccess("Berhasil", "Penugasan ditambah");
     } catch (err) {
-      console.error("Gagal menyimpan penugasan", err);
-      showError("Error", "Gagal menyimpan penugasan");
+      handleAxiosError(err, "Gagal menyimpan penugasan");
     }
   };
 

--- a/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
@@ -3,9 +3,9 @@ import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
 import {
   showSuccess,
-  showError,
   confirmDelete,
   confirmCancel,
+  handleAxiosError,
 } from "../../utils/alerts";
 import { Pencil, Trash2 } from "lucide-react";
 import Select from "react-select";
@@ -50,8 +50,7 @@ export default function TugasTambahanDetailPage() {
         deskripsi: dRes.data.deskripsi || "",
       });
     } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal mengambil data");
+      handleAxiosError(err, "Gagal mengambil data");
     }
   }, [id]);
 
@@ -70,8 +69,7 @@ export default function TugasTambahanDetailPage() {
       setEditing(false);
       fetchDetail();
     } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal menyimpan");
+      handleAxiosError(err, "Gagal menyimpan");
     }
   };
 
@@ -91,8 +89,7 @@ export default function TugasTambahanDetailPage() {
       });
       fetchDetail();
     } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal menambah laporan");
+      handleAxiosError(err, "Gagal menambah laporan");
     }
   };
 
@@ -104,8 +101,7 @@ export default function TugasTambahanDetailPage() {
       showSuccess("Dihapus", "Kegiatan dihapus");
       navigate(-1);
     } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal menghapus");
+      handleAxiosError(err, "Gagal menghapus");
     }
   };
 

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo } from "react";
 import axios from "axios";
-import { showSuccess, showError, confirmDelete } from "../../utils/alerts";
+import { showSuccess, confirmDelete, handleAxiosError } from "../../utils/alerts";
 import { Plus, Eye, Pencil, Trash2 } from "lucide-react";
 import Table from "../../components/ui/Table";
 import tableStyles from "../../components/ui/Table.module.css";
@@ -57,7 +57,7 @@ export default function TugasTambahanPage() {
       setKegiatan(kRes.data.data || kRes.data);
       setTeams(teamRes.data);
     } catch (err) {
-      console.error(err);
+      handleAxiosError(err, "Gagal mengambil data");
     } finally {
       setLoading(false);
     }
@@ -109,8 +109,7 @@ export default function TugasTambahanPage() {
       fetchData();
       showSuccess("Berhasil", "Data disimpan");
     } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal menyimpan");
+      handleAxiosError(err, "Gagal menyimpan");
     }
   };
 
@@ -122,8 +121,7 @@ export default function TugasTambahanPage() {
       fetchData();
       showSuccess("Dihapus", "Kegiatan dihapus");
     } catch (err) {
-      console.error(err);
-      showError("Error", "Gagal menghapus");
+      handleAxiosError(err, "Gagal menghapus");
     }
   };
 

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -2,10 +2,10 @@ import { useEffect, useState, useCallback } from "react";
 import axios from "axios";
 import {
   showSuccess,
-  showError,
   showWarning,
   confirmDelete,
   confirmCancel,
+  handleAxiosError,
 } from "../../utils/alerts";
 import { Pencil, Plus, Trash2 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
@@ -44,7 +44,7 @@ export default function TeamsPage() {
       }
       setTeams(res.data);
     } catch (err) {
-      console.error("Gagal mengambil tim", err);
+      handleAxiosError(err, "Gagal mengambil tim");
     } finally {
       setLoading(false);
     }
@@ -77,8 +77,7 @@ export default function TeamsPage() {
       fetchTeams();
       showSuccess("Berhasil", "Tim disimpan");
     } catch (err) {
-      console.error("Gagal menyimpan tim", err);
-      showError("Error", "Gagal menyimpan tim");
+      handleAxiosError(err, "Gagal menyimpan tim");
     }
   };
 
@@ -90,8 +89,7 @@ export default function TeamsPage() {
       fetchTeams();
       showSuccess("Dihapus", "Tim berhasil dihapus");
     } catch (err) {
-      console.error("Gagal menghapus tim", err);
-      showError("Error", "Gagal menghapus tim");
+      handleAxiosError(err, "Gagal menghapus tim");
     }
   }, []);
 

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -2,10 +2,10 @@ import { useEffect, useState, useCallback, useMemo } from "react";
 import axios from "axios";
 import {
   showSuccess,
-  showError,
   showWarning,
   confirmDelete,
   confirmCancel,
+  handleAxiosError,
 } from "../../utils/alerts";
 import { Pencil, Plus, Trash2 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
@@ -49,7 +49,7 @@ export default function UsersPage() {
       const res = await axios.get("/users");
       setUsers(res.data);
     } catch (err) {
-      console.error("Gagal mengambil pengguna", err);
+      handleAxiosError(err, "Gagal mengambil pengguna");
     } finally {
       setLoading(false);
     }
@@ -60,7 +60,7 @@ export default function UsersPage() {
       const res = await axios.get("/roles");
       setRoles(res.data);
     } catch (err) {
-      console.error("Gagal mengambil role", err);
+      handleAxiosError(err, "Gagal mengambil role");
     }
   };
 
@@ -96,8 +96,7 @@ export default function UsersPage() {
       fetchUsers();
       showSuccess("Berhasil", "Pengguna disimpan");
     } catch (err) {
-      console.error("Gagal menyimpan pengguna", err);
-      showError("Error", "Gagal menyimpan pengguna");
+      handleAxiosError(err, "Gagal menyimpan pengguna");
     }
   };
 
@@ -109,8 +108,7 @@ export default function UsersPage() {
       fetchUsers();
       showSuccess("Dihapus", "Pengguna berhasil dihapus");
     } catch (err) {
-      console.error("Gagal menghapus pengguna", err);
-      showError("Error", "Gagal menghapus pengguna");
+      handleAxiosError(err, "Gagal menghapus pengguna");
     }
   }, []);
 

--- a/web/src/utils/alerts.js
+++ b/web/src/utils/alerts.js
@@ -34,10 +34,20 @@ export const confirmCancel = (title = "Batalkan perubahan?") =>
     icon: "question",
   });
 
+export const handleAxiosError = (error, defaultMessage = "Terjadi kesalahan") => {
+  const message =
+    error?.response?.data?.message ||
+    (error?.request
+      ? "Tidak dapat terhubung ke server. Coba lagi nanti."
+      : defaultMessage);
+  showError("Error", message);
+};
+
 export default {
   showSuccess,
   showError,
   showWarning,
   confirmDelete,
   confirmCancel,
+  handleAxiosError,
 };


### PR DESCRIPTION
## Summary
- add helper `handleAxiosError` for standardized toast alerts
- show user-friendly error messages for axios requests across pages

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6879d10429bc832bb9662d29392be3fc