### PR TITLE
Add admin endpoint to view all additional tasks

### DIFF
--- a/api/src/laporan/tugas-tambahan.controller.ts
+++ b/api/src/laporan/tugas-tambahan.controller.ts
@@ -6,6 +6,7 @@ import {
   UseGuards,
   Req,
   Param,
+  Query,
   ParseIntPipe,
   Put,
   Delete,
@@ -13,12 +14,15 @@ import {
 import { Request } from "express";
 import { TambahanService } from "./tugas-tambahan.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
+import { RolesGuard } from "../common/guards/roles.guard";
+import { Roles } from "../common/guards/roles.decorator";
+import { ROLES } from "../common/roles.constants";
 import { AddTambahanDto } from "./dto/add-tambahan.dto";
 import { UpdateTambahanDto } from "./dto/update-tambahan.dto";
 import { AuthRequestUser } from "../common/auth-request-user.interface";
 
 @Controller("tugas-tambahan")
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class TambahanController {
   constructor(private readonly tambahanService: TambahanService) {}
 
@@ -32,6 +36,17 @@ export class TambahanController {
   getByUser(@Req() req: Request) {
     const userId = (req.user as AuthRequestUser).userId;
     return this.tambahanService.getByUser(userId);
+  }
+
+  @Get('all')
+  @Roles(ROLES.ADMIN)
+  getAll(
+    @Query('teamId') teamId?: string,
+    @Query('userId') userId?: string,
+  ) {
+    const tId = teamId ? parseInt(teamId, 10) : undefined;
+    const uId = userId ? parseInt(userId, 10) : undefined;
+    return this.tambahanService.getAll({ teamId: tId, userId: uId });
   }
 
   @Get(":id")

--- a/api/src/laporan/tugas-tambahan.service.ts
+++ b/api/src/laporan/tugas-tambahan.service.ts
@@ -36,6 +36,17 @@ export class TambahanService {
     });
   }
 
+  getAll(filter: { teamId?: number; userId?: number } = {}) {
+    const where: any = {};
+    if (filter.teamId) where.teamId = filter.teamId;
+    if (filter.userId) where.userId = filter.userId;
+    return this.prisma.kegiatanTambahan.findMany({
+      where,
+      include: { kegiatan: { include: { team: true } } },
+      orderBy: { tanggal: "desc" },
+    });
+  }
+
   getOne(id: number, userId: number) {
     return this.prisma.kegiatanTambahan.findFirst({
       where: { id, userId },


### PR DESCRIPTION
## Summary
- allow admins to fetch all additional tasks
- expose `/tugas-tambahan/all` guarded by `RolesGuard`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687b2464fbe0832b87332f8a13f1264b