### PR TITLE
Add seeder for demo users with precise laporan dates

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -71,9 +71,9 @@ npx prisma db push
 
 5. **Seed data dummy**
 ```bash
-npx tsc prisma/seed.ts
-node prisma/seed.js
+npm run seed
 ```
+Script ini juga menambahkan pengguna demo dengan laporan terakhir 1, 3, dan 7 hari sebelum tanggal `BASE_DATE` di `prisma/seed.ts`.
 
 6. **Jalankan server**
 ```bash


### PR DESCRIPTION
## Summary
- extend `prisma/seed.ts` with demo users whose last `laporan_harian` are 1, 3 and 7 days before `BASE_DATE`
- document how to run the seeder in `api/README.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687a5728aa84832b9f15633a3179b415