### PR TITLE
Update penugasan status sync logic

### DIFF
--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -28,6 +28,17 @@ export class LaporanService {
   }
 
   private async syncPenugasanStatus(penugasanId: number) {
+    const finished = await this.prisma.laporanHarian.findFirst({
+      where: { penugasanId, status: STATUS.SELESAI_DIKERJAKAN },
+    });
+    if (finished) {
+      await this.prisma.penugasan.update({
+        where: { id: penugasanId },
+        data: { status: STATUS.SELESAI_DIKERJAKAN },
+      });
+      return;
+    }
+
     const latest = await this.prisma.laporanHarian.findFirst({
       where: { penugasanId },
       orderBy: { tanggal: 'desc' },

--- a/api/test/laporan.service.spec.ts
+++ b/api/test/laporan.service.spec.ts
@@ -57,7 +57,30 @@ describe('LaporanService submit', () => {
 
     expect(res).toEqual({ id: 10 });
     expect(prisma.laporanHarian.create).toHaveBeenCalled();
-    expect(prisma.penugasan.update).toHaveBeenCalled();
+    expect(prisma.penugasan.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { status: STATUS.BELUM },
+    });
+  });
+
+  it('sets assignment status to selesai when any report finished', async () => {
+    prisma.penugasan.findUnique.mockResolvedValue({
+      id: 1,
+      pegawaiId: 1,
+      kegiatan: { teamId: 1 },
+    });
+    prisma.laporanHarian.create.mockResolvedValue({ id: 11 });
+    prisma.laporanHarian.findFirst.mockResolvedValueOnce({
+      status: STATUS.SELESAI_DIKERJAKAN,
+    });
+    prisma.penugasan.update.mockResolvedValue({});
+
+    await service.submit(data as any, 1, ROLES.ANGGOTA);
+
+    expect(prisma.penugasan.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { status: STATUS.SELESAI_DIKERJAKAN },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- update `syncPenugasanStatus` to check for any finished reports
- set assignment to `SELESAI_DIKERJAKAN` when a finished report exists
- extend unit tests for the new logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687d0363c254832ba2ae2771c2b692ad