### PR TITLE
Update sidebar roles

### DIFF
--- a/web/src/__tests__/Sidebar.test.jsx
+++ b/web/src/__tests__/Sidebar.test.jsx
@@ -8,7 +8,7 @@ jest.mock('../pages/auth/useAuth');
 const mockedUseAuth = useAuth;
 
 describe('Sidebar role visibility', () => {
-  test('pimpinan sees only monitoring links', () => {
+  test('pimpinan sees tugas mingguan and monitoring links', () => {
     mockedUseAuth.mockReturnValue({ user: { role: 'pimpinan' } });
     render(
       <MemoryRouter>
@@ -17,12 +17,12 @@ describe('Sidebar role visibility', () => {
     );
     expect(screen.getByText(/Monitoring/i)).toBeInTheDocument();
     expect(screen.getByText(/Keterlambatan/i)).toBeInTheDocument();
+    expect(screen.getByText(/Tugas Mingguan/i)).toBeInTheDocument();
     expect(screen.queryByText(/Dashboard/i)).toBeNull();
-    expect(screen.queryByText(/Tugas Mingguan/i)).toBeNull();
     expect(screen.queryByText(/Master Kegiatan/i)).toBeNull();
   });
 
-  test('ketua sees tugas links', () => {
+  test('ketua sees all main links', () => {
     mockedUseAuth.mockReturnValue({ user: { role: 'ketua' } });
     render(
       <MemoryRouter>
@@ -34,7 +34,7 @@ describe('Sidebar role visibility', () => {
     expect(screen.getByText(/Tugas Tambahan/i)).toBeInTheDocument();
     expect(screen.getByText(/Laporan Harian/i)).toBeInTheDocument();
     expect(screen.getByText(/Master Kegiatan/i)).toBeInTheDocument();
-    expect(screen.queryByText(/Monitoring/i)).toBeNull();
-    expect(screen.queryByText(/Keterlambatan/i)).toBeNull();
+    expect(screen.getByText(/Monitoring/i)).toBeInTheDocument();
+    expect(screen.getByText(/Keterlambatan/i)).toBeInTheDocument();
   });
 });

--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -25,7 +25,7 @@ const mainLinks = [
     to: "/tugas-mingguan",
     label: "Tugas Mingguan",
     icon: ClipboardList,
-    roles: [ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA],
+    roles: [ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA, ROLES.PIMPINAN],
   },
   {
     to: "/tugas-tambahan",
@@ -43,13 +43,13 @@ const mainLinks = [
     to: "/monitoring",
     label: "Monitoring",
     icon: BarChart2,
-    roles: [ROLES.ADMIN, ROLES.PIMPINAN],
+    roles: [ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA, ROLES.PIMPINAN],
   },
   {
     to: "/laporan-terlambat",
     label: "Keterlambatan",
     icon: AlertCircle,
-    roles: [ROLES.ADMIN, ROLES.PIMPINAN],
+    roles: [ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA, ROLES.PIMPINAN],
   },
 ];
 


### PR DESCRIPTION
## Summary
- show Pimpinan role in weekly tasks menu
- allow all roles to see Monitoring and Keterlambatan links
- adjust sidebar visibility tests

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error and unused vars)*

------
https://chatgpt.com/codex/tasks/task_b_6888729e898c832bbfc9fad003ce7e99