### PR TITLE
Add tests for Loading component

### DIFF
--- a/web/src/__tests__/Loading.test.jsx
+++ b/web/src/__tests__/Loading.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import Loading from '../components/Loading';
+
+it('renders default loading message', () => {
+  render(<Loading />);
+  expect(screen.getByText(/Sabar, ambil nafas dulu/i)).toBeInTheDocument();
+});
+
+it('supports custom message and size', () => {
+  const { container } = render(<Loading message="Please wait" size="h-8 w-8" />);
+  expect(screen.getByText(/Please wait/i)).toBeInTheDocument();
+  const svg = container.querySelector('svg');
+  expect(svg).toHaveClass('h-8 w-8');
+});

--- a/web/src/__tests__/Router.test.jsx
+++ b/web/src/__tests__/Router.test.jsx
@@ -16,5 +16,8 @@ test('renders login page at /login', async () => {
     </AuthProvider>
   );
 
+  // shows loading fallback while lazy component loads
+  expect(screen.getByText(/Sabar, ambil nafas dulu/i)).toBeInTheDocument();
+
   expect(await screen.findByText(/Masuk untuk melanjutkan/i)).toBeInTheDocument();
 });

--- a/web/src/components/Loading.jsx
+++ b/web/src/components/Loading.jsx
@@ -1,11 +1,17 @@
 import Spinner from "./Spinner";
 
-export default function Loading({ fullScreen = false }) {
+export default function Loading({
+  fullScreen = false,
+  message = "Sabar, ambil nafas dulu...",
+  size = "h-10 w-10",
+}) {
   const content = (
     <div className="flex flex-col items-center space-y-4 animate-fade-in">
-      <Spinner className="h-10 w-10 text-primary-500 animate-pulse drop-shadow" />
+      <Spinner
+        className={`${size} text-primary-500 animate-pulse drop-shadow`}
+      />
       <div className="text-lg font-medium text-gray-700 dark:text-gray-300 tracking-wide transition-colors">
-        Sabar, ambil nafas dulu...
+        {message}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- extend `Loading` component with `message` and `size` props
- check loader fallback in `Router` test
- add new test suite for `Loading` component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68885ddc70d0832b85bde281aecb53da