### PR TITLE
Switch monitoring tables to DataTable

### DIFF
--- a/web/src/components/monitoring/MonthlyMatrix.jsx
+++ b/web/src/components/monitoring/MonthlyMatrix.jsx
@@ -1,31 +1,9 @@
-import React from "react";
+import React, { useMemo } from "react";
+import DataTable from "../ui/DataTable";
 
-export const MonthlyMatrixRow = ({ user, progressColor, style }) => (
-  <tr className="text-center" style={style}>
-    <td className="p-2 border text-left whitespace-nowrap text-sm">{user.nama}</td>
-    {(user.months || []).map((b, idx) => (
-      <td key={idx} className="p-1 border space-y-1">
-        <div
-          role="progressbar"
-          aria-valuenow={b.persen}
-          aria-valuemin="0"
-          aria-valuemax="100"
-          className="w-full bg-gray-200 dark:bg-gray-700 rounded h-2"
-        >
-          <div
-            className={`${progressColor(b.persen)} h-2 rounded`}
-            style={{ width: `${b.persen}%` }}
-          />
-        </div>
-        <span className="text-xs font-medium">{b.persen}%</span>
-      </td>
-    ))}
-  </tr>
-);
 import months from "../../utils/months";
 
 const MonthlyMatrix = ({ data = [] }) => {
-  if (!Array.isArray(data) || data.length === 0) return null;
 
   const colorFor = (p) => {
     if (p >= 80) return "green";
@@ -42,25 +20,59 @@ const MonthlyMatrix = ({ data = [] }) => {
       : "bg-red-500";
   };
 
+  const columns = useMemo(() => {
+    if (!Array.isArray(data) || data.length === 0) return [];
+    const cols = [
+      {
+        Header: "Nama",
+        accessor: "nama",
+        meta: { cellClassName: "p-2 border text-left whitespace-nowrap text-sm" },
+        disableFilters: true,
+      },
+    ];
+    months.forEach((m, i) => {
+      cols.push({
+        id: `month-${i + 1}`,
+        Header: m.slice(0, 3),
+        accessor: (row) => (row.months || [])[i],
+        Cell: ({ row }) => {
+          const val = (row.original.months || [])[i] || { persen: 0 };
+          return (
+            <div className="space-y-1">
+              <div
+                role="progressbar"
+                aria-valuenow={val.persen}
+                aria-valuemin="0"
+                aria-valuemax="100"
+                className="w-full bg-gray-200 dark:bg-gray-700 rounded h-2"
+              >
+                <div
+                  className={`${progressColor(val.persen)} h-2 rounded`}
+                  style={{ width: `${val.persen}%` }}
+                />
+              </div>
+              <span className="text-xs font-medium">{val.persen}%</span>
+            </div>
+          );
+        },
+        meta: { cellClassName: "p-1 border text-center" },
+        disableFilters: true,
+      });
+    });
+    return cols;
+  }, [data, progressColor]);
+
+  if (!Array.isArray(data) || data.length === 0) return null;
+
   return (
     <div className="overflow-auto">
-      <table className="min-w-full text-xs border-collapse">
-        <thead>
-          <tr>
-            <th className="p-2 border text-left">Nama</th>
-            {months.map((m, i) => (
-              <th key={i} className="p-2 border text-center whitespace-nowrap">
-                {m.slice(0, 3)}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((u) => (
-            <MonthlyMatrixRow key={u.userId} user={u} progressColor={progressColor} />
-          ))}
-        </tbody>
-      </table>
+      <DataTable
+        columns={columns}
+        data={data}
+        showGlobalFilter={false}
+        showPagination={false}
+        selectable={false}
+      />
     </div>
   );
 };

--- a/web/src/components/ui/DataTable.jsx
+++ b/web/src/components/ui/DataTable.jsx
@@ -146,7 +146,7 @@ export default function DataTable({
                   className="px-4 py-3 font-semibold text-center border-t border-b border-gray-300 dark:border-gray-700 select-none"
                   onClick={header.column.getToggleSortingHandler()}
                 >
-                  <div className="flex items-center gap-1">
+                  <div className="flex items-center justify-center gap-1">
                     {flexRender(
                       header.column.columnDef.header,
                       header.getContext()
@@ -181,17 +181,24 @@ export default function DataTable({
                 key={row.id}
                 className="text-center odd:bg-white even:bg-gray-50 dark:odd:bg-gray-900 dark:even:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
               >
-                {row.getVisibleCells().map((cell) => (
-                  <td
-                    key={cell.id}
-                    className="px-4 py-3 border-t border-b border-gray-300 dark:border-gray-700"
-                  >
-                    {flexRender(
-                      cell.column.columnDef.cell ?? cell.getValue(),
-                      cell.getContext()
-                    )}
-                  </td>
-                ))}
+                {row.getVisibleCells().map((cell) => {
+                  let extra = cell.column.columnDef.meta?.cellClassName;
+                  if (typeof extra === "function") {
+                    extra = extra(cell);
+                  }
+                  if (!extra) extra = "px-4 py-3";
+                  return (
+                    <td
+                      key={cell.id}
+                      className={`${extra} border-t border-b border-gray-300 dark:border-gray-700`}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell ?? cell.getValue(),
+                        cell.getContext()
+                      )}
+                    </td>
+                  );
+                })}
               </tr>
             ))
           )}

--- a/web/src/pages/monitoring/DailyMatrix.jsx
+++ b/web/src/pages/monitoring/DailyMatrix.jsx
@@ -1,18 +1,12 @@
+import React, { useMemo } from "react";
 import { getHolidays } from "../../utils/holidays";
+import DataTable from "../../components/ui/DataTable";
 
-export const DailyMatrixRow = ({ user, boxClass, style }) => (
-  <tr className="text-center" style={style}>
-    <td className="p-2 border text-left whitespace-nowrap text-sm">{user.nama}</td>
-    {user.detail.map((day, i) => (
-      <td key={i} className={`p-1 border ${boxClass(day)}`}>{day.count || ""}</td>
-    ))}
-  </tr>
-);
 
 const DailyMatrix = ({ data = [] }) => {
-  if (!Array.isArray(data) || data.length === 0) return null;
-
-  const year = new Date(data[0].detail[0].tanggal).getFullYear();
+  const year = data[0]?.detail?.[0]
+    ? new Date(data[0].detail[0].tanggal).getFullYear()
+    : new Date().getFullYear();
   const today = new Date().toISOString().slice(0, 10);
   const HOLIDAYS = getHolidays(year);
 
@@ -37,27 +31,45 @@ const DailyMatrix = ({ data = [] }) => {
     return "bg-gray-100 dark:bg-gray-700";
   };
 
-  const dayCount = data[0].detail.length;
+  const dayCount = data[0]?.detail?.length || 0;
+
+  const columns = useMemo(() => {
+    if (dayCount === 0) return [];
+    const cols = [
+      {
+        Header: "Nama",
+        accessor: "nama",
+        meta: { cellClassName: "p-2 border text-left whitespace-nowrap text-sm" },
+        disableFilters: true,
+      },
+    ];
+    for (let i = 0; i < dayCount; i += 1) {
+      cols.push({
+        id: `day-${i + 1}`,
+        Header: i + 1,
+        accessor: (row) => row.detail[i],
+        Cell: ({ row }) => row.original.detail[i].count || "",
+        meta: {
+          cellClassName: (cell) =>
+            `p-1 border text-center ${boxClass(cell.getValue())}`,
+        },
+        disableFilters: true,
+      });
+    }
+    return cols;
+  }, [dayCount, boxClass]);
+
+  if (!Array.isArray(data) || data.length === 0) return null;
 
   return (
     <div className="overflow-auto md:overflow-visible">
-      <table className="min-w-full text-xs border-collapse">
-        <thead>
-          <tr>
-            <th className="p-2 border text-left">Nama</th>
-            {Array.from({ length: dayCount }, (_, i) => (
-              <th key={i} className="p-1 border text-center">
-                {i + 1}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((u) => (
-            <DailyMatrixRow key={u.userId} user={u} boxClass={boxClass} />
-          ))}
-        </tbody>
-      </table>
+      <DataTable
+        columns={columns}
+        data={data}
+        showGlobalFilter={false}
+        showPagination={false}
+        selectable={false}
+      />
     </div>
   );
 };

--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, Fragment, useCallback } from "react";
+import { useEffect, useState, Fragment, useCallback, useMemo } from "react";
 import axios from "axios";
 import { Listbox, Transition } from "@headlessui/react";
 import { ChevronUpDownIcon, CheckIcon } from "@heroicons/react/20/solid";
@@ -11,9 +11,9 @@ import MonthlyMatrix from "../../components/monitoring/MonthlyMatrix";
 import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
 import { handleAxiosError } from "../../utils/alerts";
+import DataTable from "../../components/ui/DataTable";
 
 const WeeklyProgressTable = ({ data = [] }) => {
-  if (!Array.isArray(data) || data.length === 0) return null;
 
   const colorFor = (p) => {
     if (p >= 80) return "green";
@@ -30,42 +30,64 @@ const WeeklyProgressTable = ({ data = [] }) => {
       : "bg-red-500";
   };
 
+  const columns = useMemo(
+    () => [
+      {
+        Header: "Nama",
+        accessor: "nama",
+        meta: { cellClassName: "p-2 border text-left whitespace-nowrap text-sm" },
+        disableFilters: true,
+      },
+      {
+        Header: "Selesai",
+        accessor: "selesai",
+        meta: { cellClassName: "p-1 border text-center" },
+        disableFilters: true,
+      },
+      {
+        Header: "Total",
+        accessor: "total",
+        meta: { cellClassName: "p-1 border text-center" },
+        disableFilters: true,
+      },
+      {
+        Header: "Progress",
+        accessor: "persen",
+        Cell: ({ row }) => (
+          <div className="space-y-1">
+            <div
+              role="progressbar"
+              aria-valuenow={row.original.persen}
+              aria-valuemin="0"
+              aria-valuemax="100"
+              className="w-full bg-gray-200 dark:bg-gray-700 rounded h-2"
+            >
+              <div
+                className={`${progressColor(row.original.persen)} h-2 rounded`}
+                style={{ width: `${row.original.persen}%` }}
+              />
+            </div>
+            <span className="text-xs font-medium">{row.original.persen}%</span>
+          </div>
+        ),
+        meta: { cellClassName: "p-1 border text-center" },
+        disableFilters: true,
+      },
+    ],
+    [data, progressColor]
+  );
+
+  if (!Array.isArray(data) || data.length === 0) return null;
+
   return (
     <div className="overflow-auto md:overflow-visible mt-4">
-      <table className="min-w-full text-xs border-collapse">
-        <thead>
-          <tr>
-            <th className="p-2 border text-left">Nama</th>
-            <th className="p-2 border text-center">Selesai</th>
-            <th className="p-2 border text-center">Total</th>
-            <th className="p-2 border text-center">Progress</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((u) => (
-            <tr key={u.userId} className="text-center">
-              <td className="p-2 border text-left whitespace-nowrap text-sm">{u.nama}</td>
-              <td className="p-1 border">{u.selesai}</td>
-              <td className="p-1 border">{u.total}</td>
-              <td className="p-1 border space-y-1">
-                <div
-                  role="progressbar"
-                  aria-valuenow={u.persen}
-                  aria-valuemin="0"
-                  aria-valuemax="100"
-                  className="w-full bg-gray-200 dark:bg-gray-700 rounded h-2"
-                >
-                  <div
-                    className={`${progressColor(u.persen)} h-2 rounded`}
-                    style={{ width: `${u.persen}%` }}
-                  />
-                </div>
-                <span className="text-xs font-medium">{u.persen}%</span>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <DataTable
+        columns={columns}
+        data={data}
+        showGlobalFilter={false}
+        showPagination={false}
+        selectable={false}
+      />
     </div>
   );
 };

--- a/web/src/pages/monitoring/WeeklyMatrix.jsx
+++ b/web/src/pages/monitoring/WeeklyMatrix.jsx
@@ -1,30 +1,8 @@
-import React from "react";
+import React, { useMemo } from "react";
+import DataTable from "../../components/ui/DataTable";
 
-export const WeeklyMatrixRow = ({ user, progressColor, style }) => (
-  <tr className="text-center" style={style}>
-    <td className="p-2 border text-left whitespace-nowrap text-sm">{user.nama}</td>
-    {user.weeks.map((w, i) => (
-      <td key={i} className="p-1 border space-y-1">
-        <div
-          role="progressbar"
-          aria-valuenow={w.persen}
-          aria-valuemin="0"
-          aria-valuemax="100"
-          className="w-full bg-gray-200 dark:bg-gray-700 rounded h-2"
-        >
-          <div
-            className={`${progressColor(w.persen)} h-2 rounded`}
-            style={{ width: `${w.persen}%` }}
-          />
-        </div>
-        <span className="text-xs font-medium">{w.persen}%</span>
-      </td>
-    ))}
-  </tr>
-);
 
 const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek }) => {
-  if (!Array.isArray(data) || data.length === 0) return null;
 
   const colorFor = (p) => {
     if (p >= 80) return "green";
@@ -41,29 +19,60 @@ const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek }) => {
       : "bg-red-500";
   };
 
+  const columns = useMemo(() => {
+    if (!Array.isArray(data) || data.length === 0) return [];
+    const cols = [
+      {
+        Header: "Nama",
+        accessor: "nama",
+        meta: { cellClassName: "p-2 border text-left whitespace-nowrap text-sm" },
+        disableFilters: true,
+      },
+    ];
+    weeks.forEach((_, i) => {
+      cols.push({
+        id: `week-${i + 1}`,
+        Header: (
+          <span onClick={() => onSelectWeek && onSelectWeek(i)} className="cursor-pointer">
+            Minggu {i + 1}
+          </span>
+        ),
+        accessor: (row) => row.weeks[i],
+        Cell: ({ row }) => (
+          <div className="space-y-1">
+            <div
+              role="progressbar"
+              aria-valuenow={row.original.weeks[i].persen}
+              aria-valuemin="0"
+              aria-valuemax="100"
+              className="w-full bg-gray-200 dark:bg-gray-700 rounded h-2"
+            >
+              <div
+                className={`${progressColor(row.original.weeks[i].persen)} h-2 rounded`}
+                style={{ width: `${row.original.weeks[i].persen}%` }}
+              />
+            </div>
+            <span className="text-xs font-medium">{row.original.weeks[i].persen}%</span>
+          </div>
+        ),
+        meta: { cellClassName: "p-1 border text-center" },
+        disableFilters: true,
+      });
+    });
+    return cols;
+  }, [weeks, onSelectWeek, progressColor, data]);
+
+  if (!Array.isArray(data) || data.length === 0) return null;
+
   return (
     <div className="overflow-auto md:overflow-visible">
-      <table className="min-w-full text-xs border-collapse">
-        <thead>
-          <tr>
-            <th className="p-2 border text-left">Nama</th>
-            {weeks.map((_, i) => (
-              <th
-                key={i}
-                onClick={() => onSelectWeek && onSelectWeek(i)}
-                className="p-2 border text-center cursor-pointer"
-              >
-                Minggu {i + 1}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((u) => (
-            <WeeklyMatrixRow key={u.userId} user={u} progressColor={progressColor} />
-          ))}
-        </tbody>
-      </table>
+      <DataTable
+        columns={columns}
+        data={data}
+        showGlobalFilter={false}
+        showPagination={false}
+        selectable={false}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- center DataTable headers
- allow DataTable columns to specify cell class names
- refactor monitoring tables to use the DataTable component

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687a10f4a490832b838bf4e821131975