### PR TITLE
Start Tailwind standardization

### DIFF
--- a/web/src/components/ui/DataTable.jsx
+++ b/web/src/components/ui/DataTable.jsx
@@ -13,7 +13,6 @@ import Pagination from "../Pagination";
 import SelectDataShow from "./SelectDataShow";
 import SearchInput from "../SearchInput";
 import Input from "./Input";
-import tableStyles from "./Table.module.css";
 
 function GlobalFilter({ table }) {
   return (
@@ -139,13 +138,16 @@ export default function DataTable({
     <div className="space-y-4 overflow-x-auto md:overflow-x-visible">
       {showGlobalFilter && <GlobalFilter table={table} />}
       <Table className="min-w-full">
-        <thead className={tableStyles.headerCell}>
+        <thead>
           {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id} className={tableStyles.headerRow}>
+            <tr
+              key={headerGroup.id}
+              className="bg-gray-100 dark:bg-gray-800"
+            >
               {headerGroup.headers.map((header) => (
                 <th
                   key={header.id}
-                  className={`${tableStyles.cell} select-none text-left`}
+                  className="px-4 py-3 font-semibold text-center border-t border-b border-gray-300 dark:border-gray-700 select-none text-left"
                   onClick={header.column.getToggleSortingHandler()}
                 >
                   <div className="flex items-center gap-1">
@@ -179,9 +181,15 @@ export default function DataTable({
             </tr>
           ) : (
             table.getRowModel().rows.map((row) => (
-              <tr key={row.id} className={tableStyles.row}>
+              <tr
+                key={row.id}
+                className="text-center odd:bg-white even:bg-gray-50 dark:odd:bg-gray-900 dark:even:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
                 {row.getVisibleCells().map((cell) => (
-                  <td key={cell.id} className={tableStyles.cell}>
+                  <td
+                    key={cell.id}
+                    className="px-4 py-3 border-t border-b border-gray-300 dark:border-gray-700"
+                  >
                     {flexRender(
                       cell.column.columnDef.cell ?? cell.getValue(),
                       cell.getContext()

--- a/web/src/components/ui/Input.jsx
+++ b/web/src/components/ui/Input.jsx
@@ -1,6 +1,7 @@
 import React from "react";
-import styles from "./Input.module.css";
 
 export default function Input({ className = "", ...props }) {
-  return <input className={`${styles.input} ${className}`.trim()} {...props} />;
+  const baseClasses =
+    "w-full border rounded px-3 py-2 bg-white text-gray-900 dark:bg-gray-700 dark:text-gray-200";
+  return <input className={`${baseClasses} ${className}`.trim()} {...props} />;
 }

--- a/web/src/components/ui/Input.module.css
+++ b/web/src/components/ui/Input.module.css
@@ -1,3 +1,0 @@
-.input {
-  @apply w-full border rounded px-3 py-2 bg-white text-gray-900 dark:bg-gray-700 dark:text-gray-200;
-}

--- a/web/src/components/ui/Label.jsx
+++ b/web/src/components/ui/Label.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import styles from "./Label.module.css";
 
 export default function Label({ className = "", ...props }) {
-  return <label className={`${styles.label} ${className}`.trim()} {...props} />;
+  const baseClasses = "block text-sm mb-1";
+  return <label className={`${baseClasses} ${className}`.trim()} {...props} />;
 }

--- a/web/src/components/ui/Label.module.css
+++ b/web/src/components/ui/Label.module.css
@@ -1,3 +1,0 @@
-.label {
-  @apply block text-sm mb-1;
-}

--- a/web/src/components/ui/Table.jsx
+++ b/web/src/components/ui/Table.jsx
@@ -1,9 +1,10 @@
-import styles from "./Table.module.css";
-
 export default function Table({ children, className = "", ...props }) {
   return (
-    <div className={`${styles.wrapper} overflow-x-auto md:overflow-x-visible`}>
-      <table className={`${styles.table} ${className}`} {...props}>
+    <div className="overflow-x-auto md:overflow-x-visible rounded-xl shadow-md">
+      <table
+        className={`w-full border-collapse text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 ${className}`.trim()}
+        {...props}
+      >
         {children}
       </table>
     </div>


### PR DESCRIPTION
## Summary
- convert `Input` and `Label` components to use Tailwind classes
- drop old CSS modules
- update `Table` and `DataTable` to rely on Tailwind utilities

## Testing
- `npm test` in `web`
- `npm test` in `api`


------
https://chatgpt.com/codex/tasks/task_b_6879ed41d1a0832b95105d1d98c9d985