### PR TITLE
Display employee count in monitoring card

### DIFF
--- a/web/src/pages/monitoring/MissedReportsPage.jsx
+++ b/web/src/pages/monitoring/MissedReportsPage.jsx
@@ -165,7 +165,7 @@ export default function MissedReportsPage() {
           {title}
         </h2>
         <span className="text-2xl font-bold" style={{ color }}>
-          {count}
+          {count} Pegawai
         </span>
       </div>
       <div className="max-h-72 overflow-y-auto pr-1 custom-scrollbar">


### PR DESCRIPTION
## Summary
- show descriptive count label in `MissedReportsPage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6888c9a40f98832b83ece03d68e578ab