### PR TITLE
Add notification feature

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -63,6 +63,9 @@ Jika `JWT_SECRET` tidak diatur, aplikasi akan langsung keluar dengan error.
 `CORS_ORIGIN` opsional, isi dengan satu atau beberapa origin (pisahkan koma)
 untuk membatasi akses CORS.
 
+Fitur notifikasi tidak memerlukan variabel tambahan. Jadwal pengingat harian
+aktif secara otomatis setiap pagi.
+
 4. **Setup database**
 ```bash
 npx prisma generate
@@ -126,6 +129,9 @@ Setiap IP dibatasi **100 request** setiap **15 menit**.
 | GET    | `/monitoring/bulanan/all`  | Monitoring bulanan semua pegawai (query: `year`, `bulan` opsional, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/bulanan/matrix` | Matriks bulanan per user (query: `year`, `teamId` opsional) | admin, pimpinan, ketua tim |
 | GET    | `/monitoring/laporan/terlambat` | Daftar pegawai terlambat mengisi laporan (query: `teamId` opsional) | admin, pimpinan, ketua tim |
+| GET    | `/notifications`           | Daftar notifikasi user       | login |
+| POST   | `/notifications/read-all`  | Tandai semua notifikasi user | login |
+| POST   | `/notifications/:id/read`  | Tandai satu notifikasi       | login |
 
 Endpoint `/tugas-tambahan/all` memungkinkan admin melihat seluruh laporan tugas tambahan.
 Gunakan parameter opsional `teamId` atau `userId` untuk memfilter hasil.

--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
     "@nestjs/passport": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/throttler": "^6.4.0",
+    "@nestjs/schedule": "^6.0.0",
     "@prisma/client": "^5.22.0",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   penugasan Penugasan[]        @relation("PenugasanUser")
   laporan   LaporanHarian[]
   tambahan  KegiatanTambahan[]
+  notifications Notification[]
 }
 
 model Team {
@@ -96,4 +97,14 @@ model KegiatanTambahan {
 model Role {
   id   Int    @id @default(autoincrement())
   name String @unique
+}
+
+model Notification {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  text      String
+  link      String?
+  isRead    Boolean  @default(false)
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
 }

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { APP_GUARD } from "@nestjs/core";
 import { ThrottlerGuard, ThrottlerModule, minutes } from "@nestjs/throttler";
+import { ScheduleModule } from "@nestjs/schedule";
 import { PrismaService } from "./prisma.service";
 import { AuthModule } from "./auth/auth.module";
 import { UsersModule } from "./users/users.module";
@@ -15,6 +16,7 @@ import { HealthController } from "./health.controller";
 @Module({
   imports: [
     ThrottlerModule.forRoot([{ ttl: minutes(15), limit: 100 }]),
+    ScheduleModule.forRoot(),
     AuthModule,
     UsersModule,
     TeamsModule,

--- a/api/src/kegiatan/kegiatan.module.ts
+++ b/api/src/kegiatan/kegiatan.module.ts
@@ -4,8 +4,10 @@ import { MasterKegiatanService } from "./master-kegiatan.service";
 import { PenugasanController } from "./penugasan.controller";
 import { PenugasanService } from "./penugasan.service";
 import { PrismaService } from "../prisma.service";
+import { NotificationsModule } from "../notifications/notifications.module";
 
 @Module({
+  imports: [NotificationsModule],
   controllers: [MasterKegiatanController, PenugasanController],
   providers: [PrismaService, MasterKegiatanService, PenugasanService],
 })

--- a/api/src/kegiatan/penugasan.service.ts
+++ b/api/src/kegiatan/penugasan.service.ts
@@ -5,6 +5,7 @@ import {
   BadRequestException,
 } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
+import { NotificationsService } from "../notifications/notifications.service";
 import { ROLES } from "../common/roles.constants";
 import { STATUS } from "../common/status.constants";
 import { normalizeRole } from "../common/roles";
@@ -13,7 +14,10 @@ import { AssignPenugasanBulkDto } from "./dto/assign-penugasan-bulk.dto";
 
 @Injectable()
 export class PenugasanService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private notifications: NotificationsService,
+  ) {}
 
   findAll(
     role: string,
@@ -72,7 +76,7 @@ export class PenugasanService {
         throw new ForbiddenException("bukan ketua tim kegiatan ini");
       }
     }
-    return this.prisma.penugasan.create({
+    const penugasan = await this.prisma.penugasan.create({
       data: {
         kegiatanId: data.kegiatanId,
         pegawaiId: data.pegawaiId,
@@ -83,6 +87,14 @@ export class PenugasanService {
         status: data.status || STATUS.BELUM,
       },
     });
+
+    await this.notifications.create(
+      data.pegawaiId,
+      "Penugasan baru tersedia",
+      `/tugas-mingguan/${penugasan.id}`,
+    );
+
+    return penugasan;
   }
 
   async assignBulk(data: AssignPenugasanBulkDto, userId: number, role: string) {
@@ -110,8 +122,22 @@ export class PenugasanService {
       deskripsi: data.deskripsi,
       status: data.status || STATUS.BELUM,
     }));
-    await this.prisma.penugasan.createMany({ data: rows });
-    return { count: rows.length };
+
+    const created = await this.prisma.$transaction(
+      rows.map((r) => this.prisma.penugasan.create({ data: r })),
+    );
+
+    await Promise.all(
+      created.map((p: { pegawaiId: number; id: number }) =>
+        this.notifications.create(
+          p.pegawaiId,
+          "Penugasan baru tersedia",
+          `/tugas-mingguan/${p.id}`,
+        ),
+      ),
+    );
+
+    return { count: created.length };
   }
 
   async findOne(id: number, role: string, userId: number) {

--- a/api/src/laporan/laporan.module.ts
+++ b/api/src/laporan/laporan.module.ts
@@ -4,8 +4,10 @@ import { LaporanService } from "./laporan.service";
 import { TambahanController } from "./tugas-tambahan.controller";
 import { TambahanService } from "./tugas-tambahan.service";
 import { PrismaService } from "../prisma.service";
+import { NotificationsModule } from "../notifications/notifications.module";
 
 @Module({
+  imports: [NotificationsModule],
   controllers: [LaporanController, TambahanController],
   providers: [PrismaService, LaporanService, TambahanService],
 })

--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
+import { NotificationsService } from "../notifications/notifications.service";
 import { Workbook } from "exceljs";
 import PDFDocument from "pdfkit";
 import { normalizeRole } from "../common/roles";
@@ -15,7 +16,10 @@ import { STATUS } from "../common/status.constants";
 
 @Injectable()
 export class LaporanService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private notifications: NotificationsService,
+  ) {}
 
   getAll() {
     return this.prisma.laporanHarian.findMany({
@@ -28,14 +32,36 @@ export class LaporanService {
   }
 
   private async syncPenugasanStatus(penugasanId: number) {
+    const pen = await this.prisma.penugasan.findUnique({
+      where: { id: penugasanId },
+      include: { kegiatan: true },
+    });
+    if (!pen) return;
+
     const finished = await this.prisma.laporanHarian.findFirst({
       where: { penugasanId, status: STATUS.SELESAI_DIKERJAKAN },
     });
     if (finished) {
-      await this.prisma.penugasan.update({
-        where: { id: penugasanId },
-        data: { status: STATUS.SELESAI_DIKERJAKAN },
-      });
+      if (pen.status !== STATUS.SELESAI_DIKERJAKAN) {
+        await this.prisma.penugasan.update({
+          where: { id: penugasanId },
+          data: { status: STATUS.SELESAI_DIKERJAKAN },
+        });
+
+        const leaders = await this.prisma.member.findMany({
+          where: { teamId: pen.kegiatan.teamId, isLeader: true },
+          select: { userId: true },
+        });
+        await Promise.all(
+          leaders.map((l: { userId: number }) =>
+            this.notifications.create(
+              l.userId,
+              `Penugasan ${pen.kegiatan.namaKegiatan} selesai`,
+              `/tugas-mingguan/${pen.id}`,
+            ),
+          ),
+        );
+      }
       return;
     }
 

--- a/api/src/notifications/notifications.controller.ts
+++ b/api/src/notifications/notifications.controller.ts
@@ -1,18 +1,32 @@
-import { Controller, Get, Post } from "@nestjs/common";
+import { Controller, Get, Post, Param, ParseIntPipe, UseGuards, Req } from "@nestjs/common";
+import { Request } from "express";
 import { NotificationsService } from "./notifications.service";
+import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
+import { AuthRequestUser } from "../common/auth-request-user.interface";
 
 @Controller("notifications")
+@UseGuards(JwtAuthGuard)
 export class NotificationsController {
   constructor(private readonly service: NotificationsService) {}
 
   @Get()
-  findAll() {
-    return this.service.findAll();
+  findMine(@Req() req: Request) {
+    const userId = (req.user as AuthRequestUser).userId;
+    return this.service.findByUser(userId);
   }
 
   @Post("read-all")
-  markAllAsRead() {
-    this.service.markAllAsRead();
-    return { message: "ok" };
+  markAllAsRead(@Req() req: Request) {
+    const userId = (req.user as AuthRequestUser).userId;
+    return this.service.markAllAsRead(userId);
+  }
+
+  @Post(":id/read")
+  markRead(
+    @Param("id", ParseIntPipe) id: number,
+    @Req() req: Request,
+  ) {
+    const userId = (req.user as AuthRequestUser).userId;
+    return this.service.markAsRead(id, userId);
   }
 }

--- a/api/src/notifications/notifications.module.ts
+++ b/api/src/notifications/notifications.module.ts
@@ -1,9 +1,14 @@
 import { Module } from "@nestjs/common";
 import { NotificationsController } from "./notifications.controller";
 import { NotificationsService } from "./notifications.service";
+import { PrismaService } from "../prisma.service";
+import { ReminderService } from "./reminder.service";
+import { MonitoringModule } from "../monitoring/monitoring.module";
 
 @Module({
+  imports: [MonitoringModule],
   controllers: [NotificationsController],
-  providers: [NotificationsService],
+  providers: [PrismaService, NotificationsService, ReminderService],
+  exports: [NotificationsService],
 })
 export class NotificationsModule {}

--- a/api/src/notifications/notifications.service.ts
+++ b/api/src/notifications/notifications.service.ts
@@ -1,24 +1,34 @@
 import { Injectable } from "@nestjs/common";
-
-interface Notification {
-  id: number;
-  text: string;
-  read: boolean;
-}
+import { PrismaService } from "../prisma.service";
 
 @Injectable()
 export class NotificationsService {
-  private notifications: Notification[] = [
-    { id: 1, text: "Laporan harian belum dikirim", read: false },
-    { id: 2, text: "Penugasan baru tersedia", read: false },
-    { id: 3, text: "Tim Anda telah diperbarui", read: false },
-  ];
+  constructor(private prisma: PrismaService) {}
 
-  findAll() {
-    return this.notifications;
+  create(userId: number, text: string, link?: string) {
+    return this.prisma.notification.create({
+      data: { userId, text, link },
+    });
   }
 
-  markAllAsRead() {
-    this.notifications = this.notifications.map((n) => ({ ...n, read: true }));
+  findByUser(userId: number) {
+    return this.prisma.notification.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  markAsRead(id: number, userId: number) {
+    return this.prisma.notification.updateMany({
+      where: { id, userId },
+      data: { isRead: true },
+    });
+  }
+
+  markAllAsRead(userId: number) {
+    return this.prisma.notification.updateMany({
+      where: { userId, isRead: false },
+      data: { isRead: true },
+    });
   }
 }

--- a/api/src/notifications/reminder.service.ts
+++ b/api/src/notifications/reminder.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from "@nestjs/common";
+import { Cron } from "@nestjs/schedule";
+import { MonitoringService } from "../monitoring/monitoring.service";
+import { NotificationsService } from "./notifications.service";
+
+@Injectable()
+export class ReminderService {
+  constructor(
+    private monitoring: MonitoringService,
+    private notifications: NotificationsService,
+  ) {}
+
+  @Cron("0 6 * * *") // every day at 06:00
+  async handleCron() {
+    const res = await this.monitoring.laporanTerlambat();
+    const users = [...res.day1, ...res.day3, ...res.day7];
+    await Promise.all(
+      users.map((u) =>
+        this.notifications.create(
+          u.userId,
+          "Anda belum mengirim laporan harian",
+          "/laporan-harian",
+        ),
+      ),
+    );
+  }
+}

--- a/api/test/laporan.service.spec.ts
+++ b/api/test/laporan.service.spec.ts
@@ -17,10 +17,13 @@ const prisma = {
   },
   member: {
     findFirst: jest.fn(),
+    findMany: jest.fn(),
   },
 } as any;
 
-const service = new LaporanService(prisma);
+const notifications = { create: jest.fn() } as any;
+
+const service = new LaporanService(prisma, notifications);
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -69,6 +72,7 @@ describe('LaporanService submit', () => {
       pegawaiId: 1,
       kegiatan: { teamId: 1 },
     });
+    prisma.member.findMany.mockResolvedValue([]);
     prisma.laporanHarian.create.mockResolvedValue({ id: 11 });
     prisma.laporanHarian.findFirst.mockResolvedValueOnce({
       status: STATUS.SELESAI_DIKERJAKAN,

--- a/api/test/penugasan.service.spec.ts
+++ b/api/test/penugasan.service.spec.ts
@@ -7,7 +7,9 @@ const prisma = {
   laporanHarian: { count: jest.fn() },
 } as any;
 
-const service = new PenugasanService(prisma);
+const notifications = { create: jest.fn() } as any;
+
+const service = new PenugasanService(prisma, notifications);
 
 describe("PenugasanService remove", () => {
   beforeEach(() => {

--- a/web/README.md
+++ b/web/README.md
@@ -89,3 +89,9 @@ const columns = [
 - `selectable` – include checkbox column for row selection
 - `showColumnFilters` – whether to display per-column filter dropdowns (default `true`); disabling it hides the filters
 
+## Notifications
+
+Header bell icon menampilkan daftar notifikasi terbaru. Klik notifikasi untuk
+menandainya sebagai telah dibaca dan langsung membuka tautan terkait. Tombol
+"Tandai sudah dibaca" akan menandai semua notifikasi sebagai selesai.
+


### PR DESCRIPTION
## Summary
- add Notification model and Prisma migration support
- implement notification services and reminder cron
- trigger notifications on task assignment and completion
- show notifications in the frontend layout with read actions
- document notification API and usage
- fix missing relation field and tests

## Testing
- `npm test`
- `npm run lint` *(fails: parserOptions.project issue)*
- `npm run lint` in `web` *(fails: cannot find @eslint/js)*
- `npx prisma generate` *(fails: 403 Forbidden fetching prisma engine)*

------
https://chatgpt.com/codex/tasks/task_b_6888d5104048832b90d4607e7a5c03be