### PR TITLE
Refactor loading component

### DIFF
--- a/web/src/components/Loading.jsx
+++ b/web/src/components/Loading.jsx
@@ -1,11 +1,15 @@
 import Spinner from "./Spinner";
 
-export default function Loading({ fullScreen = false }) {
+export default function Loading({
+  fullScreen = false,
+  size = 40,
+  message = "Sabar, ambil nafas dulu...",
+}) {
   const content = (
     <div className="flex flex-col items-center space-y-4 animate-fade-in">
-      <Spinner className="h-10 w-10 text-primary-500 animate-pulse drop-shadow" />
+      <Spinner className="text-primary-500 drop-shadow" style={{ height: size, width: size }} />
       <div className="text-lg font-medium text-gray-700 dark:text-gray-300 tracking-wide transition-colors">
-        Sabar, ambil nafas dulu...
+        {message}
       </div>
     </div>
   );

--- a/web/src/components/Spinner.jsx
+++ b/web/src/components/Spinner.jsx
@@ -1,26 +1,5 @@
-import React from "react";
+import { Loader2 } from "lucide-react";
 
 export default function Spinner({ className = "h-5 w-5" }) {
-  return (
-    <svg
-      className={`animate-spin ${className}`}
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <circle
-        className="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        strokeWidth="4"
-      ></circle>
-      <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.343A8.001 8.001 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3.93-1.595zM12 20a8 8 0 008-8h-4a4 4 0 01-4 4v4zm6.343-2.93A8.001 8.001 0 0120 12h4c0 3.042-1.135 5.824-3 7.938l-3.657-1.868z"
-      ></path>
-    </svg>
-  );
+  return <Loader2 className={`animate-spin ${className}`} />;
 }


### PR DESCRIPTION
## Summary
- modernize spinner using lucide-react
- allow Loading component to accept `size` and `message` props

## Testing
- `npm test` in `web`
- `npm test` in `api`
- `npm run lint` in `web` *(fails: 4 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68885dd1a860832b9e11643cb18cd58f