### PR TITLE
Rename snake_case columns with migration

### DIFF
--- a/api/prisma/migrations/20250728000000_rename_snake_columns/migration.sql
+++ b/api/prisma/migrations/20250728000000_rename_snake_columns/migration.sql
@@ -1,0 +1,8 @@
+-- Rename legacy snake_case columns to camelCase
+ALTER TABLE `Team` CHANGE `nama_tim` `namaTim` VARCHAR(191) NOT NULL;
+ALTER TABLE `Member` CHANGE `is_leader` `isLeader` BOOLEAN NOT NULL;
+ALTER TABLE `MasterKegiatan` CHANGE `nama_kegiatan` `namaKegiatan` VARCHAR(191) NOT NULL;
+ALTER TABLE `LaporanHarian` CHANGE `bukti_link` `buktiLink` VARCHAR(191);
+ALTER TABLE `KegiatanTambahan` CHANGE `bukti_link` `buktiLink` VARCHAR(191);
+ALTER TABLE `KegiatanTambahan` CHANGE `tanggal_selesai` `tanggalSelesai` DATETIME(3);
+ALTER TABLE `KegiatanTambahan` CHANGE `tanggal_selesai_akhir` `tanggalSelesaiAkhir` DATETIME(3);


### PR DESCRIPTION
## Summary
- add migration to rename legacy snake_case columns to camelCase

## Testing
- `npx prisma migrate dev --schema=api/prisma/schema.prisma --name rename_snake_columns --skip-seed --skip-generate --no-install` *(fails: failed to fetch prisma engine)*
- `npx prisma db push --schema=api/prisma/schema.prisma` *(fails: failed to fetch prisma engine)*
- `npx ts-node prisma/seed.ts` *(fails: cannot find module '@prisma/client')*

------
https://chatgpt.com/codex/tasks/task_b_6879e44d80ac832ba586da9d6ea71886