### PR TITLE
Improve task sorting

### DIFF
--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -27,8 +27,25 @@ import SelectDataShow from "../../components/ui/SelectDataShow";
 import TableSkeleton from "../../components/ui/TableSkeleton";
 import { AnimatePresence, motion } from "framer-motion";
 import Spinner from "../../components/Spinner";
+import { STATUS } from "../../utils/status";
 
 const EXCLUDED_TB_NAMES = ["Ayu Pinta Gabina Siregar", "Elly Astutik"];
+
+function sortPenugasan(list, teamId) {
+  const dateVal = (p) =>
+    p.tahun * 10000 + parseInt(p.bulan, 10) * 100 + p.minggu;
+  return [...list].sort((a, b) => {
+    if (a.status === STATUS.BELUM && b.status !== STATUS.BELUM) return -1;
+    if (b.status === STATUS.BELUM && a.status !== STATUS.BELUM) return 1;
+    const diff = dateVal(b) - dateVal(a);
+    if (diff !== 0) return diff;
+    const aOwn = teamId && a.kegiatan?.teamId === teamId;
+    const bOwn = teamId && b.kegiatan?.teamId === teamId;
+    if (aOwn && !bOwn) return -1;
+    if (bOwn && !aOwn) return 1;
+    return 0;
+  });
+}
 
 const getCurrentWeek = () => {
   const today = new Date();
@@ -159,7 +176,7 @@ export default function PenugasanPage() {
       } else {
         kRes = { data: { data: [] } };
       }
-      setPenugasan(pRes.data);
+      setPenugasan(sortPenugasan(pRes.data, user?.teamId));
       setTeams(
         tRes.data.filter(
           (t) => t.namaTim !== "Admin" && t.namaTim !== "Pimpinan"

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -21,6 +21,20 @@ import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
 import formatDate from "../../utils/formatDate";
 
+function sortTambahan(list, teamId) {
+  return [...list].sort((a, b) => {
+    if (a.status === STATUS.BELUM && b.status !== STATUS.BELUM) return -1;
+    if (b.status === STATUS.BELUM && a.status !== STATUS.BELUM) return 1;
+    const dateDiff = new Date(b.tanggal) - new Date(a.tanggal);
+    if (dateDiff !== 0) return dateDiff;
+    const aOwn = teamId && a.teamId === teamId;
+    const bOwn = teamId && b.teamId === teamId;
+    if (aOwn && !bOwn) return -1;
+    if (bOwn && !aOwn) return 1;
+    return 0;
+  });
+}
+
 export default function TugasTambahanPage() {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -76,7 +90,7 @@ export default function TugasTambahanPage() {
           ? axios.get("/users")
           : Promise.resolve({ data: [] }),
       ]);
-      setItems(tRes.data);
+      setItems(sortTambahan(tRes.data, user?.teamId));
       setKegiatan(kRes.data.data || kRes.data);
       setTeams(
         teamRes.data.filter(


### PR DESCRIPTION
## Summary
- prioritize unfinished items in weekly and additional task lists
- sort by date and user's team

## Testing
- `npm test` in `api`
- `npm test` in `web`
- `npm run lint` *(fails: motion unused, empty blocks, unused vars)*

------
https://chatgpt.com/codex/tasks/task_b_6888df880170832ba485d1e76bf186aa