### PR TITLE
Allow pimpinan view tasks

### DIFF
--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -121,11 +121,13 @@ export default function PenugasanPage() {
       let kRes;
       if (user?.role === ROLES.ADMIN) {
         kRes = await axios.get("/master-kegiatan?limit=1000");
-      } else {
+      } else if (user?.role === ROLES.KETUA) {
         const tId = tRes.data[0]?.id;
         kRes = tId
           ? await axios.get(`/master-kegiatan?team=${tId}`)
           : { data: { data: [] } };
+      } else {
+        kRes = { data: { data: [] } };
       }
       setPenugasan(pRes.data);
       setUsers([...uRes.data].sort((a, b) => a.nama.localeCompare(b.nama)));

--- a/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
@@ -46,7 +46,9 @@ export default function TugasTambahanDetailPage() {
     try {
       const [dRes, kRes] = await Promise.all([
         axios.get(`/tugas-tambahan/${id}`),
-        axios.get("/master-kegiatan?limit=1000"),
+        user?.role === ROLES.ADMIN || user?.role === ROLES.KETUA
+          ? axios.get("/master-kegiatan?limit=1000")
+          : Promise.resolve({ data: [] }),
       ]);
       setItem(dRes.data);
       setKegiatan(kRes.data.data || kRes.data);

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -61,7 +61,9 @@ export default function TugasTambahanPage() {
 
       const [tRes, kRes, teamRes, userRes] = await Promise.all([
         tugasReq,
-        axios.get("/master-kegiatan?limit=1000"),
+        user?.role === ROLES.ADMIN || user?.role === ROLES.KETUA
+          ? axios.get("/master-kegiatan?limit=1000")
+          : Promise.resolve({ data: [] }),
         axios.get("/teams").then(async (res) => {
           if (Array.isArray(res.data) && res.data.length === 0) {
             return axios.get("/teams/member");


### PR DESCRIPTION
## Summary
- let pimpinan fetch task pages without hitting restricted Master Kegiatan API
- avoid unauthorized master-kegiatan requests for pimpinan users

## Testing
- `npm test --prefix api`
- `npm test --prefix web`


------
https://chatgpt.com/codex/tasks/task_b_68886e6b57a8832ba078694226ac5f76