### PR TITLE
Improve accessibility labels

### DIFF
--- a/web/src/components/Pagination.jsx
+++ b/web/src/components/Pagination.jsx
@@ -20,6 +20,7 @@ export default function Pagination({ currentPage, totalPages, onPageChange }) {
       <button
         onClick={() => onPageChange(Math.max(1, currentPage - 1))}
         disabled={currentPage === 1}
+        aria-label="Halaman sebelumnya"
         className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-xl
           bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 
           text-gray-800 dark:text-gray-100 disabled:opacity-50 disabled:cursor-not-allowed
@@ -33,13 +34,15 @@ export default function Pagination({ currentPage, totalPages, onPageChange }) {
           <button
             key={idx}
             onClick={() => onPageChange(p)}
-            className={`px-4 py-2 rounded-xl 
+            className={`px-4 py-2 rounded-xl
               ${
                 currentPage === p
                   ? "bg-blue-600 text-white dark:bg-blue-700"
                   : "border border-gray-300 dark:border-gray-600 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-100"
               }
               focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-sm transition`}
+            aria-label={`Halaman ${p}`}
+            aria-current={currentPage === p ? "page" : undefined}
           >
             {p}
           </button>
@@ -53,6 +56,7 @@ export default function Pagination({ currentPage, totalPages, onPageChange }) {
       <button
         onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
         disabled={currentPage >= totalPages}
+        aria-label="Halaman selanjutnya"
         className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-xl
           bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 
           text-gray-800 dark:text-gray-100 disabled:opacity-50 disabled:cursor-not-allowed

--- a/web/src/components/ui/DataTable.jsx
+++ b/web/src/components/ui/DataTable.jsx
@@ -52,6 +52,7 @@ export function SelectColumnFilter({ column, options }) {
       value={column.getFilterValue() || ""}
       onChange={(e) => column.setFilterValue(e.target.value || undefined)}
       className="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-xl px-2 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+      aria-label="Filter kolom"
     >
       <option value="">Semua</option>
       {opts.map((o) => (

--- a/web/src/components/ui/DateFilter.jsx
+++ b/web/src/components/ui/DateFilter.jsx
@@ -8,6 +8,7 @@ export default function DateFilter({ tanggal, setTanggal, setCurrentPage }) {
       <input
         id="filterTanggal"
         type="date"
+        aria-label="Filter tanggal"
         ref={inputRef}
         value={tanggal}
         onChange={(e) => {

--- a/web/src/components/ui/SelectDataShow.jsx
+++ b/web/src/components/ui/SelectDataShow.jsx
@@ -9,6 +9,7 @@ export default function SelectDataShow({
     <div className={`space-x-2 ${className}`}>
       <select
         value={pageSize}
+        aria-label="Data per halaman"
         onChange={(e) => {
           setPageSize(parseInt(e.target.value, 10));
           setCurrentPage(1);


### PR DESCRIPTION
## Summary
- add `aria-label` for next/prev and page buttons in pagination
- label date filter and page-size select components
- label table column filter selects

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6879d10586dc832b85e8890be4439bf4