### PR TITLE
Filter admin & pimpinan teams

### DIFF
--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -132,7 +132,11 @@ export default function PenugasanPage() {
         kRes = { data: { data: [] } };
       }
       setPenugasan(pRes.data);
-      setTeams(tRes.data);
+      setTeams(
+        tRes.data.filter(
+          (t) => t.namaTim !== "Admin" && t.namaTim !== "Pimpinan"
+        )
+      );
       setUsers([...uRes.data].sort((a, b) => a.nama.localeCompare(b.nama)));
       const kData = kRes.data.data || kRes.data;
       setKegiatan(

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -74,7 +74,11 @@ export default function TugasTambahanPage() {
       ]);
       setItems(tRes.data);
       setKegiatan(kRes.data.data || kRes.data);
-      setTeams(teamRes.data);
+      setTeams(
+        teamRes.data.filter(
+          (t) => t.namaTim !== "Admin" && t.namaTim !== "Pimpinan"
+        )
+      );
       if (user?.role === ROLES.ADMIN) {
         const sorted = userRes.data
           .filter((u) => u.role !== ROLES.ADMIN && u.role !== ROLES.PIMPINAN)


### PR DESCRIPTION
## Summary
- ignore Admin and Pimpinan teams when fetching teams in Penugasan and Tugas Tambahan pages

## Testing
- `npm test --silent` in `web`
- `npm test --silent` in `api`


------
https://chatgpt.com/codex/tasks/task_b_6888be9603e0832b9a176075c0fa752e