### PR TITLE
Add ErrorBoundary and wrap top level routes

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2,6 +2,7 @@ import React, { Suspense } from "react";
 import AppRoutes from "./routes/AppRoutes";
 import { useAuth } from "./pages/auth/useAuth";
 import Loading from "./components/Loading";
+import ErrorBoundary from "./components/ErrorBoundary";
 
 const LoginPage = React.lazy(() => import("./pages/auth/LoginPage"));
 
@@ -10,11 +11,17 @@ export default function App() {
 
   if (!user) {
     return (
-      <Suspense fallback={<Loading fullScreen />}>
-        <LoginPage />
-      </Suspense>
+      <ErrorBoundary>
+        <Suspense fallback={<Loading fullScreen />}>
+          <LoginPage />
+        </Suspense>
+      </ErrorBoundary>
     );
   }
 
-  return <AppRoutes />;
+  return (
+    <ErrorBoundary>
+      <AppRoutes />
+    </ErrorBoundary>
+  );
 }

--- a/web/src/components/ErrorBoundary.jsx
+++ b/web/src/components/ErrorBoundary.jsx
@@ -1,0 +1,29 @@
+import React from "react"
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, info) {
+    console.error("Uncaught error:", error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-[70vh] flex flex-col items-center justify-center px-6 text-center space-y-4">
+          <h1 className="text-2xl font-bold">Oops! Something went wrong.</h1>
+          <p className="text-gray-600 dark:text-gray-400">Please refresh the page.</p>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/web/src/routes/AppRoutes.jsx
+++ b/web/src/routes/AppRoutes.jsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import React, { Suspense } from "react";
 import { useAuth } from "../pages/auth/useAuth";
 import Loading from "../components/Loading";
+import ErrorBoundary from "../components/ErrorBoundary";
 
 const LoginPage = React.lazy(() => import("../pages/auth/LoginPage"));
 const Dashboard = React.lazy(() => import("../pages/dashboard/Dashboard"));
@@ -43,8 +44,9 @@ export default function AppRoutes() {
   const { user } = useAuth();
 
   return (
-    <Suspense fallback={<Loading fullScreen />}>
-      <Routes>
+    <ErrorBoundary>
+      <Suspense fallback={<Loading fullScreen />}>
+        <Routes>
         {/* Login tidak pakai layout */}
         <Route
           path="/login"
@@ -78,7 +80,8 @@ export default function AppRoutes() {
           />
           <Route path="*" element={<NotFound />} />
         </Route>
-      </Routes>
-    </Suspense>
+        </Routes>
+      </Suspense>
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## Summary
- add a generic `ErrorBoundary` component
- wrap routes and login page with the boundary so runtime errors render a fallback instead of a blank page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6879ed4734ec832bb68385f56055380c