### PR TITLE
Switch other tables to DataTable

### DIFF
--- a/web/src/components/ui/DataTable.jsx
+++ b/web/src/components/ui/DataTable.jsx
@@ -146,7 +146,7 @@ export default function DataTable({
                   className="px-4 py-3 font-semibold text-center border-t border-b border-gray-300 dark:border-gray-700 select-none"
                   onClick={header.column.getToggleSortingHandler()}
                 >
-                  <div className="flex items-center gap-1">
+                  <div className="flex items-center justify-center gap-1">
                     {flexRender(
                       header.column.columnDef.header,
                       header.getContext()
@@ -181,17 +181,24 @@ export default function DataTable({
                 key={row.id}
                 className="text-center odd:bg-white even:bg-gray-50 dark:odd:bg-gray-900 dark:even:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
               >
-                {row.getVisibleCells().map((cell) => (
-                  <td
-                    key={cell.id}
-                    className="px-4 py-3 border-t border-b border-gray-300 dark:border-gray-700"
-                  >
-                    {flexRender(
-                      cell.column.columnDef.cell ?? cell.getValue(),
-                      cell.getContext()
-                    )}
-                  </td>
-                ))}
+                {row.getVisibleCells().map((cell) => {
+                  let extra = cell.column.columnDef.meta?.cellClassName;
+                  if (typeof extra === "function") {
+                    extra = extra(cell);
+                  }
+                  if (!extra) extra = "px-4 py-3";
+                  return (
+                    <td
+                      key={cell.id}
+                      className={`${extra} border-t border-b border-gray-300 dark:border-gray-700`}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell ?? cell.getValue(),
+                        cell.getContext()
+                      )}
+                    </td>
+                  );
+                })}
               </tr>
             ))
           )}

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -4,8 +4,7 @@ import { Pencil, Trash2, ExternalLink, X } from "lucide-react";
 import { showSuccess, handleAxiosError } from "../../utils/alerts";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
-import Table from "../../components/ui/Table";
-import tableStyles from "../../components/ui/Table.module.css";
+import DataTable from "../../components/ui/DataTable";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
@@ -86,6 +85,56 @@ export default function LaporanHarianPage() {
   );
   const totalPages = Math.ceil(filtered.length / pageSize) || 1;
 
+  const columns = [
+    {
+      Header: "No",
+      accessor: (_row, i) => (currentPage - 1) * pageSize + i + 1,
+      disableFilters: true,
+    },
+    {
+      Header: "Kegiatan",
+      accessor: (row) => row.penugasan?.kegiatan?.namaKegiatan || "-",
+      disableFilters: true,
+    },
+    {
+      Header: "Tim",
+      accessor: (row) => row.penugasan?.tim?.namaTim || "-",
+      disableFilters: true,
+    },
+    {
+      Header: "Deskripsi Kegiatan",
+      accessor: (row) => row.penugasan?.kegiatan?.deskripsi || "-",
+      disableFilters: true,
+    },
+    {
+      Header: "Status",
+      accessor: "status",
+      Cell: ({ row }) => <StatusBadge status={row.original.status} />,
+      disableFilters: true,
+    },
+    {
+      Header: "Bukti",
+      accessor: (row) => row.buktiLink,
+      Cell: ({ row }) =>
+        row.original.buktiLink ? (
+          <a href={row.original.buktiLink} target="_blank" rel="noreferrer">
+            <ExternalLink
+              size={16}
+              className="mx-auto text-blue-600 dark:text-blue-400"
+            />
+          </a>
+        ) : (
+          <X className="w-4 h-4 text-red-600" />
+        ),
+      disableFilters: true,
+    },
+    {
+      Header: "Catatan",
+      accessor: (row) => row.catatan || "-",
+      disableFilters: true,
+    },
+  ];
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-end gap-2">
@@ -109,107 +158,19 @@ export default function LaporanHarianPage() {
       </div>
       <>
         <div className="overflow-x-auto md:overflow-x-visible">
-          <Table>
-            <thead>
-              <tr className={tableStyles.headerRow}>
-                <th className={tableStyles.cell}>No</th>
-                <th className={tableStyles.cell}>Kegiatan</th>
-                <th className={tableStyles.cell}>Deskripsi Kegiatan</th>
-                <th className={tableStyles.cell}>Tanggal</th>
-                <th className={tableStyles.cell}>Status</th>
-                <th className={tableStyles.cell}>Bukti</th>
-                <th className={tableStyles.cell}>Catatan</th>
-              </tr>
-            </thead>
-            <tbody>
-              {loading ? (
-                <tr>
-                  <td colSpan="7" className="py-10">
-                    <div className="flex flex-col items-center justify-center space-y-3">
-                      <svg
-                        className="animate-spin h-8 w-8 text-blue-600"
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                      >
-                        <circle
-                          className="opacity-25"
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke="currentColor"
-                          strokeWidth="4"
-                        ></circle>
-                        <path
-                          className="opacity-75"
-                          fill="currentColor"
-                          d="M4 12a8 8 0 018-8V0C5.373 
-              0 0 5.373 0 12h4zm2.93 6.364A8.001 
-              8.001 0 0112 20v4c-6.627 
-              0-12-5.373-12-12h4a8.001 
-              8.001 0 006.364 2.93z"
-                        ></path>
-                      </svg>
-                      <p className="text-gray-600 dark:text-gray-300 text-sm font-medium tracking-wide">
-                        Memuat data laporan...
-                      </p>
-                    </div>
-                  </td>
-                </tr>
-              ) : filtered.length === 0 ? (
-                <tr>
-                  <td
-                    colSpan="7"
-                    className="py-6 text-center text-gray-600 dark:text-gray-300"
-                  >
-                    <div className="flex flex-col items-center space-y-1">
-                      <span className="text-xl">🫰🫰🤟🤟😜☝☝</span>
-                      <span className="text-sm font-medium tracking-wide">
-                        Data tidak ditemukan.
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-              ) : (
-                paginated.map((item, idx) => (
-                  <tr key={item.id} className={tableStyles.row}>
-                    <td className={tableStyles.cell}>
-                      {(currentPage - 1) * pageSize + idx + 1}
-                    </td>
-                    <td className={tableStyles.cell}>
-                      {item.penugasan?.kegiatan?.namaKegiatan || "-"}
-                    </td>
-                    <td className={tableStyles.cell}>
-                      {item.penugasan?.tim?.namaTim || "-"}
-                    </td>
-                    <td className={tableStyles.cell}>
-                      {item.penugasan?.kegiatan?.deskripsi || "-"}
-                    </td>
-                    <td className={tableStyles.cell}>
-                      <StatusBadge status={item.status} />
-                    </td>
-                    <td className={tableStyles.cell}>
-                      {item.buktiLink ? (
-                        <a
-                          href={item.buktiLink}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          <ExternalLink
-                            size={16}
-                            className="mx-auto text-blue-600 dark:text-blue-400"
-                          />
-                        </a>
-                      ) : (
-                        <X className="w-4 h-4 text-red-600" />
-                      )}
-                    </td>
-                    <td className={tableStyles.cell}>{item.catatan || "-"}</td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </Table>
+          {loading ? (
+            <div className="py-10">
+              <div className="flex flex-col items-center justify-center space-y-3">
+                <svg className="animate-spin h-8 w-8 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.364A8.001 8.001 0 0112 20v4c-6.627 0-12-5.373-12-12h4a8.001 8.001 0 006.364 2.93z"></path>
+                </svg>
+                <p className="text-gray-600 dark:text-gray-300 text-sm font-medium tracking-wide">Memuat data laporan...</p>
+              </div>
+            </div>
+          ) : (
+            <DataTable columns={columns} data={paginated} showGlobalFilter={false} showPagination={false} selectable={false} />
+          )}
           <div className="flex items-center justify-between mt-2">
             <SelectDataShow
               value={pageSize}

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import axios from "axios";
 import {
   showSuccess,
@@ -12,8 +12,7 @@ import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import useModalForm from "../../hooks/useModalForm";
-import Table from "../../components/ui/Table";
-import tableStyles from "../../components/ui/Table.module.css";
+import DataTable from "../../components/ui/DataTable";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
@@ -41,6 +40,53 @@ export default function MasterKegiatanPage() {
   const [filterTeam, setFilterTeam] = useState("");
   const [search, setSearch] = useState("");
   const totalPages = lastPage || 1;
+
+  const columns = useMemo(
+    () => [
+      {
+        Header: "No",
+        accessor: (_row, i) => (page - 1) * perPage + i + 1,
+        disableFilters: true,
+      },
+      {
+        Header: "Tim",
+        accessor: (row) => row.team?.namaTim || row.teamId,
+        disableFilters: true,
+      },
+      { Header: "Nama Kegiatan", accessor: "namaKegiatan", disableFilters: true },
+      {
+        Header: "Deskripsi",
+        accessor: (row) => row.deskripsi || "-",
+        disableFilters: true,
+      },
+      {
+        Header: "Aksi",
+        accessor: "id",
+        Cell: ({ row }) => (
+          <div className="space-x-2">
+            <Button
+              onClick={() => openEdit(row.original)}
+              variant="warning"
+              icon
+              aria-label="Edit"
+            >
+              <Pencil size={16} />
+            </Button>
+            <Button
+              onClick={() => deleteItem(row.original)}
+              variant="danger"
+              icon
+              aria-label="Hapus"
+            >
+              <Trash2 size={16} />
+            </Button>
+          </div>
+        ),
+        disableFilters: true,
+      },
+    ],
+    [page, perPage, openEdit, deleteItem]
+  );
   const fetchItems = useCallback(async () => {
     try {
       setLoading(true);
@@ -82,13 +128,13 @@ export default function MasterKegiatanPage() {
     openCreateForm();
   };
 
-  const openEdit = (item) => {
+  function openEdit(item) {
     openEditForm(item, (i) => ({
       teamId: i.teamId,
       namaKegiatan: i.namaKegiatan,
       deskripsi: i.deskripsi || "",
     }));
-  };
+  }
 
   const saveItem = async () => {
     if (!form.teamId || isNaN(form.teamId) || !form.namaKegiatan) {
@@ -109,7 +155,7 @@ export default function MasterKegiatanPage() {
     }
   };
 
-  const deleteItem = async (item) => {
+  async function deleteItem(item) {
     const r = await confirmDelete("Hapus kegiatan ini?");
     if (!r.isConfirmed) return;
     try {
@@ -119,7 +165,7 @@ export default function MasterKegiatanPage() {
     } catch (err) {
       handleAxiosError(err, "Gagal menghapus kegiatan");
     }
-  };
+  }
 
   if (![ROLES.KETUA, ROLES.ADMIN].includes(user?.role)) {
     return (
@@ -178,65 +224,13 @@ export default function MasterKegiatanPage() {
       </div>
 
       <div className="overflow-x-auto md:overflow-x-visible">
-      <Table>
-        <thead>
-          <tr className={tableStyles.headerRow}>
-            <th className={tableStyles.cell}>No</th>
-            <th className={tableStyles.cell}>Tim</th>
-            <th className={tableStyles.cell}>Nama Kegiatan</th>
-            <th className={tableStyles.cell}>Deskripsi</th>
-            <th className={tableStyles.cell}>Aksi</th>
-          </tr>
-        </thead>
-        <tbody>
-          {loading ? (
-            <tr>
-              <td colSpan="5" className="py-4 text-center">
-                <Spinner className="h-6 w-6 mx-auto" />
-              </td>
-            </tr>
-          ) : items.length === 0 ? (
-            <tr>
-              <td colSpan="5" className="py-4 text-center">
-                Data tidak ditemukan
-              </td>
-            </tr>
-          ) : (
-            items.map((item, idx) => (
-              <tr key={item.id} className={tableStyles.row}>
-                <td className={tableStyles.cell}>
-                  {(page - 1) * perPage + idx + 1}
-                </td>
-                <td className={tableStyles.cell}>
-                  {item.team?.namaTim || item.teamId}
-                </td>
-                <td className={tableStyles.cell}>{item.namaKegiatan}</td>
-                <td className={tableStyles.cell}>
-                  {!item.deskripsi ? "-" : item.deskripsi}
-                </td>
-                <td className={`${tableStyles.cell} space-x-2`}>
-                  <Button
-                    onClick={() => openEdit(item)}
-                    variant="warning"
-                    icon
-                    aria-label="Edit"
-                  >
-                    <Pencil size={16} />
-                  </Button>
-                  <Button
-                    onClick={() => deleteItem(item)}
-                    variant="danger"
-                    icon
-                    aria-label="Hapus"
-                  >
-                    <Trash2 size={16} />
-                  </Button>
-                </td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </Table>
+        {loading ? (
+          <div className="py-4 text-center">
+            <Spinner className="h-6 w-6 mx-auto" />
+          </div>
+        ) : (
+          <DataTable columns={columns} data={items} showGlobalFilter={false} showPagination={false} selectable={false} />
+        )}
       </div>
 
       <div className="flex items-center justify-between mt-4">

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useRef, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
 import {
@@ -17,8 +17,7 @@ import { ROLES } from "../../utils/roles";
 import { STATUS, formatStatus } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
 import Modal from "../../components/ui/Modal";
-import Table from "../../components/ui/Table";
-import tableStyles from "../../components/ui/Table.module.css";
+import DataTable from "../../components/ui/DataTable";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
@@ -191,6 +190,80 @@ export default function PenugasanDetailPage() {
       handleAxiosError(err, "Gagal menghapus laporan");
     }
   };
+
+  const columns = useMemo(
+    () => [
+      {
+        Header: "No",
+        accessor: (_row, i) => i + 1,
+        disableFilters: true,
+      },
+      { Header: "Deskripsi", accessor: "deskripsi", disableFilters: true },
+      {
+        Header: "Tanggal",
+        accessor: (row) => formatDMY(row.tanggal),
+        disableFilters: true,
+      },
+      {
+        Header: "Status",
+        accessor: "status",
+        Cell: ({ row }) => <StatusBadge status={row.original.status} />,
+        disableFilters: true,
+      },
+      {
+        Header: "Bukti",
+        accessor: "buktiLink",
+        Cell: ({ row }) =>
+          row.original.buktiLink ? (
+            <a
+              href={row.original.buktiLink}
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Lihat bukti dukung"
+            >
+              <ExternalLink
+                size={16}
+                className="mx-auto text-blue-600 dark:text-blue-400 hover:scale-110 transition-transform"
+              />
+            </a>
+          ) : (
+            "-"
+          ),
+        disableFilters: true,
+      },
+      {
+        Header: "Catatan",
+        accessor: (row) => row.catatan || "-",
+        disableFilters: true,
+      },
+      {
+        Header: "Aksi",
+        accessor: "id",
+        Cell: ({ row }) => (
+          <div className="space-x-2">
+            <Button
+              onClick={() => editLaporan(row.original)}
+              variant="warning"
+              icon
+              aria-label="Edit laporan"
+            >
+              <Pencil size={14} />
+            </Button>
+            <Button
+              onClick={() => deleteLaporan(row.original.id)}
+              variant="danger"
+              icon
+              aria-label="Hapus laporan"
+            >
+              <Trash2 size={14} />
+            </Button>
+          </div>
+        ),
+        disableFilters: true,
+      },
+    ],
+    [editLaporan, deleteLaporan]
+  );
 
   const remove = async () => {
     const r = await confirmDelete("Hapus penugasan ini?");
@@ -475,78 +548,7 @@ export default function PenugasanDetailPage() {
         </div>
 
         <div className="overflow-x-auto md:overflow-x-visible rounded-lg border dark:border-gray-700">
-          <Table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead>
-              <tr className={tableStyles.headerRow}>
-                <th className={tableStyles.cell}>No</th>
-                <th className={tableStyles.cell}>Deskripsi</th>
-                <th className={tableStyles.cell}>Tanggal</th>
-                <th className={tableStyles.cell}>Status</th>
-                <th className={tableStyles.cell}>Bukti</th>
-                <th className={tableStyles.cell}>Catatan</th>
-                <th className={tableStyles.cell}>Aksi</th>
-              </tr>
-            </thead>
-            <tbody>
-              {laporan.length === 0 ? (
-                <tr>
-                  <td
-                    colSpan="7"
-                    className="py-6 text-center text-gray-500 dark:text-gray-400"
-                  >
-                    Belum ada laporan
-                  </td>
-                </tr>
-              ) : (
-                laporan.map((l, idx) => (
-                  <tr key={l.id} className={tableStyles.row}>
-                    <td className={tableStyles.cell}>{idx + 1}</td>
-                    <td className={tableStyles.cell}>{l.deskripsi}</td>
-                    <td className={tableStyles.cell}>{formatDMY(l.tanggal)}</td>
-                    <td className={tableStyles.cell}>
-                      <StatusBadge status={l.status} />
-                    </td>
-                    <td className={tableStyles.cell}>
-                      {l.buktiLink ? (
-                        <a
-                          href={l.buktiLink}
-                          target="_blank"
-                          rel="noreferrer"
-                          aria-label="Lihat bukti dukung"
-                        >
-                          <ExternalLink
-                            size={16}
-                            className="mx-auto text-blue-600 dark:text-blue-400 hover:scale-110 transition-transform"
-                          />
-                        </a>
-                      ) : (
-                        "-"
-                      )}
-                    </td>
-                    <td className={tableStyles.cell}>{l.catatan || "-"}</td>
-                    <td className={`${tableStyles.cell} space-x-2`}>
-                      <Button
-                        onClick={() => editLaporan(l)}
-                        variant="warning"
-                        icon
-                        aria-label="Edit laporan"
-                      >
-                        <Pencil size={14} />
-                      </Button>
-                      <Button
-                        onClick={() => deleteLaporan(l.id)}
-                        variant="danger"
-                        icon
-                        aria-label="Hapus laporan"
-                      >
-                        <Trash2 size={14} />
-                      </Button>
-                    </td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </Table>
+          <DataTable columns={columns} data={laporan} showGlobalFilter={false} showPagination={false} selectable={false} />
         </div>
       </div>
 

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -15,8 +15,7 @@ import { useNavigate } from "react-router-dom";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
 import useModalForm from "../../hooks/useModalForm";
-import Table from "../../components/ui/Table";
-import tableStyles from "../../components/ui/Table.module.css";
+import DataTable from "../../components/ui/DataTable";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
@@ -163,6 +162,59 @@ export default function PenugasanPage() {
   );
   const totalPages = Math.ceil(filtered.length / pageSize) || 1;
 
+  const columns = useMemo(
+    () => [
+      {
+        Header: "No",
+        accessor: (_row, i) => (currentPage - 1) * pageSize + i + 1,
+        disableFilters: true,
+      },
+      {
+        Header: "Kegiatan",
+        accessor: (row) => row.kegiatan?.namaKegiatan || "-",
+        disableFilters: true,
+      },
+      {
+        Header: "Tim",
+        accessor: (row) => row.kegiatan?.team?.namaTim || "-",
+        disableFilters: true,
+      },
+      {
+        Header: "Pegawai",
+        accessor: (row) => row.pegawai?.nama || "-",
+        disableFilters: true,
+      },
+      { Header: "Minggu", accessor: "minggu", disableFilters: true },
+      {
+        Header: "Bulan",
+        accessor: (row) => `${months[row.bulan - 1]} ${row.tahun}`,
+        disableFilters: true,
+      },
+      {
+        Header: "Status",
+        accessor: "status",
+        Cell: ({ row }) => <StatusBadge status={row.original.status} />,
+        disableFilters: true,
+      },
+      {
+        Header: "Aksi",
+        accessor: "id",
+        Cell: ({ row }) => (
+          <Button
+            onClick={() => navigate(`/tugas-mingguan/${row.original.id}`)}
+            variant="icon"
+            icon
+            aria-label="Detail"
+          >
+            <Eye size={16} />
+          </Button>
+        ),
+        disableFilters: true,
+      },
+    ],
+    [currentPage, pageSize, navigate]
+  );
+
   return (
     <div className="space-y-6">
       <div className="flex flex-wrap justify-between items-center gap-2">
@@ -198,105 +250,19 @@ export default function PenugasanPage() {
       </div>
 
       <div className="overflow-x-auto md:overflow-x-visible">
-      <Table>
-        <thead>
-          <tr className={tableStyles.headerRow}>
-            <th className={tableStyles.cell}>No</th>
-            <th className={tableStyles.cell}>Kegiatan</th>
-            <th className={tableStyles.cell}>Tim</th>
-            <th className={tableStyles.cell}>Pegawai</th>
-            <th className={tableStyles.cell}>Minggu</th>
-            <th className={tableStyles.cell}>Bulan</th>
-            <th className={tableStyles.cell}>Status</th>
-            <th className={tableStyles.cell}>Aksi</th>
-          </tr>
-        </thead>
-        <tbody>
-          {loading ? (
-            <tr>
-              <td
-                colSpan="7"
-                className="py-6 text-center text-gray-600 dark:text-gray-300"
-              >
-                <div className="flex flex-col items-center space-y-2">
-                  <svg
-                    className="animate-spin h-6 w-6 text-blue-600"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 
-            6.364A8.001 8.001 0 0112 20v4c-6.627 
-            0-12-5.373-12-12h4a8.001 8.001 
-            0 006.364 2.93z"
-                    ></path>
-                  </svg>
-                  <span className="text-sm font-medium tracking-wide">
-                    Memuat data...
-                  </span>
-                </div>
-              </td>
-            </tr>
-          ) : filtered.length === 0 ? (
-            <tr>
-              <td
-                colSpan="7"
-                className="py-6 text-center text-gray-600 dark:text-gray-300"
-              >
-                <div className="flex flex-col items-center space-y-1">
-                  <span className="text-xl">🫰🫰🤟🤟😜☝☝</span>
-                  <span className="text-sm font-medium tracking-wide">
-                    Data tidak ditemukan.
-                  </span>
-                </div>
-              </td>
-            </tr>
-          ) : (
-            paginated.map((p, idx) => (
-              <tr key={p.id} className={tableStyles.row}>
-                <td className={tableStyles.cell}>
-                  {(currentPage - 1) * pageSize + idx + 1}
-                </td>
-                <td className={tableStyles.cell}>
-                  {p.kegiatan?.namaKegiatan || "-"}
-                </td>
-                <td className={tableStyles.cell}>
-                  {p.kegiatan?.team?.namaTim || "-"}
-                </td>
-                <td className={tableStyles.cell}>{p.pegawai?.nama || "-"}</td>
-                <td className={tableStyles.cell}>{p.minggu}</td>
-                <td className={tableStyles.cell}>
-                  {months[p.bulan - 1]} {p.tahun}
-                </td>
-                <td className={tableStyles.cell}>
-                  <StatusBadge status={p.status} />
-                </td>
-                <td className={tableStyles.cell}>
-                  <Button
-                    onClick={() => navigate(`/tugas-mingguan/${p.id}`)}
-                    variant="icon"
-                    icon
-                    aria-label="Detail"
-                  >
-                    <Eye size={16} />
-                  </Button>
-                </td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </Table>
+        {loading ? (
+          <div className="py-6 text-center text-gray-600 dark:text-gray-300">
+            <div className="flex flex-col items-center space-y-2">
+              <svg className="animate-spin h-6 w-6 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.364A8.001 8.001 0 0112 20v4c-6.627 0-12-5.373-12-12h4a8.001 8.001 0 006.364 2.93z"></path>
+              </svg>
+              <span className="text-sm font-medium tracking-wide">Memuat data...</span>
+            </div>
+          </div>
+        ) : (
+          <DataTable columns={columns} data={paginated} showGlobalFilter={false} showPagination={false} selectable={false} />
+        )}
       </div>
 
       <div className="flex items-center justify-between mt-4">

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -2,8 +2,7 @@ import { useEffect, useState, useMemo } from "react";
 import axios from "axios";
 import { showSuccess, confirmDelete, handleAxiosError } from "../../utils/alerts";
 import { Plus, Eye, Pencil, Trash2 } from "lucide-react";
-import Table from "../../components/ui/Table";
-import tableStyles from "../../components/ui/Table.module.css";
+import DataTable from "../../components/ui/DataTable";
 import { useNavigate } from "react-router-dom";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
@@ -154,6 +153,78 @@ export default function TugasTambahanPage() {
   );
   const totalPages = Math.ceil(filteredItems.length / pageSize) || 1;
 
+  const columns = useMemo(
+    () => [
+      {
+        Header: "No",
+        accessor: (_row, i) => (currentPage - 1) * pageSize + i + 1,
+        disableFilters: true,
+      },
+      { Header: "Kegiatan", accessor: "nama", disableFilters: true },
+      {
+        Header: "Tim",
+        accessor: (row) => row.kegiatan.team?.namaTim || "-",
+        disableFilters: true,
+      },
+      {
+        Header: "Tanggal",
+        accessor: (row) => row.tanggal.slice(0, 10),
+        disableFilters: true,
+      },
+      {
+        Header: "Deskripsi",
+        accessor: (row) => row.deskripsi || "-",
+        disableFilters: true,
+      },
+      {
+        Header: "Status",
+        accessor: "status",
+        Cell: ({ row }) => <StatusBadge status={row.original.status} />,
+        disableFilters: true,
+      },
+      {
+        Header: "Bukti Dukung",
+        accessor: (row) => row.buktiLink,
+        Cell: ({ row }) =>
+          row.original.buktiLink ? (
+            <Check className="w-4 h-4 text-green-600" />
+          ) : (
+            <X className="w-4 h-4 text-red-600" />
+          ),
+        disableFilters: true,
+      },
+      {
+        Header: "Aksi",
+        accessor: "id",
+        Cell: ({ row }) => (
+          <div className="space-x-2">
+            <Button onClick={() => openDetail(row.original.id)} icon aria-label="Detail">
+              <Eye size={16} />
+            </Button>
+            <Button
+              onClick={() => openEdit(row.original)}
+              variant="warning"
+              icon
+              aria-label="Edit"
+            >
+              <Pencil size={16} />
+            </Button>
+            <Button
+              onClick={() => remove(row.original)}
+              variant="danger"
+              icon
+              aria-label="Hapus"
+            >
+              <Trash2 size={16} />
+            </Button>
+          </div>
+        ),
+        disableFilters: true,
+      },
+    ],
+    [currentPage, pageSize, openDetail, openEdit, remove]
+  );
+
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center flex-wrap gap-2">
@@ -181,124 +252,19 @@ export default function TugasTambahanPage() {
       </div>
 
       <div className="overflow-x-auto md:overflow-x-visible">
-      <Table>
-        <thead>
-          <tr className={tableStyles.headerRow}>
-            <th className={tableStyles.cell}>No</th>
-            <th className={tableStyles.cell}>Kegiatan</th>
-            <th className={tableStyles.cell}>Tim</th>
-            <th className={tableStyles.cell}>Tanggal</th>
-            <th className={tableStyles.cell}>Deskripsi</th>
-            <th className={tableStyles.cell}>Status</th>
-            <th className={tableStyles.cell}>Bukti Dukung</th>
-            <th className={tableStyles.cell}>Aksi</th>
-          </tr>
-        </thead>
-        <tbody>
-          {loading ? (
-            <tr>
-              <td
-                colSpan="7"
-                className="py-6 text-center text-gray-600 dark:text-gray-300"
-              >
-                <div className="flex flex-col items-center space-y-2">
-                  <svg
-                    className="animate-spin h-6 w-6 text-blue-600"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 
-            6.364A8.001 8.001 0 0112 20v4c-6.627 
-            0-12-5.373-12-12h4a8.001 8.001 
-            0 006.364 2.93z"
-                    ></path>
-                  </svg>
-                  <span className="text-sm font-medium tracking-wide">
-                    Memuat data...
-                  </span>
-                </div>
-              </td>
-            </tr>
-          ) : paginatedItems.length === 0 ? (
-            <tr>
-              <td
-                colSpan="7"
-                className="py-6 text-center text-gray-600 dark:text-gray-300"
-              >
-                <div className="flex flex-col items-center space-y-1">
-                  <span className="text-xl">🫰🫰🤟🤟😜☝☝</span>
-                  <span className="text-sm font-medium tracking-wide">
-                    Data tidak ditemukan.
-                  </span>
-                </div>
-              </td>
-            </tr>
-          ) : (
-            paginatedItems.map((item, idx) => (
-              <tr key={item.id} className={tableStyles.row}>
-                <td className={tableStyles.cell}>
-                  {(currentPage - 1) * pageSize + idx + 1}
-                </td>
-                <td className={tableStyles.cell}>{item.nama}</td>
-                <td className={tableStyles.cell}>
-                  {item.kegiatan.team?.namaTim || "-"}
-                </td>
-                <td className={tableStyles.cell}>
-                  {item.tanggal.slice(0, 10)}
-                </td>
-                <td className={tableStyles.cell}>{item.deskripsi || "-"}</td>
-                <td className={tableStyles.cell}>
-                  <StatusBadge status={item.status} />
-                </td>
-                <td className={tableStyles.cell}>
-                  {item.buktiLink ? (
-                    <Check className="w-4 h-4 text-green-600" />
-                  ) : (
-                    <X className="w-4 h-4 text-red-600" />
-                  )}
-                </td>
-                <td className={`${tableStyles.cell} space-x-2`}>
-                  <Button
-                    onClick={() => openDetail(item.id)}
-                    icon
-                    aria-label="Detail"
-                  >
-                    <Eye size={16} />
-                  </Button>
-                  <Button
-                    onClick={() => openEdit(item)}
-                    variant="warning"
-                    icon
-                    aria-label="Edit"
-                  >
-                    <Pencil size={16} />
-                  </Button>
-                  <Button
-                    onClick={() => remove(item)}
-                    variant="danger"
-                    icon
-                    aria-label="Hapus"
-                  >
-                    <Trash2 size={16} />
-                  </Button>
-                </td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </Table>
+        {loading ? (
+          <div className="py-6 text-center text-gray-600 dark:text-gray-300">
+            <div className="flex flex-col items-center space-y-2">
+              <svg className="animate-spin h-6 w-6 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.364A8.001 8.001 0 0112 20v4c-6.627 0-12-5.373-12-12h4a8.001 8.001 0 006.364 2.93z"></path>
+              </svg>
+              <span className="text-sm font-medium tracking-wide">Memuat data...</span>
+            </div>
+          </div>
+        ) : (
+          <DataTable columns={columns} data={paginatedItems} showGlobalFilter={false} showPagination={false} selectable={false} />
+        )}
       </div>
 
       <div className="flex items-center justify-between mt-4">

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import axios from "axios";
 import {
   showSuccess,
@@ -14,8 +14,7 @@ import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
 import { ROLES } from "../../utils/roles";
-import Table from "../../components/ui/Table";
-import tableStyles from "../../components/ui/Table.module.css";
+import DataTable from "../../components/ui/DataTable";
 import SearchInput from "../../components/SearchInput";
 import Pagination from "../../components/Pagination";
 import SelectDataShow from "../../components/ui/SelectDataShow";
@@ -102,6 +101,48 @@ export default function TeamsPage() {
   );
   const totalPages = Math.ceil(filtered.length / pageSize) || 1;
 
+  const columns = useMemo(
+    () => [
+      {
+        Header: "No",
+        accessor: (_row, i) => (currentPage - 1) * pageSize + i + 1,
+        disableFilters: true,
+      },
+      { Header: "Nama Tim", accessor: "namaTim", disableFilters: true },
+      {
+        Header: "Jumlah Anggota",
+        accessor: (row) => row.members?.length || 0,
+        disableFilters: true,
+      },
+      {
+        Header: "Aksi",
+        accessor: "id",
+        Cell: ({ row }) => (
+          <div className="space-x-2">
+            <Button
+              onClick={() => openEdit(row.original)}
+              variant="warning"
+              icon
+              aria-label="Edit"
+            >
+              <Pencil size={16} />
+            </Button>
+            <Button
+              onClick={() => deleteTeam(row.original.id)}
+              variant="danger"
+              icon
+              aria-label="Hapus"
+            >
+              <Trash2 size={16} />
+            </Button>
+          </div>
+        ),
+        disableFilters: true,
+      },
+    ],
+    [currentPage, pageSize, openEdit, deleteTeam]
+  );
+
   if (user?.role !== ROLES.ADMIN) {
     return (
       <div className="p-6 text-center">
@@ -130,59 +171,11 @@ export default function TeamsPage() {
       </div>
 
       <div className="overflow-x-auto md:overflow-x-visible">
-      <Table>
-        <thead>
-          <tr className={tableStyles.headerRow}>
-            <th className={tableStyles.cell}>No</th>
-            <th className={tableStyles.cell}>Nama Tim</th>
-            <th className={tableStyles.cell}>Jumlah Anggota</th>
-            <th className={tableStyles.cell}>Aksi</th>
-          </tr>
-        </thead>
-        <tbody>
-          {loading ? (
-            <tr>
-              <td colSpan="4" className="py-4 text-center">
-                Memuat data...
-              </td>
-            </tr>
-          ) : paginated.length === 0 ? (
-            <tr>
-              <td colSpan="4" className="py-4 text-center">
-                Data tidak ditemukan
-              </td>
-            </tr>
-          ) : (
-            paginated.map((t, idx) => (
-              <tr key={t.id} className={tableStyles.row}>
-                <td className={tableStyles.cell}>
-                  {(currentPage - 1) * pageSize + idx + 1}
-                </td>
-                <td className={tableStyles.cell}>{t.namaTim}</td>
-                <td className={tableStyles.cell}>{t.members?.length || 0}</td>
-                <td className={`${tableStyles.cell} space-x-2`}>
-                  <Button
-                    onClick={() => openEdit(t)}
-                    variant="warning"
-                    icon
-                    aria-label="Edit"
-                  >
-                    <Pencil size={16} />
-                  </Button>
-                  <Button
-                    onClick={() => deleteTeam(t.id)}
-                    variant="danger"
-                    icon
-                    aria-label="Hapus"
-                  >
-                    <Trash2 size={16} />
-                  </Button>
-                </td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </Table>
+        {loading ? (
+          <div className="py-4 text-center">Memuat data...</div>
+        ) : (
+          <DataTable columns={columns} data={paginated} showGlobalFilter={false} showPagination={false} selectable={false} />
+        )}
       </div>
 
       <div className="flex items-center justify-between mt-4">


### PR DESCRIPTION
## Summary
- revert monitoring matrices to plain tables
- convert assignment, additional task, daily report, master activity and team pages to use DataTable
- keep header text centered in DataTable component
- fix openEdit initialization

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687a10f4a490832b838bf4e821131975