### PR TITLE
Restrict master kegiatan routes to admins or team leaders

### DIFF
--- a/api/src/kegiatan/master-kegiatan.controller.ts
+++ b/api/src/kegiatan/master-kegiatan.controller.ts
@@ -17,9 +17,12 @@ import { CreateMasterKegiatanDto } from "./dto/create-master-kegiatan.dto";
 import { UpdateMasterKegiatanDto } from "./dto/update-master-kegiatan.dto";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
+import { Roles } from "../common/guards/roles.decorator";
+import { ROLES } from "../common/roles.constants";
 
 @Controller("master-kegiatan")
 @UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(ROLES.ADMIN, ROLES.KETUA)
 export class MasterKegiatanController {
   constructor(private readonly masterService: MasterKegiatanService) {}
 


### PR DESCRIPTION
## Summary
- gate all master kegiatan endpoints behind the RolesGuard
- allow only users with the admin or ketua role to access these routes

## Testing
- `npm test --silent` in `api`
- `npm test --silent` in `web`


------
https://chatgpt.com/codex/tasks/task_b_68887af72078832ba659de83ab9891ea