### PR TITLE
Improve table responsiveness and auto-collapse sidebar

### DIFF
--- a/web/src/components/ui/DataTable.jsx
+++ b/web/src/components/ui/DataTable.jsx
@@ -146,9 +146,9 @@ export default function DataTable({
   });
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 overflow-x-auto md:overflow-x-visible">
       {showGlobalFilter && <GlobalFilter table={table} />}
-      <Table>
+      <Table className="min-w-full">
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id} className={tableStyles.headerRow}>

--- a/web/src/components/ui/Table.jsx
+++ b/web/src/components/ui/Table.jsx
@@ -2,7 +2,7 @@ import styles from "./Table.module.css";
 
 export default function Table({ children, className = "", ...props }) {
   return (
-    <div className={styles.wrapper}>
+    <div className={`${styles.wrapper} overflow-x-auto md:overflow-x-visible`}>
       <table className={`${styles.table} ${className}`} {...props}>
         {children}
       </table>

--- a/web/src/components/ui/Table.module.css
+++ b/web/src/components/ui/Table.module.css
@@ -1,7 +1,6 @@
 /* Table.module.css */
 
 .wrapper {
-  overflow-x: auto;
   border-radius: 1rem;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -109,7 +109,7 @@ export default function LaporanHarianPage() {
         />
       </div>
       <>
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto md:overflow-x-visible">
           <Table>
             <thead>
               <tr className={tableStyles.headerRow}>

--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -23,7 +23,9 @@ export default function Layout() {
   const { user, setUser } = useAuth();
   const location = useLocation();
 
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(() =>
+    typeof window !== "undefined" ? window.innerWidth >= 768 : true
+  );
   const [notifCount, setNotifCount] = useState(3);
   const [notifications, setNotifications] = useState([
     { id: 1, text: "Laporan harian belum dikirim", read: false },
@@ -67,6 +69,15 @@ export default function Layout() {
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth < 768) setSidebarOpen(false);
+    };
+    window.addEventListener("resize", handleResize);
+    handleResize();
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   const displayedNotifications = notifications.slice(0, 5);

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -180,6 +180,7 @@ export default function MasterKegiatanPage() {
         </div>
       </div>
 
+      <div className="overflow-x-auto md:overflow-x-visible">
       <Table>
         <thead>
           <tr className={tableStyles.headerRow}>
@@ -239,6 +240,7 @@ export default function MasterKegiatanPage() {
           )}
         </tbody>
       </Table>
+      </div>
 
       <div className="flex items-center justify-between mt-4">
         <SelectDataShow

--- a/web/src/pages/monitoring/DailyMatrix.jsx
+++ b/web/src/pages/monitoring/DailyMatrix.jsx
@@ -40,7 +40,7 @@ const DailyMatrix = ({ data = [] }) => {
   const dayCount = data[0].detail.length;
 
   return (
-    <div className="overflow-auto">
+    <div className="overflow-auto md:overflow-visible">
       <table className="min-w-full text-xs border-collapse">
         <thead>
           <tr>

--- a/web/src/pages/monitoring/WeeklyMatrix.jsx
+++ b/web/src/pages/monitoring/WeeklyMatrix.jsx
@@ -42,7 +42,7 @@ const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek }) => {
   };
 
   return (
-    <div className="overflow-auto">
+    <div className="overflow-auto md:overflow-visible">
       <table className="min-w-full text-xs border-collapse">
         <thead>
           <tr>

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -479,7 +479,7 @@ export default function PenugasanDetailPage() {
           )}
         </div>
 
-        <div className="overflow-x-auto rounded-lg border dark:border-gray-700">
+        <div className="overflow-x-auto md:overflow-x-visible rounded-lg border dark:border-gray-700">
           <Table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead>
               <tr className={tableStyles.headerRow}>

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -203,6 +203,7 @@ export default function PenugasanPage() {
         )}
       </div>
 
+      <div className="overflow-x-auto md:overflow-x-visible">
       <Table>
         <thead>
           <tr className={tableStyles.headerRow}>
@@ -302,6 +303,7 @@ export default function PenugasanPage() {
           )}
         </tbody>
       </Table>
+      </div>
 
       <div className="flex items-center justify-between mt-4">
         <SelectDataShow

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -182,6 +182,7 @@ export default function TugasTambahanPage() {
         </div>
       </div>
 
+      <div className="overflow-x-auto md:overflow-x-visible">
       <Table>
         <thead>
           <tr className={tableStyles.headerRow}>
@@ -300,6 +301,7 @@ export default function TugasTambahanPage() {
           )}
         </tbody>
       </Table>
+      </div>
 
       <div className="flex items-center justify-between mt-4">
         <SelectDataShow

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -131,6 +131,7 @@ export default function TeamsPage() {
         </Button>
       </div>
 
+      <div className="overflow-x-auto md:overflow-x-visible">
       <Table>
         <thead>
           <tr className={tableStyles.headerRow}>
@@ -184,6 +185,7 @@ export default function TeamsPage() {
           )}
         </tbody>
       </Table>
+      </div>
 
       <div className="flex items-center justify-between mt-4">
         <SelectDataShow

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -218,14 +218,16 @@ export default function UsersPage() {
           <Spinner className="h-6 w-6 mx-auto" />
         </div>
       ) : (
-        <DataTable
-          columns={columns}
-          data={paginated}
-          showGlobalFilter={false}
-          showColumnFilters={false}
-          showPagination={false}
-          selectable={false}
-        />
+        <div className="overflow-x-auto md:overflow-x-visible">
+          <DataTable
+            columns={columns}
+            data={paginated}
+            showGlobalFilter={false}
+            showColumnFilters={false}
+            showPagination={false}
+            selectable={false}
+          />
+        </div>
       )}
 
       <div className="flex items-center justify-between mt-4">


### PR DESCRIPTION
## Summary
- make `<Table>` wrapper responsive using Tailwind
- allow `DataTable` to scroll on mobile
- ensure tables on pages use responsive wrappers
- auto-collapse `Sidebar` when screen width is small

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6879d10dc658832b82a2e2df62bb0683