### PR TITLE
Add profile update feature

### DIFF
--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -8,6 +8,7 @@ import {
   Body,
   UseGuards,
   ParseIntPipe,
+  Req,
 } from "@nestjs/common";
 import { UsersService } from "./users.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
@@ -16,6 +17,8 @@ import { Roles } from "../common/guards/roles.decorator";
 import { ROLES } from "../common/roles.constants";
 import { CreateUserDto } from "./dto/create-user.dto";
 import { UpdateUserDto } from "./dto/update-user.dto";
+import { Request } from "express";
+import { AuthRequestUser } from "../common/auth-request-user.interface";
 
 @Controller("users")
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -32,6 +35,20 @@ export class UsersController {
   @Roles(ROLES.ADMIN)
   findOne(@Param("id", ParseIntPipe) id: number) {
     return this.usersService.findOne(id);
+  }
+
+  @Get("profile")
+  getProfile(@Req() req: Request) {
+    const { userId } = req.user as AuthRequestUser;
+    return this.usersService.findProfile(userId);
+  }
+
+  @Put("profile")
+  updateProfile(@Req() req: Request, @Body() body: UpdateUserDto) {
+    const { userId, role } = req.user as AuthRequestUser;
+    const data = { ...body } as any;
+    if (role !== ROLES.ADMIN) delete data.role;
+    return this.usersService.updateProfile(userId, data);
   }
 
   @Post()

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -39,6 +39,43 @@ export class UsersService {
     return this.prisma.user.update({ where: { id }, data });
   }
 
+  async findProfile(id: number) {
+    const user = await this.prisma.user.findUnique({
+      where: { id },
+      include: { members: { include: { team: true } } },
+    });
+    if (!user) throw new NotFoundException("not found");
+    const member = user.members?.[0];
+    const sanitized: any = {
+      ...user,
+      teamId: member?.teamId,
+      teamName: member?.team?.namaTim,
+    };
+    delete sanitized.password;
+    return sanitized;
+  }
+
+  async updateProfile(id: number, data: any) {
+    if (data.password) {
+      data.password = await hashPassword(data.password);
+    }
+    if (data.email) {
+      data.username = data.email.split("@")[0];
+    }
+    const user = await this.prisma.user.update({ where: { id }, data });
+    const member = await this.prisma.member.findFirst({
+      where: { userId: id },
+      include: { team: true },
+    });
+    const sanitized: any = {
+      ...user,
+      teamId: member?.teamId,
+      teamName: member?.team?.namaTim,
+    };
+    delete sanitized.password;
+    return sanitized;
+  }
+
   remove(id: number) {
     return this.prisma.user.delete({ where: { id } });
   }

--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -1,4 +1,4 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet, useLocation, Link } from "react-router-dom";
 import Sidebar from "./Sidebar";
 import { useAuth } from "../auth/useAuth";
 import { useState, useEffect, useRef, useCallback } from "react";
@@ -257,9 +257,13 @@ export default function Layout() {
               </button>
               {showProfileMenu && (
                 <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50 py-2">
-                  <button className="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700">
+                  <Link
+                    to="/profile"
+                    onClick={() => setShowProfileMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
                     <FaIdBadge className="mr-2" /> Lihat Profil
-                  </button>
+                  </Link>
                   <button
                     onClick={handleLogout}
                     className="flex items-center w-full px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700"

--- a/web/src/pages/profile/ProfilePage.jsx
+++ b/web/src/pages/profile/ProfilePage.jsx
@@ -1,0 +1,75 @@
+import { useState, useEffect } from "react";
+import axios from "axios";
+import { useAuth } from "../auth/useAuth";
+import Button from "../../components/ui/Button";
+import Input from "../../components/ui/Input";
+import Label from "../../components/ui/Label";
+import { showSuccess, showWarning, handleAxiosError } from "../../utils/alerts";
+
+export default function ProfilePage() {
+  const { user, setUser } = useAuth();
+  const [form, setForm] = useState({ nama: "", email: "", password: "" });
+
+  useEffect(() => {
+    if (user) {
+      setForm({ nama: user.nama || "", email: user.email || "", password: "" });
+    }
+  }, [user]);
+
+  const save = async () => {
+    if (!form.nama || !form.email) {
+      showWarning("Lengkapi data", "Nama dan email wajib diisi");
+      return;
+    }
+    try {
+      const res = await axios.put("/users/profile", form);
+      const updated = res.data;
+      setUser(updated);
+      localStorage.setItem("user", JSON.stringify(updated));
+      setForm({ ...form, password: "" });
+      showSuccess("Berhasil", "Profil diperbarui");
+    } catch (err) {
+      handleAxiosError(err, "Gagal menyimpan profil");
+    }
+  };
+
+  if (!user) {
+    return <div className="p-6 text-center">Memuat...</div>;
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-4">
+      <h2 className="text-xl font-semibold">Profil Saya</h2>
+      <div>
+        <Label htmlFor="nama">Nama</Label>
+        <Input
+          id="nama"
+          type="text"
+          value={form.nama}
+          onChange={(e) => setForm({ ...form, nama: e.target.value })}
+        />
+      </div>
+      <div>
+        <Label htmlFor="email">Email</Label>
+        <Input
+          id="email"
+          type="email"
+          value={form.email}
+          onChange={(e) => setForm({ ...form, email: e.target.value })}
+        />
+      </div>
+      <div>
+        <Label htmlFor="password">Password Baru</Label>
+        <Input
+          id="password"
+          type="password"
+          value={form.password}
+          onChange={(e) => setForm({ ...form, password: e.target.value })}
+        />
+      </div>
+      <div className="flex justify-end">
+        <Button onClick={save}>Simpan</Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/AppRoutes.jsx
+++ b/web/src/routes/AppRoutes.jsx
@@ -33,6 +33,7 @@ const MonitoringPage = React.lazy(() =>
 const MissedReportsPage = React.lazy(() =>
   import("../pages/monitoring/MissedReportsPage")
 );
+const ProfilePage = React.lazy(() => import("../pages/profile/ProfilePage"));
 const NotFound = React.lazy(() => import("../pages/NotFound"));
 
 function PrivateRoute({ children }) {
@@ -69,6 +70,7 @@ export default function AppRoutes() {
         >
           <Route index element={<Navigate to="/dashboard" replace />} />
           <Route path="dashboard" element={<Dashboard />} />
+          <Route path="profile" element={<ProfilePage />} />
           <Route path="users" element={<UsersPage />} />
           <Route path="teams" element={<TeamsPage />} />
           <Route path="master-kegiatan" element={<MasterKegiatanPage />} />


### PR DESCRIPTION
## Summary
- allow users to edit their own profile
- expose `GET /users/profile` and `PUT /users/profile`
- link to Profile page in layout menu
- add Profile page and route in frontend

## Testing
- `npm test` in `api`
- `npm test` in `web`
- `npm run lint` in `web`
- `npm run lint` in `api` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_b_687b82f0f65c832b8f568272354c8d08