### PR TITLE
Add tests for auth, teams and laporan

### DIFF
--- a/api/test/auth.controller.spec.ts
+++ b/api/test/auth.controller.spec.ts
@@ -1,0 +1,37 @@
+import { AuthController } from '../src/auth/auth.controller';
+import { UnauthorizedException } from '@nestjs/common';
+
+const service = {
+  login: jest.fn(),
+} as any;
+
+const controller = new AuthController(service);
+
+describe('AuthController login', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('sets cookie and returns user', async () => {
+    const res: any = { cookie: jest.fn() };
+    service.login.mockResolvedValue({ access_token: 'tok', user: { id: 1 } });
+    const result = await controller.login({ identifier: 'a', password: 'b' } as any, res);
+    expect(result).toEqual({ user: { id: 1 } });
+    expect(res.cookie).toHaveBeenCalledWith('token', 'tok', expect.any(Object));
+  });
+
+  it('propagates errors from service', async () => {
+    const res: any = { cookie: jest.fn() };
+    service.login.mockRejectedValue(new UnauthorizedException());
+    await expect(controller.login({ identifier: 'a', password: 'b' } as any, res)).rejects.toThrow(UnauthorizedException);
+  });
+});
+
+describe('AuthController logout', () => {
+  it('clears cookie and returns message', () => {
+    const res: any = { clearCookie: jest.fn() };
+    const result = controller.logout(res);
+    expect(res.clearCookie).toHaveBeenCalledWith('token');
+    expect(result).toEqual({ message: 'Logged out' });
+  });
+});

--- a/api/test/laporan.service.spec.ts
+++ b/api/test/laporan.service.spec.ts
@@ -1,0 +1,99 @@
+import { LaporanService } from '../src/laporan/laporan.service';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ROLES } from '../src/common/roles.constants';
+import { STATUS } from '../src/common/status.constants';
+
+const prisma = {
+  laporanHarian: {
+    findFirst: jest.fn(),
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  penugasan: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+  member: {
+    findFirst: jest.fn(),
+  },
+} as any;
+
+const service = new LaporanService(prisma);
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('LaporanService submit', () => {
+  const data = {
+    penugasanId: 1,
+    tanggal: '2024-05-01',
+    status: STATUS.BELUM,
+    deskripsi: 'test',
+  };
+
+  it('throws ForbiddenException when not assignment owner', async () => {
+    prisma.penugasan.findUnique.mockResolvedValue({
+      id: 1,
+      pegawaiId: 2,
+      kegiatan: { teamId: 1 },
+    });
+    await expect(service.submit(data as any, 1, ROLES.ANGGOTA)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('allows admin to submit for other user', async () => {
+    prisma.penugasan.findUnique.mockResolvedValue({
+      id: 1,
+      pegawaiId: 2,
+      kegiatan: { teamId: 1 },
+    });
+    prisma.laporanHarian.create.mockResolvedValue({ id: 10 });
+    prisma.laporanHarian.findFirst.mockResolvedValue(null);
+    prisma.penugasan.update.mockResolvedValue({});
+
+    const res = await service.submit(data as any, 1, ROLES.ADMIN);
+
+    expect(res).toEqual({ id: 10 });
+    expect(prisma.laporanHarian.create).toHaveBeenCalled();
+    expect(prisma.penugasan.update).toHaveBeenCalled();
+  });
+});
+
+describe('LaporanService update', () => {
+  it('throws ForbiddenException when updating others report', async () => {
+    prisma.laporanHarian.findUnique.mockResolvedValue({
+      id: 1,
+      pegawaiId: 2,
+      penugasanId: 1,
+      penugasan: { kegiatan: { teamId: 1 } },
+    });
+    const action = service.update(1, { tanggal: '2024-05-01', status: STATUS.BELUM } as any, 3, ROLES.ANGGOTA);
+    await expect(action).rejects.toThrow(ForbiddenException);
+  });
+});
+
+describe('LaporanService remove', () => {
+  it('throws NotFoundException when report not found', async () => {
+    prisma.laporanHarian.findUnique.mockResolvedValue(null);
+    await expect(service.remove(1, 1, ROLES.ADMIN)).rejects.toThrow(NotFoundException);
+  });
+
+  it('allows leader to remove others report', async () => {
+    prisma.laporanHarian.findUnique.mockResolvedValue({
+      id: 1,
+      pegawaiId: 2,
+      penugasanId: 1,
+      penugasan: { kegiatan: { teamId: 1 } },
+    });
+    prisma.member.findFirst.mockResolvedValue({ id: 1 });
+    prisma.laporanHarian.delete.mockResolvedValue({});
+    prisma.laporanHarian.findFirst.mockResolvedValue(null);
+    prisma.penugasan.update.mockResolvedValue({});
+
+    const res = await service.remove(1, 3, ROLES.KETUA);
+    expect(prisma.laporanHarian.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+    expect(res).toEqual({ success: true });
+  });
+});

--- a/api/test/teams.service.spec.ts
+++ b/api/test/teams.service.spec.ts
@@ -1,0 +1,38 @@
+import { TeamsService } from '../src/teams/teams.service';
+import { NotFoundException } from '@nestjs/common';
+
+const prisma = {
+  team: { findUnique: jest.fn() },
+  member: { create: jest.fn() },
+} as any;
+
+const service = new TeamsService(prisma);
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('TeamsService findOne', () => {
+  it('throws NotFoundException when team missing', async () => {
+    prisma.team.findUnique.mockResolvedValue(null);
+    await expect(service.findOne(1)).rejects.toThrow(NotFoundException);
+  });
+
+  it('returns team when found', async () => {
+    prisma.team.findUnique.mockResolvedValue({ id: 1 });
+    const res = await service.findOne(1);
+    expect(res).toEqual({ id: 1 });
+  });
+});
+
+describe('TeamsService addMember', () => {
+  it('creates member with given data', async () => {
+    prisma.member.create.mockResolvedValue({ id: 2 });
+    const data = { user_id: 3, is_leader: true };
+    const res = await service.addMember(1, data);
+    expect(prisma.member.create).toHaveBeenCalledWith({
+      data: { teamId: 1, userId: 3, is_leader: true },
+    });
+    expect(res).toEqual({ id: 2 });
+  });
+});


### PR DESCRIPTION
## Summary
- add more unit tests for LaporanService
- add TeamsService unit test
- cover AuthController login/logout endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6879d10a3598832baed3dbf9c0cbbcfa