### PR TITLE
Use DATABASE_URL env var

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,8 +1,4 @@
-DB_HOST=localhost
-DB_PORT=3306
-DB_USER=root
-DB_PASS=yourpassword
-DB_NAME=semakin_6502
+DATABASE_URL="mysql://root:password@localhost:3306/semakin_6502"
 # Server port (optional, defaults to 3000)
 PORT=3000
 # JWT secret for signing tokens (required)

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -4,6 +4,12 @@ import cookieParser from "cookie-parser";
 import { AppModule } from "./app.module";
 import { LoggingInterceptor } from "./common/logging.interceptor";
 
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  // Fail fast when DATABASE_URL is missing
+  throw new Error("DATABASE_URL environment variable is required");
+}
+
 async function bootstrap() {
   const isProd = process.env.NODE_ENV === "production";
   const logLevels: LogLevel[] = isProd


### PR DESCRIPTION
## Summary
- use a single `DATABASE_URL` in the sample environment file
- check that `DATABASE_URL` is provided during app start

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687b5f7e5294832b81f4a64212ff5d3b