### PR TITLE
Implement auth/me endpoint

### DIFF
--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -1,7 +1,9 @@
-import { Controller, Post, Body, Res } from "@nestjs/common";
-import { Response } from "express";
+import { Controller, Post, Body, Res, Get, Req, UseGuards } from "@nestjs/common";
+import { Request, Response } from "express";
 import { AuthService } from "./auth.service";
 import { LoginDto } from "./dto/login.dto";
+import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
+import { AuthRequestUser } from "../common/auth-request-user.interface";
 
 @Controller("auth")
 export class AuthController {
@@ -33,5 +35,13 @@ export class AuthController {
   logout(@Res({ passthrough: true }) res: Response) {
     res.clearCookie("token");
     return { message: "Logged out" };
+  }
+
+  @Get("me")
+  @UseGuards(JwtAuthGuard)
+  async me(@Req() req: Request) {
+    const { userId } = req.user as AuthRequestUser;
+    const user = await this.authService.me(userId);
+    return { user };
   }
 }

--- a/api/test/auth.controller.spec.ts
+++ b/api/test/auth.controller.spec.ts
@@ -3,6 +3,7 @@ import { UnauthorizedException } from '@nestjs/common';
 
 const service = {
   login: jest.fn(),
+  me: jest.fn(),
 } as any;
 
 const controller = new AuthController(service);
@@ -33,5 +34,15 @@ describe('AuthController logout', () => {
     const result = controller.logout(res);
     expect(res.clearCookie).toHaveBeenCalledWith('token');
     expect(result).toEqual({ message: 'Logged out' });
+  });
+});
+
+describe('AuthController me', () => {
+  it('returns current user', async () => {
+    const req: any = { user: { userId: 1 } };
+    service.me.mockResolvedValue({ id: 1 });
+    const result = await controller.me(req);
+    expect(service.me).toHaveBeenCalledWith(1);
+    expect(result).toEqual({ user: { id: 1 } });
   });
 });

--- a/api/test/auth.service.spec.ts
+++ b/api/test/auth.service.spec.ts
@@ -1,10 +1,10 @@
 import { AuthService } from '../src/auth/auth.service';
 import { JwtService } from '@nestjs/jwt';
-import { UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException, NotFoundException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 
 const prisma = {
-  user: { findFirst: jest.fn() },
+  user: { findFirst: jest.fn(), findUnique: jest.fn() },
 } as any;
 
 const jwtService = { sign: jest.fn(() => 'signed') } as any;
@@ -35,4 +35,43 @@ test('returns token and user on success', async () => {
   expect(result.user).toHaveProperty('id', 1);
   expect(prisma.user.findFirst).toHaveBeenCalled();
   expect(jwtService.sign).toHaveBeenCalled();
+});
+
+describe('AuthService me', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('throws NotFoundException when user missing', async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+    await expect(service.me(1)).rejects.toThrow(NotFoundException);
+  });
+
+  it('returns sanitized user', async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      id: 1,
+      nama: 'A',
+      username: 'a',
+      email: 'a@b.c',
+      password: 'x',
+      role: 'admin',
+      members: [{ teamId: 2, team: { namaTim: 'Tim' } }],
+    });
+    const res = await service.me(1);
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: 1 },
+      include: { members: { include: { team: true } } },
+    });
+    expect(res).toEqual({
+      id: 1,
+      nama: 'A',
+      username: 'a',
+      email: 'a@b.c',
+      role: 'admin',
+      members: [{ teamId: 2, team: { namaTim: 'Tim' } }],
+      teamId: 2,
+      teamName: 'Tim',
+    });
+    expect(res).not.toHaveProperty('password');
+  });
 });


### PR DESCRIPTION
## Summary
- add `GET /auth/me` endpoint to return logged-in user
- support new route in service and tests

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6879e97e7e40832bb5857a628f42ff2e