### PR TITLE
Filter admin roles in laporanTerlambat

### DIFF
--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
 import MONTHS from "../common/months";
 import { STATUS } from "../common/status.constants";
+import { ROLES } from "../common/roles.constants";
 
 // Tanggal pada service monitoring diasumsikan diproses dalam timezone UTC.
 
@@ -534,7 +535,9 @@ export class MonitoringService {
   }
 
   async laporanTerlambat(teamId?: number) {
-    const whereUser: any = {};
+    const whereUser: any = {
+      NOT: { role: { in: [ROLES.ADMIN, ROLES.PIMPINAN] } },
+    };
     if (teamId) whereUser.members = { some: { teamId } };
 
     const users = await this.prisma.user.findMany({

--- a/api/test/monitoring.service.spec.ts
+++ b/api/test/monitoring.service.spec.ts
@@ -1,5 +1,6 @@
 import { MonitoringService } from '../src/monitoring/monitoring.service';
 import { STATUS } from '../src/common/status.constants';
+import { ROLES } from '../src/common/roles.constants';
 
 describe('MonitoringService aggregated', () => {
   const prisma = {
@@ -226,22 +227,47 @@ describe('MonitoringService aggregated', () => {
     ]);
   });
 
-  it('laporanTerlambat categorizes users by last report date', async () => {
+  it('laporanTerlambat categorizes users by last report date and excludes admin/pimpinan', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2024-05-10'));
     prisma.user.findMany.mockResolvedValue([
-      { id: 1, nama: 'A', laporan: [{ tanggal: new Date('2024-05-02') }] },
-      { id: 2, nama: 'B', laporan: [{ tanggal: new Date('2024-05-05') }] },
-      { id: 3, nama: 'C', laporan: [] },
+      {
+        id: 1,
+        nama: 'A',
+        role: ROLES.ANGGOTA,
+        laporan: [{ tanggal: new Date('2024-05-02') }],
+      },
+      {
+        id: 2,
+        nama: 'B',
+        role: ROLES.KETUA,
+        laporan: [{ tanggal: new Date('2024-05-05') }],
+      },
     ]);
 
     const res = await service.laporanTerlambat();
 
-    expect(res.day7).toEqual([
-      { userId: 1, nama: 'A' },
-      { userId: 3, nama: 'C' },
-    ]);
+    expect(prisma.user.findMany).toHaveBeenCalledWith({
+      where: { NOT: { role: { in: [ROLES.ADMIN, ROLES.PIMPINAN] } } },
+      include: { laporan: { orderBy: { tanggal: 'desc' }, take: 1 } },
+      orderBy: { nama: 'asc' },
+    });
+
+    expect(res.day7).toEqual([{ userId: 1, nama: 'A' }]);
     expect(res.day3).toEqual([{ userId: 2, nama: 'B' }]);
     expect(res.day1).toEqual([]);
     jest.useRealTimers();
+  });
+
+  it('laporanTerlambat merges role filter with team filter', async () => {
+    prisma.user.findMany.mockResolvedValue([]);
+    await service.laporanTerlambat(1);
+    expect(prisma.user.findMany).toHaveBeenCalledWith({
+      where: {
+        NOT: { role: { in: [ROLES.ADMIN, ROLES.PIMPINAN] } },
+        members: { some: { teamId: 1 } },
+      },
+      include: { laporan: { orderBy: { tanggal: 'desc' }, take: 1 } },
+      orderBy: { nama: 'asc' },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- exclude `admin` and `pimpinan` from `laporanTerlambat`
- ensure filter combines with `teamId`
- test role filter on laporanTerlambat

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_b_687a571cb250832baa8448ffc55ab353