### PR TITLE
Modify Sidebar for pimpinan

### DIFF
--- a/web/src/__tests__/Sidebar.test.jsx
+++ b/web/src/__tests__/Sidebar.test.jsx
@@ -18,8 +18,9 @@ describe('Sidebar role visibility', () => {
     expect(screen.getByText(/Monitoring/i)).toBeInTheDocument();
     expect(screen.getByText(/Keterlambatan/i)).toBeInTheDocument();
     expect(screen.getByText(/Tugas Mingguan/i)).toBeInTheDocument();
+    expect(screen.getByText(/Tugas Tambahan/i)).toBeInTheDocument();
+    expect(screen.getByText(/Data Pegawai/i)).toBeInTheDocument();
     expect(screen.queryByText(/Dashboard/i)).toBeNull();
-    expect(screen.queryByText(/Tugas Tambahan/i)).toBeNull();
     expect(screen.queryByText(/Laporan Harian/i)).toBeNull();
     expect(screen.queryByText(/Master Kegiatan/i)).toBeNull();
     expect(screen.queryByText(/Kelola Pengguna/i)).toBeNull();

--- a/web/src/pages/layout/Sidebar.jsx
+++ b/web/src/pages/layout/Sidebar.jsx
@@ -31,7 +31,7 @@ const mainLinks = [
     to: "/tugas-tambahan",
     label: "Tugas Tambahan",
     icon: FilePlus,
-    roles: [ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA],
+    roles: [ROLES.ADMIN, ROLES.KETUA, ROLES.ANGGOTA, ROLES.PIMPINAN],
   },
   {
     to: "/laporan-harian",
@@ -80,6 +80,13 @@ export default function Sidebar({ setSidebarOpen }) {
   const isLinkVisible = (link) => !link.roles || link.roles.includes(user?.role);
   const visibleMainLinks = mainLinks.filter(isLinkVisible);
   const visibleManageLinks = manageLinks.filter(isLinkVisible);
+  const isPimpinan = user?.role === ROLES.PIMPINAN;
+
+  const getLink = (path) => visibleMainLinks.find((l) => l.to === path);
+  const monitoringLink = getLink("/monitoring");
+  const terlambatLink = getLink("/laporan-terlambat");
+  const mingguanLink = getLink("/tugas-mingguan");
+  const tambahanLink = getLink("/tugas-tambahan");
 
   const renderLink = (link) => {
     const Icon = link.icon;
@@ -115,7 +122,20 @@ export default function Sidebar({ setSidebarOpen }) {
       </div>
 
       <nav className="space-y-2">
-        {visibleMainLinks.map(renderLink)}
+        {isPimpinan ? (
+          <>
+            {monitoringLink && renderLink(monitoringLink)}
+            {terlambatLink && renderLink(terlambatLink)}
+            <hr className="my-4 border-gray-200 dark:border-gray-700" />
+            <div className="px-4 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+              Data Pegawai
+            </div>
+            {mingguanLink && renderLink(mingguanLink)}
+            {tambahanLink && renderLink(tambahanLink)}
+          </>
+        ) : (
+          visibleMainLinks.map(renderLink)
+        )}
         {visibleManageLinks.length > 0 && (
           <hr className="my-4 border-gray-200 dark:border-gray-700" />
         )}


### PR DESCRIPTION
## Summary
- allow pimpinan access to Tugas Tambahan
- show a custom link order for pimpinan with a *Data Pegawai* separator
- update sidebar tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6888aca330a4832bb44962b2a7878163