### PR TITLE
Add global rate limiting

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -80,6 +80,11 @@ npm run start:dev
 
 Server berjalan di: `http://localhost:${PORT}` (default 3000)
 
+## ⏱️ Rate Limiting
+
+Aplikasi menerapkan rate limit global menggunakan `@nestjs/throttler`.
+Setiap IP dibatasi **100 request** setiap **15 menit**.
+
 ---
 
 ## 🔐 Role & Akses

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/jwt": "^10.0.0",
         "@nestjs/passport": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/throttler": "^6.4.0",
         "@prisma/client": "^5.22.0",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
@@ -3008,6 +3009,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.4.0.tgz",
+      "integrity": "sha512-osL67i0PUuwU5nqSuJjtUJZMkxAnYB4VldgYUMGzvYRJDCqGRFMWbsbzm/CkUtPLRL30I8T74Xgt/OQxnYokiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/api/package.json
+++ b/api/package.json
@@ -21,6 +21,7 @@
     "@nestjs/jwt": "^10.0.0",
     "@nestjs/passport": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/throttler": "^6.4.0",
     "@prisma/client": "^5.22.0",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,4 +1,6 @@
 import { Module } from "@nestjs/common";
+import { APP_GUARD } from "@nestjs/core";
+import { ThrottlerGuard, ThrottlerModule } from "@nestjs/throttler";
 import { PrismaService } from "./prisma.service";
 import { AuthModule } from "./auth/auth.module";
 import { UsersModule } from "./users/users.module";
@@ -10,6 +12,7 @@ import { RolesModule } from "./roles/roles.module";
 
 @Module({
   imports: [
+    ThrottlerModule.forRoot({ ttl: 900, limit: 100 }),
     AuthModule,
     UsersModule,
     TeamsModule,
@@ -18,7 +21,13 @@ import { RolesModule } from "./roles/roles.module";
     MonitoringModule,
     RolesModule,
   ],
-  providers: [PrismaService],
+  providers: [
+    PrismaService,
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
   exports: [PrismaService],
 })
 export class AppModule {}


### PR DESCRIPTION
## Summary
- add `@nestjs/throttler` to backend API
- enable global rate limiting (100 requests per 15 minutes)
- document the limits in the API README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6879d1100870832b8f6e16303b07eaa7