### PR TITLE
Fix keys in overview components

### DIFF
--- a/web/src/components/dashboard/DailyOverview.jsx
+++ b/web/src/components/dashboard/DailyOverview.jsx
@@ -41,14 +41,14 @@ const DailyOverview = ({ data = [] }) => {
       </h2>
       <Legend className="mb-2" />
       <div className="grid grid-cols-4 sm:grid-cols-7 gap-2">
-        {data.map((day, index) => {
+        {data.map((day) => {
           const dayName = new Date(day.tanggal).toLocaleDateString("id-ID", {
             weekday: "short",
           });
           const weekend = isWeekend(day.tanggal) || isHoliday(day.tanggal);
           return (
             <div
-              key={index}
+              key={day.tanggal}
               className={`p-3 rounded-lg text-center text-sm font-medium border ${boxClass(
                 day
               )}`}

--- a/web/src/components/dashboard/MonthlyOverview.jsx
+++ b/web/src/components/dashboard/MonthlyOverview.jsx
@@ -5,9 +5,9 @@ const MonthlyOverview = ({ data = [] }) => {
         Capaian Kinerja Bulanan
       </h2>
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
-        {data.map((item, index) => (
+        {data.map((item) => (
           <div
-            key={index}
+            key={item.bulan}
             className="p-3 rounded-lg bg-blue-50 dark:bg-blue-900 text-center"
           >
             <div className="font-medium">{item.bulan}</div>

--- a/web/src/components/dashboard/WeeklyOverview.jsx
+++ b/web/src/components/dashboard/WeeklyOverview.jsx
@@ -41,9 +41,9 @@ const WeeklyOverview = ({ data }) => {
             const dow = new Date(d.tanggal).getDay();
             return (dow >= 1 && dow <= 5) || d.total > 0;
           })
-          .map((day, index) => (
+          .map((day) => (
             <div
-              key={index}
+              key={day.tanggal}
               className="bg-white dark:bg-gray-800 p-3 rounded-lg shadow"
             >
               <div className="flex justify-between text-sm">


### PR DESCRIPTION
## Summary
- avoid using array indices as React keys in DailyOverview
- avoid using array indices as React keys in WeeklyOverview
- avoid using array indices as React keys in MonthlyOverview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6879ed3f4e80832bbee4991f6c44542d