### PR TITLE
Adjust monitoring weekly view

### DIFF
--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -25,10 +25,14 @@ export default function MonitoringPage() {
 
   const { user } = useAuth();
 
-  // Fetch daftar tim jika admin/ketua
+  // Fetch daftar tim jika admin/ketua/pimpinan
   useEffect(() => {
     const fetchTeams = async () => {
-      if (user?.role === ROLES.ADMIN || user?.role === ROLES.KETUA) {
+      if (
+        user?.role === ROLES.ADMIN ||
+        user?.role === ROLES.KETUA ||
+        user?.role === ROLES.PIMPINAN
+      ) {
         try {
           const res = await axios.get("/teams");
           setTeams(res.data);

--- a/web/src/pages/monitoring/WeeklyMatrix.jsx
+++ b/web/src/pages/monitoring/WeeklyMatrix.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import getProgressColor from "../../utils/progressColor";
 
-export const WeeklyMatrixRow = ({ user, progressColor }) => (
+export const WeeklyMatrixRow = ({ user, progressColor, weekCount }) => (
   <tr className="text-center">
     <td className="p-2 border text-left whitespace-nowrap text-sm">{user.nama}</td>
-    {user.weeks.map((w, i) => (
+    {user.weeks.slice(0, weekCount).map((w, i) => (
       <td key={i} className="p-1 border space-y-1">
         <div
           role="progressbar"
@@ -49,7 +49,12 @@ const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek, selectedWeek }) => 
         </thead>
         <tbody>
           {data.map((u) => (
-            <WeeklyMatrixRow key={u.userId} user={u} progressColor={progressColor} />
+            <WeeklyMatrixRow
+              key={u.userId}
+              user={u}
+              progressColor={progressColor}
+              weekCount={weeks.length}
+            />
           ))}
         </tbody>
       </table>

--- a/web/src/pages/monitoring/components/FilterToolbar.jsx
+++ b/web/src/pages/monitoring/components/FilterToolbar.jsx
@@ -142,7 +142,7 @@ export default function FilterToolbar({
       )}
 
       {/* Filter tim */}
-      {(userRole === "admin" || userRole === "ketua") && (
+      {(userRole === "admin" || userRole === "ketua" || userRole === "pimpinan") && (
         <div className="w-36">
           <select
             value={teamId}

--- a/web/src/pages/monitoring/components/TabContent.jsx
+++ b/web/src/pages/monitoring/components/TabContent.jsx
@@ -134,17 +134,6 @@ export default function TabContent({
           <div className="flex flex-wrap gap-2 mb-4" role="tablist">
             <button
               type="button"
-              onClick={() => setWeeklyMode("matrix")}
-              className={`px-4 py-1.5 rounded-lg font-semibold text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-150 ease-in-out ${
-                weeklyMode === "matrix"
-                  ? "bg-blue-600 text-white"
-                  : "bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-300 dark:hover:bg-gray-600"
-              }`}
-            >
-              Progress per Minggu
-            </button>
-            <button
-              type="button"
               onClick={() => setWeeklyMode("summary")}
               className={`px-4 py-1.5 rounded-lg font-semibold text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-150 ease-in-out ${
                 weeklyMode === "summary"
@@ -152,7 +141,18 @@ export default function TabContent({
                   : "bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-300 dark:hover:bg-gray-600"
               }`}
             >
-              Ringkasan Minggu
+              Ringkasan Minggu Ini
+            </button>
+            <button
+              type="button"
+              onClick={() => setWeeklyMode("matrix")}
+              className={`px-4 py-1.5 rounded-lg font-semibold text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-150 ease-in-out ${
+                weeklyMode === "matrix"
+                  ? "bg-blue-600 text-white"
+                  : "bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-300 dark:hover:bg-gray-600"
+              }`}
+            >
+              Ringkasan per Minggu
             </button>
           </div>
 


### PR DESCRIPTION
## Summary
- reorder weekly view tabs and rename labels
- slice weeks in weekly matrix to avoid extra percent column
- enable team filter for leaders
- fetch team data for leader role

## Testing
- `npm test --silent` in `web`
- `npm test --silent` in `api`


------
https://chatgpt.com/codex/tasks/task_b_6888be7dc014832b8fdf9ce63606cbb6