### PR TITLE
Use unified Skeleton placeholders

### DIFF
--- a/web/src/components/ui/TableSkeleton.jsx
+++ b/web/src/components/ui/TableSkeleton.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import Skeleton from "./Skeleton";
+
+export default function TableSkeleton({ rows = 5, cols = 5 }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-xs border-collapse">
+        <thead>
+          <tr>
+            {Array.from({ length: cols }).map((_, i) => (
+              <th key={i} className="p-2 border">
+                <Skeleton className="h-4 w-full" />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: rows }).map((_, i) => (
+            <tr key={i}>
+              {Array.from({ length: cols }).map((_, j) => (
+                <td key={j} className="p-2 border">
+                  <Skeleton className="h-4 w-full" />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -13,6 +13,7 @@ import StatusBadge from "../../components/ui/StatusBadge";
 import SearchInput from "../../components/SearchInput";
 import SelectDataShow from "../../components/ui/SelectDataShow";
 import MonthYearPicker from "../../components/ui/MonthYearPicker";
+import TableSkeleton from "../../components/ui/TableSkeleton";
 import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
 
@@ -226,15 +227,7 @@ export default function LaporanHarianPage() {
       <>
         <div className="overflow-x-auto md:overflow-x-visible">
           {loading ? (
-            <div className="py-10">
-              <div className="flex flex-col items-center justify-center space-y-3">
-                <svg className="animate-spin h-8 w-8 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.364A8.001 8.001 0 0112 20v4c-6.627 0-12-5.373-12-12h4a8.001 8.001 0 006.364 2.93z"></path>
-                </svg>
-                <p className="text-gray-600 dark:text-gray-300 text-sm font-medium tracking-wide">Memuat data laporan...</p>
-              </div>
-            </div>
+            <TableSkeleton cols={columns.length} />
           ) : (
             <DataTable columns={columns} data={paginated} showGlobalFilter={false} showPagination={false} selectable={false} />
           )}

--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -7,7 +7,6 @@ import {
   handleAxiosError,
 } from "../../utils/alerts";
 import { Pencil, Plus, Trash2 } from "lucide-react";
-import Spinner from "../../components/Spinner";
 import { useAuth } from "../auth/useAuth";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";
@@ -19,6 +18,7 @@ import Label from "../../components/ui/Label";
 import { ROLES } from "../../utils/roles";
 import SearchInput from "../../components/SearchInput";
 import SelectDataShow from "../../components/ui/SelectDataShow";
+import TableSkeleton from "../../components/ui/TableSkeleton";
 
 export default function MasterKegiatanPage() {
   const { user } = useAuth();
@@ -225,9 +225,7 @@ export default function MasterKegiatanPage() {
 
       <div className="overflow-x-auto md:overflow-x-visible">
         {loading ? (
-          <div className="py-4 text-center">
-            <Spinner className="h-6 w-6 mx-auto" />
-          </div>
+          <TableSkeleton cols={columns.length} />
         ) : (
           <DataTable columns={columns} data={items} showGlobalFilter={false} showPagination={false} selectable={false} />
         )}

--- a/web/src/pages/monitoring/components/Skeleton.jsx
+++ b/web/src/pages/monitoring/components/Skeleton.jsx
@@ -1,9 +1,0 @@
-import React from "react";
-
-export default function Skeleton({ className = "" }) {
-  return (
-    <div
-      className={`animate-pulse bg-gray-200 dark:bg-gray-700 rounded ${className}`}
-    />
-  );
-}

--- a/web/src/pages/monitoring/components/TabContent.jsx
+++ b/web/src/pages/monitoring/components/TabContent.jsx
@@ -4,6 +4,7 @@ import WeeklyMatrix from "../WeeklyMatrix";
 import MonthlyMatrix from "./MonthlyMatrix";
 import WeeklyProgressTable from "./WeeklyProgressTable";
 import Skeleton from "../../../components/ui/Skeleton";
+import TableSkeleton from "../../../components/ui/TableSkeleton";
 import Legend from "../../../components/ui/Legend";
 import axios from "axios";
 import { handleAxiosError } from "../../../utils/alerts";
@@ -111,38 +112,7 @@ export default function TabContent({
   }, [activeTab, year, teamId]);
 
   if (loading) {
-    return (
-      <div className="overflow-auto">
-        <table className="min-w-full text-xs border-collapse">
-          <thead>
-            <tr>
-              <th className="p-2 border text-left">
-                <Skeleton className="h-4 w-20" />
-              </th>
-              {Array.from({ length: skeletonCols }).map((_, i) => (
-                <th key={i} className="p-1 border">
-                  <Skeleton className="h-4 w-full" />
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {Array.from({ length: 5 }).map((_, i) => (
-              <tr key={i}>
-                <td className="p-2 border">
-                  <Skeleton className="h-4 w-32" />
-                </td>
-                {Array.from({ length: skeletonCols }).map((_, j) => (
-                  <td key={j} className="p-1 border">
-                    <Skeleton className="h-4 w-full" />
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    );
+    return <TableSkeleton cols={skeletonCols + 1} />;
   }
 
   return (

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -24,7 +24,7 @@ import { ROLES } from "../../utils/roles";
 import months from "../../utils/months";
 import SearchInput from "../../components/SearchInput";
 import SelectDataShow from "../../components/ui/SelectDataShow";
-import Skeleton from "../../components/ui/Skeleton";
+import TableSkeleton from "../../components/ui/TableSkeleton";
 import { AnimatePresence, motion } from "framer-motion";
 
 const EXCLUDED_TB_NAMES = ["Ayu Pinta Gabina Siregar", "Elly Astutik"];
@@ -331,34 +331,7 @@ export default function PenugasanPage() {
       {/* TABLE */}
       <div className="overflow-x-auto md:overflow-x-visible min-h-[120px]">
         {loading ? (
-          <div className="py-6 text-center text-gray-600 dark:text-gray-300">
-            <Skeleton width={100} height={32} count={5} className="mb-2" />
-            <div className="flex flex-col items-center space-y-2">
-              <svg
-                className="animate-spin h-6 w-6 text-blue-600"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.364A8.001 8.001 0 0112 20v4c-6.627 0-12-5.373-12-12h4a8.001 8.001 0 006.364 2.93z"
-                />
-              </svg>
-              <span className="text-sm font-medium tracking-wide">
-                Memuat data...
-              </span>
-            </div>
-          </div>
+          <TableSkeleton cols={columns.length} />
         ) : error ? (
           <div className="py-10 flex flex-col items-center text-red-600 dark:text-red-400">
             <span className="mb-3 text-xl">⚠️</span>

--- a/web/src/pages/penugasan/WeeklyTasksPage.jsx
+++ b/web/src/pages/penugasan/WeeklyTasksPage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import DataTable from "../../components/ui/DataTable";
 import StatusBadge from "../../components/ui/StatusBadge";
-import Spinner from "../../components/Spinner";
+import TableSkeleton from "../../components/ui/TableSkeleton";
 
 export default function WeeklyTasksPage() {
   const [rows, setRows] = useState([]);
@@ -51,9 +51,7 @@ export default function WeeklyTasksPage() {
     <div className="space-y-4">
       <h1 className="text-xl font-semibold">Tugas Minggu Ini</h1>
       {loading ? (
-        <div className="py-4 text-center">
-          <Spinner className="h-6 w-6 mx-auto" />
-        </div>
+        <TableSkeleton cols={columns.length} />
       ) : (
         <DataTable columns={columns} data={rows} showGlobalFilter={false} showPagination={false} selectable={false} />
       )}

--- a/web/src/pages/profile/ProfilePage.jsx
+++ b/web/src/pages/profile/ProfilePage.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "../auth/useAuth";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
+import Skeleton from "../../components/ui/Skeleton";
 import { showSuccess, showWarning, handleAxiosError } from "../../utils/alerts";
 import { User } from "lucide-react";
 
@@ -40,8 +41,8 @@ export default function ProfilePage() {
 
   if (!user) {
     return (
-      <div className="p-6 text-center animate-pulse text-gray-500">
-        Memuat data pengguna...
+      <div className="p-6 text-center text-gray-500">
+        <Skeleton className="mx-auto h-4 w-40" />
       </div>
     );
   }

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -15,6 +15,7 @@ import StatusBadge from "../../components/ui/StatusBadge";
 import SearchInput from "../../components/SearchInput";
 import Pagination from "../../components/Pagination";
 import SelectDataShow from "../../components/ui/SelectDataShow";
+import TableSkeleton from "../../components/ui/TableSkeleton";
 import { useRef } from "react";
 import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
@@ -291,15 +292,7 @@ export default function TugasTambahanPage() {
 
       <div className="overflow-x-auto md:overflow-x-visible">
         {loading ? (
-          <div className="py-6 text-center text-gray-600 dark:text-gray-300">
-            <div className="flex flex-col items-center space-y-2">
-              <svg className="animate-spin h-6 w-6 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2.93 6.364A8.001 8.001 0 0112 20v4c-6.627 0-12-5.373-12-12h4a8.001 8.001 0 006.364 2.93z"></path>
-              </svg>
-              <span className="text-sm font-medium tracking-wide">Memuat data...</span>
-            </div>
-          </div>
+          <TableSkeleton cols={columns.length} />
         ) : (
           <DataTable columns={columns} data={paginatedItems} showGlobalFilter={false} showPagination={false} selectable={false} />
         )}

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -18,6 +18,7 @@ import DataTable from "../../components/ui/DataTable";
 import SearchInput from "../../components/SearchInput";
 import Pagination from "../../components/Pagination";
 import SelectDataShow from "../../components/ui/SelectDataShow";
+import TableSkeleton from "../../components/ui/TableSkeleton";
 
 export default function TeamsPage() {
   const { user } = useAuth();
@@ -172,7 +173,7 @@ export default function TeamsPage() {
 
       <div className="overflow-x-auto md:overflow-x-visible">
         {loading ? (
-          <div className="py-4 text-center">Memuat data...</div>
+          <TableSkeleton cols={columns.length} />
         ) : (
           <DataTable columns={columns} data={paginated} showGlobalFilter={false} showPagination={false} selectable={false} />
         )}

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -14,12 +14,12 @@ import useModalForm from "../../hooks/useModalForm";
 import Button from "../../components/ui/Button";
 import Input from "../../components/ui/Input";
 import Label from "../../components/ui/Label";
-import Spinner from "../../components/Spinner";
 import { ROLES } from "../../utils/roles";
 import DataTable from "../../components/ui/DataTable";
 import SearchInput from "../../components/SearchInput";
 import Pagination from "../../components/Pagination";
 import SelectDataShow from "../../components/ui/SelectDataShow";
+import TableSkeleton from "../../components/ui/TableSkeleton";
 
 export default function UsersPage() {
   const { user } = useAuth();
@@ -209,9 +209,7 @@ export default function UsersPage() {
       </div>
 
       {loading ? (
-        <div className="py-4 text-center">
-          <Spinner className="h-6 w-6 mx-auto" />
-        </div>
+        <TableSkeleton cols={columns.length} />
       ) : (
         <DataTable
           columns={columns}


### PR DESCRIPTION
## Summary
- add `TableSkeleton` UI component to standardize loading tables
- use it on monitoring tab content
- replace manual placeholders in table/list pages with `TableSkeleton`
- clean up unused skeleton component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68885ddb7274832bbdf0f903a506219e