### PR TITLE
Add formatDate helper and use it in task pages

### DIFF
--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -43,11 +43,13 @@ const mainLinks = [
     to: "/monitoring",
     label: "Monitoring",
     icon: BarChart2,
+    roles: [ROLES.PIMPINAN],
   },
   {
     to: "/laporan-terlambat",
     label: "Keterlambatan",
     icon: AlertCircle,
+    roles: [ROLES.PIMPINAN],
   },
 ];
 

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -22,6 +22,7 @@ import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
 import months from "../../utils/months";
+import formatDate from "../../utils/formatDate";
 
 export default function PenugasanDetailPage() {
   const { id } = useParams();
@@ -60,10 +61,6 @@ export default function PenugasanDetailPage() {
 
   const dateRef = useRef(null);
 
-  const formatDMY = (iso) => {
-    const [y, m, d] = iso.slice(0, 10).split("-");
-    return `${d}-${m}-${y}`;
-  };
 
   const fetchDetail = useCallback(async () => {
     try {
@@ -201,7 +198,7 @@ export default function PenugasanDetailPage() {
       { Header: "Deskripsi", accessor: "deskripsi", disableFilters: true },
       {
         Header: "Tanggal",
-        accessor: (row) => formatDMY(row.tanggal),
+        accessor: (row) => formatDate(row.tanggal),
         disableFilters: true,
       },
       {

--- a/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
@@ -14,6 +14,7 @@ import { STATUS, formatStatus } from "../../utils/status";
 import StatusBadge from "../../components/ui/StatusBadge";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
+import formatDate from "../../utils/formatDate";
 
 
 export default function TugasTambahanDetailPage() {
@@ -144,7 +145,7 @@ export default function TugasTambahanDetailPage() {
           </div>
           <div>
             <div className="text-sm text-gray-500 dark:text-gray-400">Tanggal</div>
-            <div className="font-medium">{item.tanggal.slice(0, 10)}</div>
+            <div className="font-medium">{formatDate(item.tanggal)}</div>
           </div>
           <div>
             <div className="text-sm text-gray-500 dark:text-gray-400">Deskripsi</div>
@@ -160,9 +161,9 @@ export default function TugasTambahanDetailPage() {
             <div>
               <div className="text-sm text-gray-500 dark:text-gray-400">Tanggal Selesai</div>
               <div className="font-medium">
-                {item.tanggalSelesai.slice(0, 10)}
+                {formatDate(item.tanggalSelesai)}
                 {item.tanggalSelesaiAkhir &&
-                  ` - ${item.tanggalSelesaiAkhir.slice(0, 10)}`}
+                  ` - ${formatDate(item.tanggalSelesaiAkhir)}`}
               </div>
             </div>
           )}

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -22,6 +22,7 @@ import SelectDataShow from "../../components/ui/SelectDataShow";
 import { useRef } from "react";
 import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
+import formatDate from "../../utils/formatDate";
 
 export default function TugasTambahanPage() {
   const [items, setItems] = useState([]);
@@ -231,7 +232,7 @@ export default function TugasTambahanPage() {
         : []),
       {
         Header: "Tanggal",
-        accessor: (row) => row.tanggal.slice(0, 10),
+        accessor: (row) => formatDate(row.tanggal),
         disableFilters: true,
       },
       {

--- a/web/src/utils/formatDate.js
+++ b/web/src/utils/formatDate.js
@@ -1,0 +1,12 @@
+export default function formatDate(iso = "") {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    // fallback to the raw value when date is invalid
+    return iso.slice(0, 10);
+  }
+  const day = String(d.getDate()).padStart(2, "0");
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const year = d.getFullYear();
+  return `${day}-${month}-${year}`;
+}


### PR DESCRIPTION
## Summary
- add `formatDate` utility
- format tanggal columns using `formatDate`
- display human-readable date in detail views
- restrict monitoring links to pimpinan role

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687d03059d98832bad91f5a2be2ec823