### PR TITLE
Add last date info to missed reports

### DIFF
--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -548,21 +548,25 @@ export class MonitoringService {
 
     const result = { day1: [], day3: [], day7: [] } as Record<
       'day1' | 'day3' | 'day7',
-      { userId: number; nama: string }[]
+      { userId: number; nama: string; lastDate: string | null }[]
     >;
 
     for (const u of users) {
       const last = u.laporan[0]?.tanggal;
       let diff = Infinity;
+      let lastDate: string | null = null;
       if (last) {
         const d = new Date(last);
         d.setHours(0, 0, 0, 0);
         diff = Math.floor((today.getTime() - d.getTime()) / 86400000);
+        lastDate = d.toISOString().slice(0, 10);
       }
 
-      if (diff >= 7) result.day7.push({ userId: u.id, nama: u.nama });
-      else if (diff >= 3) result.day3.push({ userId: u.id, nama: u.nama });
-      else if (diff >= 1) result.day1.push({ userId: u.id, nama: u.nama });
+      const entry = { userId: u.id, nama: u.nama, lastDate };
+
+      if (diff >= 7) result.day7.push(entry);
+      else if (diff >= 3) result.day3.push(entry);
+      else if (diff >= 1) result.day1.push(entry);
     }
 
     return result;

--- a/api/test/monitoring.service.spec.ts
+++ b/api/test/monitoring.service.spec.ts
@@ -237,10 +237,12 @@ describe('MonitoringService aggregated', () => {
     const res = await service.laporanTerlambat();
 
     expect(res.day7).toEqual([
-      { userId: 1, nama: 'A' },
-      { userId: 3, nama: 'C' },
+      { userId: 1, nama: 'A', lastDate: '2024-05-02' },
+      { userId: 3, nama: 'C', lastDate: null },
     ]);
-    expect(res.day3).toEqual([{ userId: 2, nama: 'B' }]);
+    expect(res.day3).toEqual([
+      { userId: 2, nama: 'B', lastDate: '2024-05-05' },
+    ]);
     expect(res.day1).toEqual([]);
     jest.useRealTimers();
   });

--- a/web/src/pages/monitoring/MissedReportsPage.jsx
+++ b/web/src/pages/monitoring/MissedReportsPage.jsx
@@ -21,11 +21,29 @@ export default function MissedReportsPage() {
     fetchData();
   }, []);
 
+  const formatDate = (iso) => {
+    const [y, m, d] = iso.split("-");
+    return `${d}-${m}-${y}`;
+  };
+
+  const daysLate = (iso) => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const d = new Date(iso);
+    d.setHours(0, 0, 0, 0);
+    return Math.floor((today.getTime() - d.getTime()) / 86400000);
+  };
+
   const renderList = (items) =>
     items.length > 0 ? (
       <ul className="list-disc pl-5 space-y-1">
         {items.map((u) => (
-          <li key={u.userId}>{u.nama}</li>
+          <li key={u.userId}>
+            {u.nama} -
+            {u.lastDate
+              ? ` ${daysLate(u.lastDate)} hari (${formatDate(u.lastDate)})`
+              : " belum pernah"}
+          </li>
         ))}
       </ul>
     ) : (


### PR DESCRIPTION
## Summary
- include `lastDate` when categorizing late reports
- update MissedReportsPage to show delay info next to each name
- adjust unit tests for new format

## Testing
- `npm test` in `api`
- `npm test` in `web`


------
https://chatgpt.com/codex/tasks/task_b_687a5725e4a8832b9236aa41ae5930e8