### PR TITLE
Load env for Prisma scripts

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -71,7 +71,7 @@ npx prisma db push
 
 5. **Seed data dummy**
 ```bash
-npm run seed
+npm run seed  # menjalankan `prisma db seed` dan otomatis memuat variabel `.env`
 ```
 Script ini juga menambahkan pengguna demo dengan laporan terakhir 1, 3, dan 7 hari sebelum tanggal `BASE_DATE` di `prisma/seed.ts`.
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -19,6 +19,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "cookie-parser": "^1.4.6",
+        "dotenv": "^17.2.0",
         "exceljs": "^4.3.0",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
@@ -5755,6 +5756,18 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/api/package.json
+++ b/api/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint": "eslint . --ext .ts",
     "test": "jest",
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "prisma db seed"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"
@@ -27,6 +27,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "cookie-parser": "^1.4.6",
+    "dotenv": "^17.2.0",
     "exceljs": "^4.3.0",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",

--- a/api/prisma/reset.ts
+++ b/api/prisma/reset.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { PrismaClient } from "@prisma/client";
 import { hashPassword } from "../src/common/hash";
 import { STATUS } from "../src/common/status.constants";


### PR DESCRIPTION
## Summary
- install `dotenv`
- ensure Prisma seed and reset scripts load `.env`
- run seed via `prisma db seed`
- document the new seed command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687b6bbbaf98832b91b6c0ace6de1e98