### PR TITLE
Update date format to include Indonesian month names

### DIFF
--- a/web/src/components/dashboard/DailyOverview.jsx
+++ b/web/src/components/dashboard/DailyOverview.jsx
@@ -1,5 +1,6 @@
 import { getHolidays } from "../../utils/holidays";
 import Legend from "../ui/Legend";
+import months from "../../utils/months";
 
 const DailyOverview = ({ data = [] }) => {
   if (!Array.isArray(data)) {
@@ -10,8 +11,9 @@ const DailyOverview = ({ data = [] }) => {
   const currentYear = new Date(today).getFullYear();
 
   const formatDate = (iso) => {
-    const [y, m, d] = iso.split("-");
-    return `${d}-${m}-${y}`;
+    const d = new Date(iso);
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${day} ${months[d.getMonth()]} ${d.getFullYear()}`;
   };
 
   const HOLIDAYS = getHolidays(currentYear);

--- a/web/src/utils/formatDate.js
+++ b/web/src/utils/formatDate.js
@@ -1,3 +1,5 @@
+import months from "./months";
+
 export default function formatDate(iso = "") {
   if (!iso) return "";
   const d = new Date(iso);
@@ -6,7 +8,5 @@ export default function formatDate(iso = "") {
     return iso.slice(0, 10);
   }
   const day = String(d.getDate()).padStart(2, "0");
-  const month = String(d.getMonth() + 1).padStart(2, "0");
-  const year = d.getFullYear();
-  return `${day}-${month}-${year}`;
+  return `${day} ${months[d.getMonth()]} ${d.getFullYear()}`;
 }


### PR DESCRIPTION
## Summary
- use Indonesian month names in `formatDate` util
- use the updated formatting for the daily overview component

## Testing
- `npm run lint` *(fails: 4 errors, 10 warnings)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6888b83850cc832bb243badd7a5814cb