### PR TITLE
Add health endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -82,6 +82,13 @@ npm run start:dev
 
 Server berjalan di: `http://localhost:${PORT}` (default 3000)
 
+Untuk pengecekan cepat, buka `/health`:
+
+```bash
+curl http://localhost:${PORT}/health
+# {"status":"ok"}
+```
+
 ## ⏱️ Rate Limiting
 
 Aplikasi menerapkan rate limit global menggunakan `@nestjs/throttler`.
@@ -102,6 +109,7 @@ Setiap IP dibatasi **100 request** setiap **15 menit**.
 
 | Method | Endpoint                   | Deskripsi                    | Role     |
 |--------|----------------------------|------------------------------|----------|
+| GET    | `/health`                  | Cek apakah backend hidup    | semua    |
 | POST   | `/auth/login`              | Login user & dapatkan token (body: `{ identifier, password }`) | semua    |
 | GET    | `/users`                   | Lihat semua user             | admin    |
 | GET    | `/teams`                   | Daftar tim                   | admin    |

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { LaporanModule } from "./laporan/laporan.module";
 import { MonitoringModule } from "./monitoring/monitoring.module";
 import { RolesModule } from "./roles/roles.module";
 import { NotificationsModule } from "./notifications/notifications.module";
+import { HealthController } from "./health.controller";
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { NotificationsModule } from "./notifications/notifications.module";
     RolesModule,
     NotificationsModule,
   ],
+  controllers: [HealthController],
   providers: [
     PrismaService,
     {

--- a/api/src/health.controller.ts
+++ b/api/src/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from "@nestjs/common";
+
+@Controller("health")
+export class HealthController {
+  @Get()
+  check() {
+    return { status: "ok" };
+  }
+}


### PR DESCRIPTION
## Summary
- expose `GET /health` for quick status checking
- wire health controller in `AppModule`
- document `/health` endpoint in API README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687b5f81eb40832bbefb75dd247c9607