### PR TITLE
Add weekly tasks page

### DIFF
--- a/api/src/kegiatan/penugasan.controller.ts
+++ b/api/src/kegiatan/penugasan.controller.ts
@@ -10,6 +10,7 @@ import {
   ParseIntPipe,
   Put,
   Delete,
+  BadRequestException,
 } from "@nestjs/common";
 import { Request } from "express";
 import { PenugasanService } from "./penugasan.service";
@@ -69,5 +70,13 @@ export class PenugasanController {
   remove(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
     const u = req.user as AuthRequestUser;
     return this.penugasanService.remove(id, u.userId, u.role);
+  }
+
+  @Get("minggu/all")
+  async getWeekAll(@Query("minggu") minggu?: string) {
+    if (!minggu) {
+      throw new BadRequestException("query 'minggu' diperlukan");
+    }
+    return this.penugasanService.byWeekGrouped(minggu);
   }
 }

--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -17,6 +17,7 @@ import { ROLES } from "../../utils/roles";
 const mainLinks = [
   { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { to: "/tugas-mingguan", label: "Tugas Mingguan", icon: ClipboardList },
+  { to: "/tugas-mingguan/all", label: "Tugas Minggu Ini", icon: List },
   { to: "/tugas-tambahan", label: "Tugas Tambahan", icon: FilePlus },
   { to: "/laporan-harian", label: "Laporan Harian", icon: FileText },
   {

--- a/web/src/pages/penugasan/WeeklyTasksPage.jsx
+++ b/web/src/pages/penugasan/WeeklyTasksPage.jsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import DataTable from "../../components/ui/DataTable";
+import StatusBadge from "../../components/ui/StatusBadge";
+import Spinner from "../../components/Spinner";
+
+export default function WeeklyTasksPage() {
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const today = new Date().toISOString().slice(0, 10);
+        const res = await axios.get("/penugasan/minggu/all", { params: { minggu: today } });
+        const list = [];
+        (res.data || []).forEach((u) => {
+          u.tugas.forEach((t) => {
+            list.push({
+              nama: u.nama,
+              tugas: t.tugas,
+              deskripsi: t.deskripsi,
+              status: t.status,
+            });
+          });
+        });
+        setRows(list);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const columns = [
+    { Header: "No", accessor: (_r, i) => i + 1, disableFilters: true },
+    { Header: "Nama Pegawai", accessor: "nama", disableFilters: true },
+    { Header: "Tugas", accessor: "tugas", disableFilters: true },
+    { Header: "Deskripsi", accessor: "deskripsi", disableFilters: true },
+    {
+      Header: "Status",
+      accessor: "status",
+      Cell: ({ row }) => <StatusBadge status={row.original.status} />,
+      disableFilters: true,
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Tugas Minggu Ini</h1>
+      {loading ? (
+        <div className="py-4 text-center">
+          <Spinner className="h-6 w-6 mx-auto" />
+        </div>
+      ) : (
+        <DataTable columns={columns} data={rows} showGlobalFilter={false} showPagination={false} selectable={false} />
+      )}
+    </div>
+  );
+}

--- a/web/src/routes/AppRoutes.jsx
+++ b/web/src/routes/AppRoutes.jsx
@@ -18,6 +18,9 @@ const PenugasanPage = React.lazy(() =>
 const PenugasanDetailPage = React.lazy(() =>
   import("../pages/penugasan/PenugasanDetailPage")
 );
+const WeeklyTasksPage = React.lazy(() =>
+  import("../pages/penugasan/WeeklyTasksPage")
+);
 const LaporanHarianPage = React.lazy(() =>
   import("../pages/laporan/LaporanHarianPage")
 );
@@ -75,6 +78,7 @@ export default function AppRoutes() {
           <Route path="teams" element={<TeamsPage />} />
           <Route path="master-kegiatan" element={<MasterKegiatanPage />} />
           <Route path="tugas-mingguan" element={<PenugasanPage />} />
+          <Route path="tugas-mingguan/all" element={<WeeklyTasksPage />} />
           <Route path="tugas-mingguan/:id" element={<PenugasanDetailPage />} />
           <Route path="laporan-harian" element={<LaporanHarianPage />} />
           <Route path="monitoring" element={<MonitoringPage />} />


### PR DESCRIPTION
## Summary
- group weekly tasks per user in penugasan service
- expose GET `/penugasan/minggu/all`
- add WeeklyTasksPage in React
- link page from sidebar

## Testing
- `npx jest` in `api`
- `npm test --silent` in `web`


------
https://chatgpt.com/codex/tasks/task_b_687cf66b9b48832bb49e7dd0bb861733