### PR TITLE
Add week selector for monitoring weekly view

### DIFF
--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -442,6 +442,51 @@ export default function MonitoringPage() {
                     </div>
                   </Listbox>
                 </div>
+                <div className="w-36">
+                  <Listbox value={weekIndex} onChange={setWeekIndex}>
+                    <div className="relative mt-1">
+                      <Listbox.Button className="relative w-full cursor-pointer rounded-lg bg-gray-50 dark:bg-gray-800 py-2 pl-4 pr-10 text-center border border-gray-300 dark:border-gray-600 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 transition duration-150 ease-in-out">
+                        <span className="block truncate">Minggu {weekIndex + 1}</span>
+                        <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+                          <ChevronUpDownIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+                        </span>
+                      </Listbox.Button>
+                      <Transition
+                        as={Fragment}
+                        leave="transition ease-in duration-100"
+                        leaveFrom="opacity-100"
+                        leaveTo="opacity-0"
+                      >
+                        <Listbox.Options className="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white dark:bg-gray-700 py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm z-50">
+                          {weekStarts.map((_, i) => (
+                            <Listbox.Option
+                              key={i}
+                              value={i}
+                              className={({ active }) =>
+                                `relative cursor-pointer select-none py-2 pl-10 pr-4 ${
+                                  active
+                                    ? "bg-blue-100 dark:bg-gray-600 text-blue-900 dark:text-white"
+                                    : "text-gray-900 dark:text-gray-100"
+                                }`
+                              }
+                            >
+                              {({ selected }) => (
+                                <>
+                                  <span className={`block truncate ${selected ? "font-medium" : "font-normal"}`}>Minggu {i + 1}</span>
+                                  {selected && (
+                                    <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-blue-600 dark:text-blue-400">
+                                      <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                                    </span>
+                                  )}
+                                </>
+                              )}
+                            </Listbox.Option>
+                          ))}
+                        </Listbox.Options>
+                      </Transition>
+                    </div>
+                  </Listbox>
+                </div>
               </div>
             )}
 
@@ -525,7 +570,11 @@ export default function MonitoringPage() {
                   data={weeklyMonthData}
                   weeks={weekStarts}
                   onSelectWeek={setWeekIndex}
+                  selectedWeek={weekIndex}
                 />
+                <h3 className="font-semibold mt-4 mb-2 text-blue-600 dark:text-blue-400">
+                  Ringkasan Minggu {weekIndex + 1}
+                </h3>
                 <WeeklyProgressTable data={weeklyData} />
               </>
             )}

--- a/web/src/pages/monitoring/WeeklyMatrix.jsx
+++ b/web/src/pages/monitoring/WeeklyMatrix.jsx
@@ -24,7 +24,7 @@ export const WeeklyMatrixRow = ({ user, progressColor }) => (
   </tr>
 );
 
-const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek }) => {
+const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek, selectedWeek }) => {
   if (!Array.isArray(data) || data.length === 0) return null;
   const progressColor = getProgressColor;
 
@@ -38,7 +38,9 @@ const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek }) => {
               <th
                 key={i}
                 onClick={() => onSelectWeek && onSelectWeek(i)}
-                className="p-2 border text-center cursor-pointer"
+                className={`p-2 border text-center cursor-pointer ${
+                  selectedWeek === i ? "bg-blue-200 dark:bg-blue-600" : ""
+                }`}
               >
                 Minggu {i + 1}
               </th>


### PR DESCRIPTION
## Summary
- allow choosing week in MonitoringPage via new listbox
- pass selected week to WeeklyMatrix and highlight header
- show "Ringkasan Minggu" heading above weekly progress table

## Testing
- `npm test` in `web`
- `npm test` in `api`


------
https://chatgpt.com/codex/tasks/task_b_68871a6cd088832b9eded0c59aea10ff