### PR TITLE
Implement camelCase mapping for API data

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -15,7 +15,7 @@ export default defineConfig([
     ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, ...globals.jest },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/web/jest.setup.js
+++ b/web/jest.setup.js
@@ -1,3 +1,4 @@
+/* global global */
 import '@testing-library/jest-dom';
 import { TextEncoder } from 'util';
 

--- a/web/src/components/ui/DataTable.jsx
+++ b/web/src/components/ui/DataTable.jsx
@@ -58,7 +58,6 @@ export default function DataTable({
   data,
   initialPageSize = 10,
   showGlobalFilter = true,
-  showColumnFilters = true,
   initialSorting = [],
   onRowSelectionChange,
   showPagination = true,

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -7,10 +7,21 @@ import { AuthProvider } from "./pages/auth/useAuth.jsx";
 import { ThemeProvider } from "./theme/useTheme.jsx";
 import { BrowserRouter } from "react-router-dom";
 import axios from "axios";
+import camelizeKeys from "./utils/camelizeKeys.js";
 
 axios.defaults.baseURL =
   import.meta.env.VITE_API_URL || "http://localhost:3000";
 axios.defaults.withCredentials = true;
+
+axios.interceptors.response.use(
+  (response) => {
+    if (response.data && typeof response.data === "object") {
+      response.data = camelizeKeys(response.data);
+    }
+    return response;
+  },
+  (error) => Promise.reject(error)
+);
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>

--- a/web/src/pages/auth/useAuth.jsx
+++ b/web/src/pages/auth/useAuth.jsx
@@ -7,20 +7,22 @@ import {
   useEffect,
 } from "react";
 import axios from "axios";
+import camelizeKeys from "../../utils/camelizeKeys.js";
 
 const AuthContext = createContext();
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(() => {
     const u = localStorage.getItem("user");
-    return u ? JSON.parse(u) : null;
+    return u ? camelizeKeys(JSON.parse(u)) : null;
   });
 
   const verifyToken = async () => {
     try {
       const res = await axios.get("/auth/me");
-      setUser(res.data.user);
-      localStorage.setItem("user", JSON.stringify(res.data.user));
+      const userData = camelizeKeys(res.data.user);
+      setUser(userData);
+      localStorage.setItem("user", JSON.stringify(userData));
     } catch {
       localStorage.removeItem("user");
       setUser(null);

--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -245,7 +245,6 @@ export default function Layout() {
                             } ${
                               user?.team ||
                               user?.teamName ||
-                              user?.team_name ||
                               user?.namaTim ||
                               user?.members?.[0]?.team?.namaTim ||
                               ""

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -52,6 +52,7 @@ export default function PenugasanDetailPage() {
     deskripsi: "",
     status: STATUS.BELUM, // Belum, Sedang Dikerjakan, Selesai Dikerjakan
     catatan: "",
+    buktiLink: "",
   });
 
   const closeLaporanForm = useCallback(() => {
@@ -136,6 +137,7 @@ export default function PenugasanDetailPage() {
       }
       if (
         laporanForm.status === STATUS.SELESAI_DIKERJAKAN &&
+        !laporanForm.buktiLink.trim()
       ) {
         showWarning("Lengkapi data", "Link bukti wajib diisi");
         return;

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -135,7 +135,7 @@ export default function UsersPage() {
       { Header: "Email", accessor: "email" },
       {
         Header: "Tim",
-        accessor: (row) => row.members?.[0]?.team?.nama_tim || "-",
+        accessor: (row) => row.members?.[0]?.team?.namaTim || "-",
 
       },
       { Header: "Role", accessor: "role" },

--- a/web/src/utils/camelizeKeys.js
+++ b/web/src/utils/camelizeKeys.js
@@ -1,0 +1,16 @@
+function toCamel(str) {
+  return str.replace(/[_-](\w)/g, (_, c) => (c ? c.toUpperCase() : ''));
+}
+
+export default function camelizeKeys(data) {
+  if (Array.isArray(data)) {
+    return data.map(camelizeKeys);
+  }
+  if (data && typeof data === 'object' && data.constructor === Object) {
+    return Object.entries(data).reduce((acc, [key, value]) => {
+      acc[toCamel(key)] = camelizeKeys(value);
+      return acc;
+    }, {});
+  }
+  return data;
+}


### PR DESCRIPTION
## Summary
- automatically camelCase axios response data
- convert stored user data to camelCase
- clean up profile display and team columns
- validate buktiLink in Penugasan detail
- adjust ESLint config and DataTable props
- add camelizeKeys utility

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6879ed4417a4832b9567e3578f661d47