### PR TITLE
Fix role permissions for Penugasan

### DIFF
--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -29,9 +29,7 @@ export default function PenugasanDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { user } = useAuth();
-  const canManage = [ROLES.ADMIN, ROLES.KETUA, ROLES.PIMPINAN].includes(
-    user?.role
-  );
+  const canManage = [ROLES.ADMIN, ROLES.KETUA].includes(user?.role);
   const [item, setItem] = useState(null);
   const [kegiatan, setKegiatan] = useState([]);
   const [users, setUsers] = useState([]);

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -43,9 +43,7 @@ const getCurrentWeek = () => {
 
 export default function PenugasanPage() {
   const { user } = useAuth();
-  const canManage = [ROLES.ADMIN, ROLES.KETUA, ROLES.PIMPINAN].includes(
-    user?.role
-  );
+  const canManage = [ROLES.ADMIN, ROLES.KETUA].includes(user?.role);
   const showPegawaiColumn = useMemo(
     () => [ROLES.ADMIN, ROLES.KETUA].includes(user?.role),
     [user]


### PR DESCRIPTION
## Summary
- restrict `canManage` to ADMIN/KETUA only in penugasan pages

## Testing
- `npm test --prefix web`

------
https://chatgpt.com/codex/tasks/task_b_68887af306f0832baa414c861951d7e8