### PR TITLE
Replace inline loaders with spinner components

### DIFF
--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from "react";
 import { ROLES } from "../../utils/roles";
 import Button from "../../components/ui/Button";
 import { handleAxiosError } from "../../utils/alerts";
+import Loading from "../../components/Loading";
 
 const Dashboard = () => {
   const { user } = useAuth();
@@ -138,36 +139,7 @@ const Dashboard = () => {
   }, [user?.id, user?.role, user?.teamId, monthIndex]);
 
   if (loading) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full w-full min-h-[60vh] space-y-3">
-        <svg
-          className="animate-spin h-6 w-6 text-blue-600 drop-shadow"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          ></circle>
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 
-      6.364A8.001 8.001 0 0112 20v4c-6.627 
-      0-12-5.373-12-12h4a8.001 8.001 
-      0 006.364 2.93z"
-          ></path>
-        </svg>
-        <p className="text-lg font-medium text-gray-600 dark:text-gray-300 tracking-wide">
-          Memuat data...
-        </p>
-      </div>
-    );
+    return <Loading fullScreen />;
   }
 
   if (errorMsg) {

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 import { Pencil, Trash2, ExternalLink, Minus, Download } from "lucide-react";
+import Spinner from "../../components/Spinner";
 import { showSuccess, handleAxiosError } from "../../utils/alerts";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
@@ -228,11 +229,10 @@ export default function LaporanHarianPage() {
           {loading ? (
             <div className="py-10">
               <div className="flex flex-col items-center justify-center space-y-3">
-                <svg className="animate-spin h-8 w-8 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.364A8.001 8.001 0 0112 20v4c-6.627 0-12-5.373-12-12h4a8.001 8.001 0 006.364 2.93z"></path>
-                </svg>
-                <p className="text-gray-600 dark:text-gray-300 text-sm font-medium tracking-wide">Memuat data laporan...</p>
+                <Spinner className="h-8 w-8 text-blue-600" />
+                <p className="text-gray-600 dark:text-gray-300 text-sm font-medium tracking-wide">
+                  Memuat data laporan...
+                </p>
               </div>
             </div>
           ) : (

--- a/web/src/pages/monitoring/MissedReportsPage.jsx
+++ b/web/src/pages/monitoring/MissedReportsPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
-import { AlertCircle, Loader2, Download } from "lucide-react";
+import { AlertCircle, Download } from "lucide-react";
+import Spinner from "../../components/Spinner";
 import * as XLSX from "xlsx";
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
@@ -213,7 +214,7 @@ export default function MissedReportsPage() {
       {/* Loading / Data */}
       {loading ? (
         <div className="flex justify-center items-center h-40">
-          <Loader2 className="animate-spin w-6 h-6 text-gray-500" />
+          <Spinner className="w-6 h-6 text-gray-500" />
         </div>
       ) : (
         <div className="grid md:grid-cols-3 gap-6">

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -23,6 +23,7 @@ import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
 import months from "../../utils/months";
 import formatDate from "../../utils/formatDate";
+import Loading from "../../components/Loading";
 
 export default function PenugasanDetailPage() {
   const { id } = useParams();
@@ -283,33 +284,9 @@ export default function PenugasanDetailPage() {
     }
   };
 
-  if (!item) return;
-
-  <div className="flex flex-col justify-center items-center h-72 space-y-3">
-    <svg
-      className="animate-spin h-10 w-10 text-blue-600"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <circle
-        className="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        strokeWidth="4"
-      ></circle>
-      <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.364A8.001 8.001 0 0112 20v4c-6.627 0-12-5.373-12-12h4a8.001 8.001 0 006.364 2.93zM20 12a8 8 0 01-8 8v4c6.627 0 12-5.373 12-12h-4zm-2.93-6.364A8.001 8.001 0 0112 4V0c6.627 0 12 5.373 12 12h-4a8.001 8.001 0 00-6.364-2.93z"
-      ></path>
-    </svg>
-    <span className="text-lg font-medium text-gray-600 dark:text-gray-300">
-      Memuat data penugasan...
-    </span>
-  </div>;
+  if (!item) {
+    return <Loading fullScreen />;
+  }
 
   return (
     <div className="p-3 space-y-4">

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -26,6 +26,7 @@ import SearchInput from "../../components/SearchInput";
 import SelectDataShow from "../../components/ui/SelectDataShow";
 import Skeleton from "../../components/ui/Skeleton";
 import { AnimatePresence, motion } from "framer-motion";
+import Spinner from "../../components/Spinner";
 
 const EXCLUDED_TB_NAMES = ["Ayu Pinta Gabina Siregar", "Elly Astutik"];
 
@@ -334,26 +335,7 @@ export default function PenugasanPage() {
           <div className="py-6 text-center text-gray-600 dark:text-gray-300">
             <Skeleton width={100} height={32} count={5} className="mb-2" />
             <div className="flex flex-col items-center space-y-2">
-              <svg
-                className="animate-spin h-6 w-6 text-blue-600"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.364A8.001 8.001 0 0112 20v4c-6.627 0-12-5.373-12-12h4a8.001 8.001 0 006.364 2.93z"
-                />
-              </svg>
+              <Spinner className="h-6 w-6 text-blue-600" />
               <span className="text-sm font-medium tracking-wide">
                 Memuat data...
               </span>

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -15,6 +15,7 @@ import StatusBadge from "../../components/ui/StatusBadge";
 import SearchInput from "../../components/SearchInput";
 import Pagination from "../../components/Pagination";
 import SelectDataShow from "../../components/ui/SelectDataShow";
+import Spinner from "../../components/Spinner";
 import { useRef } from "react";
 import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
@@ -293,10 +294,7 @@ export default function TugasTambahanPage() {
         {loading ? (
           <div className="py-6 text-center text-gray-600 dark:text-gray-300">
             <div className="flex flex-col items-center space-y-2">
-              <svg className="animate-spin h-6 w-6 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.364A8.001 8.001 0 0112 20v4c-6.627 0-12-5.373-12-12h4a8.001 8.001 0 006.364 2.93z"></path>
-              </svg>
+              <Spinner className="h-6 w-6 text-blue-600" />
               <span className="text-sm font-medium tracking-wide">Memuat data...</span>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- swap inline SVG loaders for new `Loading`/`Spinner` components
- use full screen `Loading` on dashboard and detail pages
- simplify custom loader markup across several pages

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68885dd93f28832b9e97c39b9addd997