### PR TITLE
Allow pimpinan view tasks

### DIFF
--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -50,6 +50,9 @@ export class LaporanService {
   }
   async submit(data: any, userId: number, role: string) {
     role = normalizeRole(role);
+    if (role === ROLES.PIMPINAN) {
+      throw new ForbiddenException('pimpinan tidak diizinkan');
+    }
     const pen = await this.prisma.penugasan.findUnique({
       where: { id: data.penugasanId },
       include: { kegiatan: true },
@@ -119,6 +122,9 @@ export class LaporanService {
 
   async update(id: number, data: any, userId: number, role: string) {
     role = normalizeRole(role);
+    if (role === ROLES.PIMPINAN) {
+      throw new ForbiddenException('pimpinan tidak diizinkan');
+    }
     const existing = await this.prisma.laporanHarian.findUnique({
       where: { id },
       include: { penugasan: { include: { kegiatan: true } } },
@@ -158,6 +164,9 @@ export class LaporanService {
 
   async remove(id: number, userId: number, role: string) {
     role = normalizeRole(role);
+    if (role === ROLES.PIMPINAN) {
+      throw new ForbiddenException('pimpinan tidak diizinkan');
+    }
     const existing = await this.prisma.laporanHarian.findUnique({
       where: { id },
       include: { penugasan: { include: { kegiatan: true } } },

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -30,6 +30,7 @@ export default function PenugasanDetailPage() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const canManage = [ROLES.ADMIN, ROLES.KETUA].includes(user?.role);
+  const canManageLaporan = user?.role !== ROLES.PIMPINAN;
   const [item, setItem] = useState(null);
   const [kegiatan, setKegiatan] = useState([]);
   const [users, setUsers] = useState([]);
@@ -188,7 +189,8 @@ export default function PenugasanDetailPage() {
   };
 
   const columns = useMemo(
-    () => [
+    () => {
+      const cols = [
       {
         Header: "No",
         accessor: (_row, i) => i + 1,
@@ -231,34 +233,37 @@ export default function PenugasanDetailPage() {
         Header: "Catatan",
         accessor: (row) => row.catatan || "-",
         disableFilters: true,
-      },
-      {
-        Header: "Aksi",
-        accessor: "id",
-        Cell: ({ row }) => (
-          <div className="space-x-2">
-            <Button
-              onClick={() => editLaporan(row.original)}
-              variant="warning"
-              icon
-              aria-label="Edit laporan"
-            >
-              <Pencil size={14} />
-            </Button>
-            <Button
-              onClick={() => deleteLaporan(row.original.id)}
-              variant="danger"
-              icon
-              aria-label="Hapus laporan"
-            >
-              <Trash2 size={14} />
-            </Button>
-          </div>
-        ),
-        disableFilters: true,
-      },
-    ],
-    [editLaporan, deleteLaporan]
+      }];
+      if (canManageLaporan) {
+        cols.push({
+          Header: "Aksi",
+          accessor: "id",
+          Cell: ({ row }) => (
+            <div className="space-x-2">
+              <Button
+                onClick={() => editLaporan(row.original)}
+                variant="warning"
+                icon
+                aria-label="Edit laporan"
+              >
+                <Pencil size={14} />
+              </Button>
+              <Button
+                onClick={() => deleteLaporan(row.original.id)}
+                variant="danger"
+                icon
+                aria-label="Hapus laporan"
+              >
+                <Trash2 size={14} />
+              </Button>
+            </div>
+          ),
+          disableFilters: true,
+        });
+      }
+      return cols;
+    },
+    [editLaporan, deleteLaporan, canManageLaporan]
   );
 
   const remove = async () => {
@@ -507,7 +512,7 @@ export default function PenugasanDetailPage() {
           <h3 className="text-xl font-bold text-gray-800 dark:text-gray-100">
             Laporan Harian
           </h3>
-          {item.status !== STATUS.SELESAI_DIKERJAKAN && (
+          {item.status !== STATUS.SELESAI_DIKERJAKAN && user?.role !== ROLES.PIMPINAN && (
             <Button
               onClick={openLaporan}
               className="flex items-center gap-2 px-3 py-2 sm:px-4"

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -52,6 +52,8 @@ export default function PenugasanPage() {
 
   // --- State
   const [penugasan, setPenugasan] = useState([]);
+  const [teams, setTeams] = useState([]);
+  const [filterTeam, setFilterTeam] = useState("");
   const [kegiatan, setKegiatan] = useState([]);
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -121,13 +123,16 @@ export default function PenugasanPage() {
       let kRes;
       if (user?.role === ROLES.ADMIN) {
         kRes = await axios.get("/master-kegiatan?limit=1000");
-      } else {
+      } else if (user?.role === ROLES.KETUA) {
         const tId = tRes.data[0]?.id;
         kRes = tId
           ? await axios.get(`/master-kegiatan?team=${tId}`)
           : { data: { data: [] } };
+      } else {
+        kRes = { data: { data: [] } };
       }
       setPenugasan(pRes.data);
+      setTeams(tRes.data);
       setUsers([...uRes.data].sort((a, b) => a.nama.localeCompare(b.nama)));
       const kData = kRes.data.data || kRes.data;
       setKegiatan(
@@ -174,12 +179,15 @@ export default function PenugasanPage() {
         p.pegawai?.nama || ""
       }`.toLowerCase();
       const matchesSearch = text.includes(search.toLowerCase());
+      const matchTeam = filterTeam
+        ? p.kegiatan?.teamId === parseInt(filterTeam, 10)
+        : true;
       if (viewTab === "mine") return matchesSearch && p.pegawaiId === user?.id;
       if (viewTab === "anggota")
-        return matchesSearch && p.pegawaiId !== user?.id;
-      return matchesSearch;
+        return matchesSearch && matchTeam && p.pegawaiId !== user?.id;
+      return matchesSearch && matchTeam;
     });
-  }, [penugasan, search, viewTab, user?.id]);
+  }, [penugasan, search, viewTab, user?.id, filterTeam]);
   const paginated = useMemo(
     () => filtered.slice((currentPage - 1) * pageSize, currentPage * pageSize),
     [filtered, currentPage, pageSize]
@@ -253,6 +261,25 @@ export default function PenugasanPage() {
             placeholder="Cari penugasan..."
             ariaLabel="Cari penugasan"
           />
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          {user?.role === ROLES.PIMPINAN && (
+            <select
+              value={filterTeam}
+              onChange={(e) => {
+                setFilterTeam(e.target.value);
+                setCurrentPage(1);
+              }}
+              className="cursor-pointer border border-gray-300 dark:border-gray-600 rounded-xl px-2 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none"
+            >
+              <option value="">Semua Tim</option>
+              {teams.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.namaTim}
+                </option>
+              ))}
+            </select>
+          )}
           <MonthYearPicker
             month={filterBulan}
             year={filterTahun}
@@ -283,49 +310,51 @@ export default function PenugasanPage() {
               </option>
             ))}
           </select>
+          {canManage && (
+            <Button
+              onClick={openCreate}
+              className="flex gap-2 items-center shadow-sm"
+              variant="primary"
+            >
+              <Plus size={16} />
+              <span className="hidden sm:inline">Tugas Mingguan</span>
+            </Button>
+          )}
         </div>
-        {canManage && (
-          <Button
-            onClick={openCreate}
-            className="flex gap-2 items-center shadow-sm"
-            variant="primary"
-          >
-            <Plus size={16} />
-            <span className="hidden sm:inline">Tugas Mingguan</span>
-          </Button>
-        )}
       </motion.div>
 
       {/* TABS */}
-      <div
-        className="flex flex-wrap gap-2"
-        role="tablist"
-        aria-label="View Tabs"
-      >
-        {[
-          { id: "all", label: "Semua" },
-          { id: "mine", label: "Tugas untuk Saya" },
-          { id: "anggota", label: "Tugas Anggota" },
-        ].map((t) => (
-          <Button
-            as="button"
-            type="button"
-            key={t.id}
-            onClick={() => {
-              setViewTab(t.id);
-              setCurrentPage(1);
-            }}
-            role="tab"
-            aria-selected={viewTab === t.id}
-            variant={viewTab === t.id ? "primary" : "ghost"}
-            className={`px-4 py-2 rounded-lg font-semibold transition ${
-              viewTab === t.id ? "shadow" : ""
-            }`}
-          >
-            {t.label}
-          </Button>
-        ))}
-      </div>
+      {user?.role !== ROLES.PIMPINAN && (
+        <div
+          className="flex flex-wrap gap-2"
+          role="tablist"
+          aria-label="View Tabs"
+        >
+          {[
+            { id: "all", label: "Semua" },
+            { id: "mine", label: "Tugas untuk Saya" },
+            { id: "anggota", label: "Tugas Anggota" },
+          ].map((t) => (
+            <Button
+              as="button"
+              type="button"
+              key={t.id}
+              onClick={() => {
+                setViewTab(t.id);
+                setCurrentPage(1);
+              }}
+              role="tab"
+              aria-selected={viewTab === t.id}
+              variant={viewTab === t.id ? "primary" : "ghost"}
+              className={`px-4 py-2 rounded-lg font-semibold transition ${
+                viewTab === t.id ? "shadow" : ""
+              }`}
+            >
+              {t.label}
+            </Button>
+          ))}
+        </div>
+      )}
 
       {/* TABLE */}
       <div className="overflow-x-auto md:overflow-x-visible min-h-[120px]">

--- a/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
@@ -46,7 +46,9 @@ export default function TugasTambahanDetailPage() {
     try {
       const [dRes, kRes] = await Promise.all([
         axios.get(`/tugas-tambahan/${id}`),
-        axios.get("/master-kegiatan?limit=1000"),
+        user?.role === ROLES.ADMIN || user?.role === ROLES.KETUA
+          ? axios.get("/master-kegiatan?limit=1000")
+          : Promise.resolve({ data: [] }),
       ]);
       setItem(dRes.data);
       setKegiatan(kRes.data.data || kRes.data);

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -61,7 +61,9 @@ export default function TugasTambahanPage() {
 
       const [tRes, kRes, teamRes, userRes] = await Promise.all([
         tugasReq,
-        axios.get("/master-kegiatan?limit=1000"),
+        user?.role === ROLES.ADMIN || user?.role === ROLES.KETUA
+          ? axios.get("/master-kegiatan?limit=1000")
+          : Promise.resolve({ data: [] }),
         axios.get("/teams").then(async (res) => {
           if (Array.isArray(res.data) && res.data.length === 0) {
             return axios.get("/teams/member");
@@ -246,7 +248,7 @@ export default function TugasTambahanPage() {
             onMonthChange={setFilterBulan}
             onYearChange={setFilterTahun}
           />
-          {user?.role === ROLES.ADMIN && (
+          {[ROLES.ADMIN, ROLES.PIMPINAN].includes(user?.role) && (
             <>
               <select
                 value={filterTeam}


### PR DESCRIPTION
## Summary
- let pimpinan fetch task pages without hitting restricted Master Kegiatan API
- avoid unauthorized master-kegiatan requests for pimpinan users
- hide task tabs for pimpinan and add team filtering
- prevent pimpinan from editing daily reports

## Testing
- `npm test --prefix api` *(fails: jest not found)*
- `npm test --prefix web` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_b_68886e6b57a8832ba078694226ac5f76