### PR TITLE
Allow all roles to access monitoring pages

### DIFF
--- a/api/src/monitoring/monitoring.controller.ts
+++ b/api/src/monitoring/monitoring.controller.ts
@@ -71,13 +71,11 @@ export class MonitoringController {
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
-    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
-      if (!tId) throw new ForbiddenException("bukan admin");
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
         where: { teamId: tId, userId: user.userId },
       });
-      if (!member || !member.isLeader)
-        throw new ForbiddenException("bukan ketua tim");
+      if (!member) throw new ForbiddenException("bukan anggota tim ini");
     }
 
     return this.monitoringService.harianAll(tanggal, tId);
@@ -96,13 +94,11 @@ export class MonitoringController {
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
-    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
-      if (!tId) throw new ForbiddenException("bukan admin");
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
         where: { teamId: tId, userId: user.userId },
       });
-      if (!member || !member.isLeader)
-        throw new ForbiddenException("bukan ketua tim");
+      if (!member) throw new ForbiddenException("bukan anggota tim ini");
     }
 
     return this.monitoringService.harianBulan(tanggal, tId);
@@ -156,13 +152,11 @@ export class MonitoringController {
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
-    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
-      if (!tId) throw new ForbiddenException("bukan admin");
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
         where: { teamId: tId, userId: user.userId },
       });
-      if (!member || !member.isLeader)
-        throw new ForbiddenException("bukan ketua tim");
+      if (!member) throw new ForbiddenException("bukan anggota tim ini");
     }
 
     return this.monitoringService.mingguanAll(minggu, tId);
@@ -216,13 +210,11 @@ export class MonitoringController {
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
-    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
-      if (!tId) throw new ForbiddenException("bukan admin");
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
         where: { teamId: tId, userId: user.userId },
       });
-      if (!member || !member.isLeader)
-        throw new ForbiddenException("bukan ketua tim");
+      if (!member) throw new ForbiddenException("bukan anggota tim ini");
     }
 
     return this.monitoringService.mingguanBulan(tanggal, tId);
@@ -277,13 +269,11 @@ export class MonitoringController {
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
-    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
-      if (!tId) throw new ForbiddenException("bukan admin");
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
         where: { teamId: tId, userId: user.userId },
       });
-      if (!member || !member.isLeader)
-        throw new ForbiddenException("bukan ketua tim");
+      if (!member) throw new ForbiddenException("bukan anggota tim ini");
     }
 
     return this.monitoringService.bulananAll(year, tId, bulan);
@@ -302,13 +292,11 @@ export class MonitoringController {
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
-    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
-      if (!tId) throw new ForbiddenException("bukan admin");
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
         where: { teamId: tId, userId: user.userId },
       });
-      if (!member || !member.isLeader)
-        throw new ForbiddenException("bukan ketua tim");
+      if (!member) throw new ForbiddenException("bukan anggota tim ini");
     }
 
     return this.monitoringService.bulananMatrix(year, tId);
@@ -323,13 +311,11 @@ export class MonitoringController {
     const role = user?.role;
     const tId = teamId ? parseInt(teamId, 10) : undefined;
 
-    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
-      if (!tId) throw new ForbiddenException("bukan admin");
+    if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
         where: { teamId: tId, userId: user.userId },
       });
-      if (!member || !member.isLeader)
-        throw new ForbiddenException("bukan ketua tim");
+      if (!member) throw new ForbiddenException("bukan anggota tim ini");
     }
 
     return this.monitoringService.laporanTerlambat(tId);

--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -23,13 +23,11 @@ const mainLinks = [
     to: "/monitoring",
     label: "Monitoring",
     icon: BarChart2,
-    roles: [ROLES.ADMIN, ROLES.KETUA, ROLES.PIMPINAN],
   },
   {
     to: "/laporan-terlambat",
     label: "Keterlambatan",
     icon: AlertCircle,
-    roles: [ROLES.ADMIN, ROLES.PIMPINAN],
   },
 ];
 


### PR DESCRIPTION
## Summary
- expose Monitoring and Keterlambatan links to all logged-in users
- relax role checks in monitoring controller so any role can access aggregated endpoints, still verifying team membership when `teamId` is provided

## Testing
- `npm test` in `api`
- `npm test` in `web`


------
https://chatgpt.com/codex/tasks/task_b_687cf6669b70832bb48b875f767abd14