### PR TITLE
Implement week filter for weekly assignments

### DIFF
--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -71,6 +71,7 @@ export default function PenugasanPage() {
   const [filterBulan, setFilterBulan] = useState("");
   const [filterTahun, setFilterTahun] = useState(new Date().getFullYear());
   const [filterMinggu, setFilterMinggu] = useState("");
+  const [weekOptions, setWeekOptions] = useState([]);
   const [pageSize, setPageSize] = useState(10);
   const [currentPage, setCurrentPage] = useState(1);
   const [viewTab, setViewTab] = useState("all");
@@ -97,6 +98,28 @@ export default function PenugasanPage() {
     if (!filterMinggu) initWeek();
     // eslint-disable-next-line
   }, [filterBulan, filterTahun]);
+
+  useEffect(() => {
+    if (!filterBulan || !filterTahun) {
+      setWeekOptions([]);
+      setFilterMinggu("");
+      return;
+    }
+    const year = parseInt(filterTahun, 10);
+    const monthIdx = parseInt(filterBulan, 10) - 1;
+    const firstOfMonth = new Date(year, monthIdx, 1);
+    const monthEnd = new Date(year, monthIdx + 1, 0);
+    const firstMonday = new Date(firstOfMonth);
+    firstMonday.setDate(
+      firstOfMonth.getDate() - ((firstOfMonth.getDay() + 6) % 7)
+    );
+    const opts = [];
+    for (let d = new Date(firstMonday); d <= monthEnd; d.setDate(d.getDate() + 7)) {
+      opts.push(opts.length + 1);
+    }
+    setWeekOptions(opts);
+    if (filterMinggu && filterMinggu > opts.length) setFilterMinggu("");
+  }, [filterBulan, filterTahun, filterMinggu]);
 
   const fetchData = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- add `weekOptions` state to Penugasan page
- compute week options based on selected month and year
- clear week filter if selected month/year changes

## Testing
- `npm test`
- `npm run lint` *(fails: 6 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_6888ce36533c832bb136eac364cdd1d1