### PR TITLE
Add filtering and export by month/week for daily reports

### DIFF
--- a/api/src/laporan/laporan.controller.ts
+++ b/api/src/laporan/laporan.controller.ts
@@ -51,14 +51,28 @@ export class LaporanController {
     return this.laporanService.getByUser(userId);
   }
 
+  @Get("mine/filter")
+  myReportsFiltered(
+    @Req() req: Request,
+    @Query("bulan") bulan?: string,
+    @Query("minggu") minggu?: string,
+  ) {
+    const userId = (req.user as AuthRequestUser).userId;
+    const week = minggu ? parseInt(minggu, 10) : undefined;
+    return this.laporanService.getByMonthWeek(userId, bulan, week);
+  }
+
   @Get("mine/export")
   async export(
     @Req() req: Request,
     @Res() res: Response,
     @Query("format") format = "xlsx",
+    @Query("bulan") bulan?: string,
+    @Query("minggu") minggu?: string,
   ) {
     const userId = (req.user as AuthRequestUser).userId;
-    const buf = await this.laporanService.export(userId, format);
+    const week = minggu ? parseInt(minggu, 10) : undefined;
+    const buf = await this.laporanService.export(userId, format, bulan, week);
     if (format === "pdf") {
       res.setHeader("Content-Type", "application/pdf");
       res.setHeader("Content-Disposition", "attachment; filename=laporan.pdf");


### PR DESCRIPTION
## Summary
- extend `LaporanService` with filtering by month and week
- expose `/laporan-harian/mine/filter` and enhance export endpoint with filters
- adjust Excel export columns and styling
- update LaporanHarianPage with month/week selectors and new export button

## Testing
- `npm test` in `api`
- `npm install` in `web`
- `npm test` in `web`
- `npm run lint` in `web`


------
https://chatgpt.com/codex/tasks/task_b_687cf644b8c4832bb9f0b40e78095098