### PR TITLE
Move daily report CTA up on dashboard

### DIFF
--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -160,6 +160,19 @@ const Dashboard = () => {
         Selamat datang, {user?.nama || "Pengguna"}! 👋
       </h1>
 
+      {!hasReportedToday && (
+        <div className="bg-yellow-50 dark:bg-yellow-900 p-6 rounded-xl shadow text-center">
+          <h2 className="text-xl font-semibold text-yellow-800 dark:text-yellow-200 mb-3">
+            Hari ini Anda belum melakukan laporan kegiatan harian Anda!
+          </h2>
+          <Link to="/tugas-mingguan">
+            <Button variant="primary" className="font-semibold w-fit mx-auto">
+              Isi Laporan Sekarang
+            </Button>
+          </Link>
+        </div>
+      )}
+
       <StatsSummary weeklyData={weeklyList[weekIndex]} />
 
       <MonitoringTabs
@@ -171,19 +184,6 @@ const Dashboard = () => {
         onMonthChange={setMonthIndex}
         monthlyData={monthlyData}
       />
-
-      {!hasReportedToday && (
-        <div className="bg-yellow-50 dark:bg-yellow-900 p-6 rounded-xl shadow text-center">
-          <h2 className="text-xl font-semibold text-yellow-800 dark:text-yellow-200 mb-3">
-            Hari ini Anda belum melakukan laporan kegiatan harian Anda!
-          </h2>
-          <Link to="/laporan-harian">
-            <Button variant="primary" className="font-semibold w-fit mx-auto">
-              Isi Laporan Sekarang
-            </Button>
-          </Link>
-        </div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show daily report call-to-action near the top of the dashboard
- link it directly to the weekly assignment list

## Testing
- `npm test --silent` in `web`
- `npm test --silent` in `api` *(fails: Cannot find module 'jest-util')*

------
https://chatgpt.com/codex/tasks/task_b_6888db249c10832ba52821dc8f890e22