### PR TITLE
Update monitoring docs

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -116,6 +116,9 @@ Setiap IP dibatasi **100 request** setiap **15 menit**.
 | GET    | `/monitoring/mingguan/bulan` | Rekap mingguan per pegawai dalam sebulan (query: `tanggal`, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/bulanan/all`  | Monitoring bulanan semua pegawai (query: `year`, `bulan` opsional, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/bulanan/matrix` | Matriks bulanan per user (query: `year`, `teamId` opsional) | admin, pimpinan, ketua tim |
+| GET    | `/monitoring/laporan/terlambat` | Daftar pegawai terlambat mengisi laporan (query: `teamId` opsional) | admin, pimpinan, ketua tim |
+
+Format hasil: objek `{ day1, day3, day7 }`. Akun admin dan pimpinan tidak ditampilkan.
 
 Format hasil: array per pengguna, masing-masing memiliki array 12 objek bulan.
 


### PR DESCRIPTION
## Summary
- document endpoint `/monitoring/laporan/terlambat` in backend README
- describe returned structure and mention admin/pimpinan exclusion

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_b_687a572c2b3c832ba050cce35333aa20