### PR TITLE
Add notification feature

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -63,6 +63,9 @@ Jika `JWT_SECRET` tidak diatur, aplikasi akan langsung keluar dengan error.
 `CORS_ORIGIN` opsional, isi dengan satu atau beberapa origin (pisahkan koma)
 untuk membatasi akses CORS.
 
+Fitur notifikasi tidak memerlukan variabel tambahan. Jadwal pengingat harian
+aktif secara otomatis setiap pagi.
+
 4. **Setup database**
 ```bash
 npx prisma generate
@@ -126,6 +129,9 @@ Setiap IP dibatasi **100 request** setiap **15 menit**.
 | GET    | `/monitoring/bulanan/all`  | Monitoring bulanan semua pegawai (query: `year`, `bulan` opsional, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/bulanan/matrix` | Matriks bulanan per user (query: `year`, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/laporan/terlambat` | Daftar pegawai terlambat mengisi laporan (query: `teamId` opsional) | admin, pimpinan, ketua tim |
+| GET    | `/notifications`           | Daftar notifikasi user       | login |
+| POST   | `/notifications/read-all`  | Tandai semua notifikasi user | login |
+| POST   | `/notifications/:id/read`  | Tandai satu notifikasi       | login |
 
 Endpoint `/tugas-tambahan/all` memungkinkan admin melihat seluruh laporan tugas tambahan.
 Gunakan parameter opsional `teamId` atau `userId` untuk memfilter hasil.

--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
     "@nestjs/passport": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/throttler": "^6.4.0",
+    "@nestjs/schedule": "^2.0.0",
     "@prisma/client": "^5.22.0",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -97,3 +97,13 @@ model Role {
   id   Int    @id @default(autoincrement())
   name String @unique
 }
+
+model Notification {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  text      String
+  link      String?
+  isRead    Boolean  @default(false)
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
+}

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { APP_GUARD } from "@nestjs/core";
 import { ThrottlerGuard, ThrottlerModule, minutes } from "@nestjs/throttler";
+import { ScheduleModule } from "@nestjs/schedule";
 import { PrismaService } from "./prisma.service";
 import { AuthModule } from "./auth/auth.module";
 import { UsersModule } from "./users/users.module";
@@ -15,6 +16,7 @@ import { HealthController } from "./health.controller";
 @Module({
   imports: [
     ThrottlerModule.forRoot([{ ttl: minutes(15), limit: 100 }]),
+    ScheduleModule.forRoot(),
     AuthModule,
     UsersModule,
     TeamsModule,

--- a/api/src/kegiatan/kegiatan.module.ts
+++ b/api/src/kegiatan/kegiatan.module.ts
@@ -4,8 +4,10 @@ import { MasterKegiatanService } from "./master-kegiatan.service";
 import { PenugasanController } from "./penugasan.controller";
 import { PenugasanService } from "./penugasan.service";
 import { PrismaService } from "../prisma.service";
+import { NotificationsModule } from "../notifications/notifications.module";
 
 @Module({
+  imports: [NotificationsModule],
   controllers: [MasterKegiatanController, PenugasanController],
   providers: [PrismaService, MasterKegiatanService, PenugasanService],
 })

--- a/api/src/laporan/laporan.module.ts
+++ b/api/src/laporan/laporan.module.ts
@@ -4,8 +4,10 @@ import { LaporanService } from "./laporan.service";
 import { TambahanController } from "./tugas-tambahan.controller";
 import { TambahanService } from "./tugas-tambahan.service";
 import { PrismaService } from "../prisma.service";
+import { NotificationsModule } from "../notifications/notifications.module";
 
 @Module({
+  imports: [NotificationsModule],
   controllers: [LaporanController, TambahanController],
   providers: [PrismaService, LaporanService, TambahanService],
 })

--- a/api/src/notifications/notifications.controller.ts
+++ b/api/src/notifications/notifications.controller.ts
@@ -1,18 +1,32 @@
-import { Controller, Get, Post } from "@nestjs/common";
+import { Controller, Get, Post, Param, ParseIntPipe, UseGuards, Req } from "@nestjs/common";
+import { Request } from "express";
 import { NotificationsService } from "./notifications.service";
+import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
+import { AuthRequestUser } from "../common/auth-request-user.interface";
 
 @Controller("notifications")
+@UseGuards(JwtAuthGuard)
 export class NotificationsController {
   constructor(private readonly service: NotificationsService) {}
 
   @Get()
-  findAll() {
-    return this.service.findAll();
+  findMine(@Req() req: Request) {
+    const userId = (req.user as AuthRequestUser).userId;
+    return this.service.findByUser(userId);
   }
 
   @Post("read-all")
-  markAllAsRead() {
-    this.service.markAllAsRead();
-    return { message: "ok" };
+  markAllAsRead(@Req() req: Request) {
+    const userId = (req.user as AuthRequestUser).userId;
+    return this.service.markAllAsRead(userId);
+  }
+
+  @Post(":id/read")
+  markRead(
+    @Param("id", ParseIntPipe) id: number,
+    @Req() req: Request,
+  ) {
+    const userId = (req.user as AuthRequestUser).userId;
+    return this.service.markAsRead(id, userId);
   }
 }

--- a/api/src/notifications/notifications.module.ts
+++ b/api/src/notifications/notifications.module.ts
@@ -1,9 +1,14 @@
 import { Module } from "@nestjs/common";
 import { NotificationsController } from "./notifications.controller";
 import { NotificationsService } from "./notifications.service";
+import { PrismaService } from "../prisma.service";
+import { ReminderService } from "./reminder.service";
+import { MonitoringModule } from "../monitoring/monitoring.module";
 
 @Module({
+  imports: [MonitoringModule],
   controllers: [NotificationsController],
-  providers: [NotificationsService],
+  providers: [PrismaService, NotificationsService, ReminderService],
+  exports: [NotificationsService],
 })
 export class NotificationsModule {}

--- a/api/src/notifications/notifications.service.ts
+++ b/api/src/notifications/notifications.service.ts
@@ -1,24 +1,34 @@
 import { Injectable } from "@nestjs/common";
-
-interface Notification {
-  id: number;
-  text: string;
-  read: boolean;
-}
+import { PrismaService } from "../prisma.service";
 
 @Injectable()
 export class NotificationsService {
-  private notifications: Notification[] = [
-    { id: 1, text: "Laporan harian belum dikirim", read: false },
-    { id: 2, text: "Penugasan baru tersedia", read: false },
-    { id: 3, text: "Tim Anda telah diperbarui", read: false },
-  ];
+  constructor(private prisma: PrismaService) {}
 
-  findAll() {
-    return this.notifications;
+  create(userId: number, text: string, link?: string) {
+    return this.prisma.notification.create({
+      data: { userId, text, link },
+    });
   }
 
-  markAllAsRead() {
-    this.notifications = this.notifications.map((n) => ({ ...n, read: true }));
+  findByUser(userId: number) {
+    return this.prisma.notification.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  markAsRead(id: number, userId: number) {
+    return this.prisma.notification.updateMany({
+      where: { id, userId },
+      data: { isRead: true },
+    });
+  }
+
+  markAllAsRead(userId: number) {
+    return this.prisma.notification.updateMany({
+      where: { userId, isRead: false },
+      data: { isRead: true },
+    });
   }
 }

--- a/api/src/notifications/reminder.service.ts
+++ b/api/src/notifications/reminder.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from "@nestjs/common";
+import { Cron } from "@nestjs/schedule";
+import { MonitoringService } from "../monitoring/monitoring.service";
+import { NotificationsService } from "./notifications.service";
+
+@Injectable()
+export class ReminderService {
+  constructor(
+    private monitoring: MonitoringService,
+    private notifications: NotificationsService,
+  ) {}
+
+  @Cron("0 6 * * *") // every day at 06:00
+  async handleCron() {
+    const res = await this.monitoring.laporanTerlambat();
+    const users = [...res.day1, ...res.day3, ...res.day7];
+    await Promise.all(
+      users.map((u) =>
+        this.notifications.create(
+          u.userId,
+          "Anda belum mengirim laporan harian",
+          "/laporan-harian",
+        ),
+      ),
+    );
+  }
+}

--- a/web/README.md
+++ b/web/README.md
@@ -89,3 +89,9 @@ const columns = [
 - `selectable` – include checkbox column for row selection
 - `showColumnFilters` – whether to display per-column filter dropdowns (default `true`); disabling it hides the filters
 
+## Notifications
+
+Header bell icon menampilkan daftar notifikasi terbaru. Klik notifikasi untuk
+menandainya sebagai telah dibaca dan langsung membuka tautan terkait. Tombol
+"Tandai sudah dibaca" akan menandai semua notifikasi sebagai selesai.
+


### PR DESCRIPTION
## Summary
- add Notification model and Prisma migration support
- implement notification services and reminder cron
- trigger notifications on task assignment and completion
- show notifications in the frontend layout with read actions
- document notification API and usage

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing ESLint deps)*
- `npm run lint` in `web` *(fails: missing ESLint deps)*

------
https://chatgpt.com/codex/tasks/task_b_6888d5104048832b90d4607e7a5c03be