### PR TITLE
Add skeleton UI and toast notifications

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
         "react-select": "^5.10.2",
+        "react-toastify": "^11.0.5",
         "react-window": "^1.8.11",
         "sweetalert2": "10.16.9"
       },
@@ -9196,6 +9197,19 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/react-transition-group": {

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^7.6.3",
     "react-select": "^5.10.2",
     "react-window": "^1.8.11",
+    "react-toastify": "^11.0.5",
     "sweetalert2": "10.16.9"
   },
   "devDependencies": {

--- a/web/src/components/ui/Skeleton.jsx
+++ b/web/src/components/ui/Skeleton.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function Skeleton({ className = "", ...props }) {
+  return (
+    <div
+      className={`animate-pulse bg-gray-200 dark:bg-gray-700 rounded ${className}`.trim()}
+      {...props}
+    />
+  );
+}

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./assets/styles/index.css";
 import "sweetalert2/dist/sweetalert2.min.css";
+import "react-toastify/dist/ReactToastify.css";
 import { AuthProvider } from "./pages/auth/useAuth.jsx";
 import { ThemeProvider } from "./theme/useTheme.jsx";
 import { BrowserRouter } from "react-router-dom";

--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -6,6 +6,7 @@ import { useTheme } from "../../theme/useTheme.jsx";
 import Swal from "sweetalert2";
 import confirmAlert from "../../utils/confirmAlert";
 import axios from "axios";
+import { ToastContainer } from "react-toastify";
 import {
   FaBell,
   FaMoon,
@@ -276,6 +277,7 @@ export default function Layout() {
         <main className="p-4 overflow-y-auto flex-1 bg-gray-100 dark:bg-gray-900">
           <Outlet />
         </main>
+        <ToastContainer position="top-right" autoClose={3000} theme={theme} />
       </div>
     </div>
   );

--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -4,6 +4,7 @@ import { Listbox, Transition } from "@headlessui/react";
 import { ChevronUpDownIcon, CheckIcon } from "@heroicons/react/20/solid";
 import months from "../../utils/months";
 import Legend from "../../components/ui/Legend";
+import Skeleton from "../../components/ui/Skeleton";
 import DailyMatrix from "./DailyMatrix";
 import WeeklyMatrix from "./WeeklyMatrix";
 import MonthlyMatrix from "../../components/monitoring/MonthlyMatrix";
@@ -28,6 +29,7 @@ export default function MonitoringPage() {
   const [weeklyMonthData, setWeeklyMonthData] = useState([]);
   const [monthlyData, setMonthlyData] = useState([]);
   const [loading, setLoading] = useState(false);
+  const skeletonCols = tab === "harian" ? 7 : tab === "mingguan" ? 4 : 12;
 
   const mergeProgressWithUsers = useCallback(
     (data) => {
@@ -432,30 +434,35 @@ export default function MonitoringPage() {
         </div>
 
         {loading ? (
-          <div className="flex flex-col justify-center items-center h-72 space-y-3">
-            <svg
-              className="animate-spin h-10 w-10 text-blue-600"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-            >
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="4"
-              ></circle>
-              <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.364A8.001 8.001 0 0112 20v4c-6.627 0-12-5.373-12-12h4a8.001 8.001 0 006.364 2.93zM20 12a8 8 0 01-8 8v4c6.627 0 12-5.373 12-12h-4zm-2.93-6.364A8.001 8.001 0 0112 4V0c6.627 0 12 5.373 12 12h-4a8.001 8.001 0 00-6.364-2.93z"
-              ></path>
-            </svg>
-            <span className="text-lg font-medium text-gray-600 dark:text-gray-300">
-              Memuat data monitoring...
-            </span>
+          <div className="overflow-auto">
+            <table className="min-w-full text-xs border-collapse">
+              <thead>
+                <tr>
+                  <th className="p-2 border text-left">
+                    <Skeleton className="h-4 w-20" />
+                  </th>
+                  {Array.from({ length: skeletonCols }).map((_, i) => (
+                    <th key={i} className="p-1 border">
+                      <Skeleton className="h-4 w-full" />
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <tr key={i}>
+                    <td className="p-2 border">
+                      <Skeleton className="h-4 w-32" />
+                    </td>
+                    {Array.from({ length: skeletonCols }).map((_, j) => (
+                      <td key={j} className="p-1 border">
+                        <Skeleton className="h-4 w-full" />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         ) : (
           <div>

--- a/web/src/utils/alerts.js
+++ b/web/src/utils/alerts.js
@@ -1,25 +1,16 @@
-import Swal from "sweetalert2";
+import { toast } from "react-toastify";
 import confirmAlert from "./confirmAlert.js";
 
-const baseOptions = {
-  heightAuto: false,
-  width: 400,
+
+const showToast = (type, title, text) => {
+  toast[type](`${title}${text ? `: ${text}` : ""}`);
 };
 
-const showAlert = (title, text, icon) =>
-  Swal.fire({
-    title,
-    text,
-    icon,
-    confirmButtonText: "OK",
-    ...baseOptions,
-  });
+export const showSuccess = (title, text = "") => showToast("success", title, text);
 
-export const showSuccess = (title, text = "") => showAlert(title, text, "success");
+export const showError = (title, text = "") => showToast("error", title, text);
 
-export const showError = (title, text = "") => showAlert(title, text, "error");
-
-export const showWarning = (title, text = "") => showAlert(title, text, "warning");
+export const showWarning = (title, text = "") => showToast("warn", title, text);
 
 export const confirmDelete = (title = "Hapus item ini?") =>
   confirmAlert({


### PR DESCRIPTION
## Summary
- add generic `Skeleton` component for placeholder loading UI
- integrate `react-toastify` for notifications
- show skeleton table while monitoring data loads
- place ToastContainer in layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6879ed45703c832bbcab1a8a2d78a17a