### PR TITLE
Set weekly task view to default to user tasks

### DIFF
--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -74,7 +74,8 @@ export default function PenugasanPage() {
   const [weekOptions, setWeekOptions] = useState([]);
   const [pageSize, setPageSize] = useState(10);
   const [currentPage, setCurrentPage] = useState(1);
-  const [viewTab, setViewTab] = useState("all");
+  // Default tab is "Tugas Saya" to show the current user's tasks first
+  const [viewTab, setViewTab] = useState("mine");
   const [formTouched, setFormTouched] = useState(false); // for validation
 
   // --- Refs for autofocus


### PR DESCRIPTION
## Summary
- default the weekly task list to the **Tugas Saya** tab

## Testing
- `npm test --silent` in `web`
- `npm test` in `api` *(fails: Cannot find module 'jest-util')*

------
https://chatgpt.com/codex/tasks/task_b_6888db88802c832bb5b8a2a9d7873622