### PR TITLE
Fix table pagination controls & filter out demo users

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -5,8 +5,9 @@ import { getHolidays } from "../src/utils/holidays";
 
 const prisma = new PrismaClient();
 
-// Base date used for demo users below
-const BASE_DATE = new Date(Date.UTC(2025, 7, 10)); // 10 August 2025
+// Base date used for demo users below – set to current UTC date
+const BASE_DATE = new Date();
+BASE_DATE.setUTCHours(0, 0, 0, 0);
 
 const rawUsers = [
   {

--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -190,10 +190,10 @@ export class MonitoringService {
         kegiatan: { teamId },
       };
 
-    const records = await this.prisma.laporanHarian.findMany({
+    const records = (await this.prisma.laporanHarian.findMany({
       where,
       include: { pegawai: true },
-    });
+    })).filter((r) => !r.pegawai.username.startsWith("demo"));
 
     const byUser: Record<
       number,
@@ -235,10 +235,10 @@ export class MonitoringService {
         kegiatan: { teamId },
       };
 
-    const records = await this.prisma.laporanHarian.findMany({
+    const records = (await this.prisma.laporanHarian.findMany({
       where,
       include: { pegawai: true },
-    });
+    })).filter((r) => !r.pegawai.username.startsWith("demo"));
 
     const byUser: Record<
       number,
@@ -279,10 +279,10 @@ export class MonitoringService {
         kegiatan: { teamId },
       };
 
-    const records = await this.prisma.laporanHarian.findMany({
+    const records = (await this.prisma.laporanHarian.findMany({
       where,
       include: { pegawai: true },
-    });
+    })).filter((r) => !r.pegawai.username.startsWith("demo"));
 
     const byUser: Record<
       number,
@@ -331,10 +331,10 @@ export class MonitoringService {
         kegiatan: { teamId },
       };
 
-    const records = await this.prisma.laporanHarian.findMany({
+    const records = (await this.prisma.laporanHarian.findMany({
       where,
       include: { pegawai: true },
-    });
+    })).filter((r) => !r.pegawai.username.startsWith("demo"));
 
     const byUser: Record<
       number,
@@ -466,10 +466,10 @@ export class MonitoringService {
     }
     if (teamId) where.kegiatan = { teamId };
 
-    const tugas = await this.prisma.penugasan.findMany({
+    const tugas = (await this.prisma.penugasan.findMany({
       where,
       include: { pegawai: true },
-    });
+    })).filter((t) => !t.pegawai.username.startsWith("demo"));
 
     const byUser: Record<
       number,
@@ -501,10 +501,10 @@ export class MonitoringService {
     const where: any = { tahun: yr };
     if (teamId) where.kegiatan = { teamId };
 
-    const tugas = await this.prisma.penugasan.findMany({
+    const tugas = (await this.prisma.penugasan.findMany({
       where,
       include: { pegawai: true },
-    });
+    })).filter((t) => !t.pegawai.username.startsWith("demo"));
 
     const byUser: Record<
       number,

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -174,11 +174,9 @@ export default function LaporanHarianPage() {
           )}
           <div className="flex items-center justify-between mt-2">
             <SelectDataShow
-              value={pageSize}
-              onChange={(e) => {
-                setPageSize(Number(e.target.value));
-                setCurrentPage(1);
-              }}
+              pageSize={pageSize}
+              setPageSize={setPageSize}
+              setCurrentPage={setCurrentPage}
               options={[5, 10, 25, 50]}
               className="w-32"
             />

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -235,11 +235,9 @@ export default function MasterKegiatanPage() {
 
       <div className="flex items-center justify-between mt-4">
         <SelectDataShow
-          value={perPage}
-          onChange={(e) => {
-            setPerPage(Number(e.target.value));
-            setPage(1);
-          }}
+          pageSize={perPage}
+          setPageSize={setPerPage}
+          setCurrentPage={setPage}
           options={[5, 10, 25, 50]}
           className="w-32"
         />

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -273,8 +273,9 @@ export default function TugasTambahanPage() {
 
       <div className="flex items-center justify-between mt-4">
         <SelectDataShow
-          value={pageSize}
-          onChange={setPageSize}
+          pageSize={pageSize}
+          setPageSize={setPageSize}
+          setCurrentPage={setCurrentPage}
           options={[5, 10, 25, 50]}
           className="w-32"
         />


### PR DESCRIPTION
## Summary
- keep demo seed data relative to current date
- filter out demo user accounts from monitoring results
- fix pagination dropdown props

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687a61f80b64832b9ea54acc4898b9f9