### PR TITLE
Implement role-based navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,11 @@ MySQL data persists in the `mysql-data` volume and is initialized from `docker/m
 
 Code and database fields use **camelCase**. When adding new API DTOs or Prisma models, prefer English terms and camelCase naming (e.g. `teamId`, `namaKegiatan`). Legacy snake_case columns remain for compatibility but new contributions should avoid them.
 
+## Role-Based Navigation
+
+Available sidebar links depend on the authenticated user's role:
+
+- **Admin** – access to all pages.
+- **Ketua Tim** – Dashboard, Tugas Mingguan, Tugas Tambahan, Laporan Harian and Master Kegiatan.
+- **Pimpinan** – Monitoring dan Keterlambatan saja.
+

--- a/web/src/__tests__/Sidebar.test.jsx
+++ b/web/src/__tests__/Sidebar.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Sidebar from '../pages/layout/Sidebar';
+import { useAuth } from '../pages/auth/useAuth';
+
+jest.mock('../pages/auth/useAuth');
+
+const mockedUseAuth = useAuth;
+
+describe('Sidebar role visibility', () => {
+  test('pimpinan sees only monitoring links', () => {
+    mockedUseAuth.mockReturnValue({ user: { role: 'pimpinan' } });
+    render(
+      <MemoryRouter>
+        <Sidebar setSidebarOpen={() => {}} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Monitoring/i)).toBeInTheDocument();
+    expect(screen.getByText(/Keterlambatan/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Dashboard/i)).toBeNull();
+    expect(screen.queryByText(/Tugas Mingguan/i)).toBeNull();
+    expect(screen.queryByText(/Master Kegiatan/i)).toBeNull();
+  });
+
+  test('ketua sees tugas links', () => {
+    mockedUseAuth.mockReturnValue({ user: { role: 'ketua' } });
+    render(
+      <MemoryRouter>
+        <Sidebar setSidebarOpen={() => {}} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Dashboard/i)).toBeInTheDocument();
+    expect(screen.getByText(/Tugas Mingguan/i)).toBeInTheDocument();
+    expect(screen.getByText(/Tugas Tambahan/i)).toBeInTheDocument();
+    expect(screen.getByText(/Laporan Harian/i)).toBeInTheDocument();
+    expect(screen.getByText(/Master Kegiatan/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Monitoring/i)).toBeNull();
+    expect(screen.queryByText(/Keterlambatan/i)).toBeNull();
+  });
+});

--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -15,15 +15,35 @@ import {
 import { ROLES } from "../../utils/roles";
 
 const mainLinks = [
-  { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { to: "/tugas-mingguan", label: "Tugas Mingguan", icon: ClipboardList },
-  { to: "/tugas-tambahan", label: "Tugas Tambahan", icon: FilePlus },
-  { to: "/laporan-harian", label: "Laporan Harian", icon: FileText },
+  {
+    to: "/dashboard",
+    label: "Dashboard",
+    icon: LayoutDashboard,
+    roles: [ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA],
+  },
+  {
+    to: "/tugas-mingguan",
+    label: "Tugas Mingguan",
+    icon: ClipboardList,
+    roles: [ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA],
+  },
+  {
+    to: "/tugas-tambahan",
+    label: "Tugas Tambahan",
+    icon: FilePlus,
+    roles: [ROLES.ADMIN, ROLES.KETUA],
+  },
+  {
+    to: "/laporan-harian",
+    label: "Laporan Harian",
+    icon: FileText,
+    roles: [ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA],
+  },
   {
     to: "/monitoring",
     label: "Monitoring",
     icon: BarChart2,
-    roles: [ROLES.ADMIN, ROLES.KETUA, ROLES.PIMPINAN],
+    roles: [ROLES.ADMIN, ROLES.PIMPINAN],
   },
   {
     to: "/laporan-terlambat",

--- a/web/src/routes/AppRoutes.jsx
+++ b/web/src/routes/AppRoutes.jsx
@@ -3,6 +3,7 @@ import React, { Suspense } from "react";
 import { useAuth } from "../pages/auth/useAuth";
 import Loading from "../components/Loading";
 import ErrorBoundary from "../components/ErrorBoundary";
+import { ROLES } from "../utils/roles";
 
 const LoginPage = React.lazy(() => import("../pages/auth/LoginPage"));
 const Dashboard = React.lazy(() => import("../pages/dashboard/Dashboard"));
@@ -44,6 +45,19 @@ function PrivateRoute({ children }) {
   return children;
 }
 
+function RoleRoute({ roles, children }) {
+  const { user } = useAuth();
+  if (roles && !roles.includes(user?.role)) {
+    return (
+      <Navigate
+        to={user?.role === ROLES.PIMPINAN ? "/monitoring" : "/dashboard"}
+        replace
+      />
+    );
+  }
+  return children;
+}
+
 export default function AppRoutes() {
   const { user } = useAuth();
 
@@ -69,20 +83,94 @@ export default function AppRoutes() {
           }
         >
           <Route index element={<Navigate to="/dashboard" replace />} />
-          <Route path="dashboard" element={<Dashboard />} />
+          <Route
+            path="dashboard"
+            element={
+              <RoleRoute roles={[ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA]}>
+                <Dashboard />
+              </RoleRoute>
+            }
+          />
           <Route path="profile" element={<ProfilePage />} />
-          <Route path="users" element={<UsersPage />} />
-          <Route path="teams" element={<TeamsPage />} />
-          <Route path="master-kegiatan" element={<MasterKegiatanPage />} />
-          <Route path="tugas-mingguan" element={<PenugasanPage />} />
-          <Route path="tugas-mingguan/:id" element={<PenugasanDetailPage />} />
-          <Route path="laporan-harian" element={<LaporanHarianPage />} />
-          <Route path="monitoring" element={<MonitoringPage />} />
-          <Route path="laporan-terlambat" element={<MissedReportsPage />} />
-          <Route path="tugas-tambahan" element={<TugasTambahanPage />} />
+          <Route
+            path="users"
+            element={
+              <RoleRoute roles={[ROLES.ADMIN]}>
+                <UsersPage />
+              </RoleRoute>
+            }
+          />
+          <Route
+            path="teams"
+            element={
+              <RoleRoute roles={[ROLES.ADMIN]}>
+                <TeamsPage />
+              </RoleRoute>
+            }
+          />
+          <Route
+            path="master-kegiatan"
+            element={
+              <RoleRoute roles={[ROLES.ADMIN, ROLES.KETUA]}>
+                <MasterKegiatanPage />
+              </RoleRoute>
+            }
+          />
+          <Route
+            path="tugas-mingguan"
+            element={
+              <RoleRoute roles={[ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA]}>
+                <PenugasanPage />
+              </RoleRoute>
+            }
+          />
+          <Route
+            path="tugas-mingguan/:id"
+            element={
+              <RoleRoute roles={[ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA]}>
+                <PenugasanDetailPage />
+              </RoleRoute>
+            }
+          />
+          <Route
+            path="laporan-harian"
+            element={
+              <RoleRoute roles={[ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA]}>
+                <LaporanHarianPage />
+              </RoleRoute>
+            }
+          />
+          <Route
+            path="monitoring"
+            element={
+              <RoleRoute roles={[ROLES.ADMIN, ROLES.PIMPINAN]}>
+                <MonitoringPage />
+              </RoleRoute>
+            }
+          />
+          <Route
+            path="laporan-terlambat"
+            element={
+              <RoleRoute roles={[ROLES.ADMIN, ROLES.PIMPINAN]}>
+                <MissedReportsPage />
+              </RoleRoute>
+            }
+          />
+          <Route
+            path="tugas-tambahan"
+            element={
+              <RoleRoute roles={[ROLES.ADMIN, ROLES.KETUA]}>
+                <TugasTambahanPage />
+              </RoleRoute>
+            }
+          />
           <Route
             path="tugas-tambahan/:id"
-            element={<TugasTambahanDetailPage />}
+            element={
+              <RoleRoute roles={[ROLES.ADMIN, ROLES.KETUA]}>
+                <TugasTambahanDetailPage />
+              </RoleRoute>
+            }
           />
           <Route path="*" element={<NotFound />} />
         </Route>


### PR DESCRIPTION
## Summary
- hide sidebar links based on role
- protect routes with new `RoleRoute`
- document role-based navigation
- test sidebar visibility for pimpinan and ketua

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cf6702408832bb92b29b57512ad15