### PR TITLE
Switch missing proof icon to minus

### DIFF
--- a/web/src/components/ui/DataTable.jsx
+++ b/web/src/components/ui/DataTable.jsx
@@ -76,7 +76,7 @@ export default function DataTable({
         : undefined,
       enableColumnFilter: !col.disableFilters,
       filterFn: col.filter,
-      meta: { Filter: col.Filter },
+      meta: { Filter: col.Filter, cellClassName: col.cellClassName },
     }));
 
     const selectColumn = {

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
-import { Pencil, Trash2, ExternalLink, X, Download } from "lucide-react";
+import { Pencil, Trash2, ExternalLink, Minus, Download } from "lucide-react";
 import { showSuccess, handleAxiosError } from "../../utils/alerts";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
@@ -154,9 +154,10 @@ export default function LaporanHarianPage() {
             />
           </a>
         ) : (
-          <X className="w-4 h-4 text-red-600" />
+          <Minus className="w-4 h-4 mx-auto text-gray-500" />
         ),
       disableFilters: true,
+      cellClassName: "text-center",
     },
     {
       Header: "Catatan",


### PR DESCRIPTION
## Summary
- use `Minus` instead of the red `X` icon for empty proof links
- allow DataTable columns to provide a custom `cellClassName`

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Sidebar role visibility › ketua sees tugas links)*

------
https://chatgpt.com/codex/tasks/task_b_687d030bfa68832b92e5922d428b7bb8