### PR TITLE
Centralize progress color logic

### DIFF
--- a/web/src/components/monitoring/MonthlyMatrix.jsx
+++ b/web/src/components/monitoring/MonthlyMatrix.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import getProgressColor from "../../utils/progressColor";
 
 export const MonthlyMatrixRow = ({ user, progressColor }) => (
   <tr className="text-center">
@@ -26,21 +27,7 @@ import months from "../../utils/months";
 
 const MonthlyMatrix = ({ data = [] }) => {
   if (!Array.isArray(data) || data.length === 0) return null;
-
-  const colorFor = (p) => {
-    if (p >= 80) return "green";
-    if (p >= 50) return "yellow";
-    return "red";
-  };
-
-  const progressColor = (p) => {
-    const c = colorFor(p);
-    return c === "green"
-      ? "bg-green-500"
-      : c === "yellow"
-      ? "bg-yellow-500"
-      : "bg-red-500";
-  };
+  const progressColor = getProgressColor;
 
   return (
     <div className="overflow-auto">

--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -11,24 +11,11 @@ import MonthlyMatrix from "../../components/monitoring/MonthlyMatrix";
 import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
 import { handleAxiosError } from "../../utils/alerts";
+import getProgressColor from "../../utils/progressColor";
 
 const WeeklyProgressTable = ({ data = [] }) => {
   if (!Array.isArray(data) || data.length === 0) return null;
-
-  const colorFor = (p) => {
-    if (p >= 80) return "green";
-    if (p >= 50) return "yellow";
-    return "red";
-  };
-
-  const progressColor = (p) => {
-    const c = colorFor(p);
-    return c === "green"
-      ? "bg-green-500"
-      : c === "yellow"
-      ? "bg-yellow-500"
-      : "bg-red-500";
-  };
+  const progressColor = getProgressColor;
 
   return (
     <div className="overflow-auto md:overflow-visible mt-4">

--- a/web/src/pages/monitoring/WeeklyMatrix.jsx
+++ b/web/src/pages/monitoring/WeeklyMatrix.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import getProgressColor from "../../utils/progressColor";
 
 export const WeeklyMatrixRow = ({ user, progressColor }) => (
   <tr className="text-center">
@@ -25,21 +26,7 @@ export const WeeklyMatrixRow = ({ user, progressColor }) => (
 
 const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek }) => {
   if (!Array.isArray(data) || data.length === 0) return null;
-
-  const colorFor = (p) => {
-    if (p >= 80) return "green";
-    if (p >= 50) return "yellow";
-    return "red";
-  };
-
-  const progressColor = (p) => {
-    const c = colorFor(p);
-    return c === "green"
-      ? "bg-green-500"
-      : c === "yellow"
-      ? "bg-yellow-500"
-      : "bg-red-500";
-  };
+  const progressColor = getProgressColor;
 
   return (
     <div className="overflow-auto md:overflow-visible">

--- a/web/src/utils/progressColor.js
+++ b/web/src/utils/progressColor.js
@@ -1,0 +1,14 @@
+export function colorFor(p) {
+  if (p >= 80) return "green";
+  if (p >= 50) return "yellow";
+  return "red";
+}
+
+export default function getProgressColor(persen) {
+  const c = colorFor(persen);
+  return c === "green"
+    ? "bg-green-500"
+    : c === "yellow"
+    ? "bg-yellow-500"
+    : "bg-red-500";
+}


### PR DESCRIPTION
## Summary
- add helper to compute progress bar colors
- use new helper in monitoring components

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687ce2f3b24c832b98dfad3a7008f2ab