### PR TITLE
Implement dynamic export filenames

### DIFF
--- a/api/src/laporan/laporan.controller.ts
+++ b/api/src/laporan/laporan.controller.ts
@@ -21,6 +21,7 @@ import { ROLES } from "../common/roles.constants";
 import { SubmitLaporanDto } from "./dto/submit-laporan.dto";
 import { UpdateLaporanDto } from "./dto/update-laporan.dto";
 import { AuthRequestUser } from "../common/auth-request-user.interface";
+import exportFileName from "../utils/exportFileName";
 
 @Controller("laporan-harian")
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -77,9 +78,14 @@ export class LaporanController {
     const userId = (req.user as AuthRequestUser).userId;
     const week = minggu ? parseInt(minggu, 10) : undefined;
     const buf = await this.laporanService.export(userId, format, bulan, week);
+    const monthIdx = bulan ? parseInt(bulan, 10) : undefined;
+    const fileName = exportFileName("LaporanHarian", monthIdx);
     if (format === "pdf") {
       res.setHeader("Content-Type", "application/pdf");
-      res.setHeader("Content-Disposition", "attachment; filename=laporan.pdf");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename=${fileName}.pdf`,
+      );
     } else {
       res.setHeader(
         "Content-Type",
@@ -87,7 +93,7 @@ export class LaporanController {
       );
       res.setHeader(
         "Content-Disposition",
-        "attachment; filename=laporan.xlsx",
+        `attachment; filename=${fileName}.xlsx`,
       );
     }
     res.send(buf);

--- a/api/src/utils/exportFileName.ts
+++ b/api/src/utils/exportFileName.ts
@@ -1,0 +1,18 @@
+import months from './months';
+
+export function exportFileName(title: string, monthIndex?: number): string {
+  const now = new Date();
+  const dd = String(now.getDate()).padStart(2, '0');
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const yyyy = now.getFullYear();
+  const hh = String(now.getHours()).padStart(2, '0');
+  const min = String(now.getMinutes()).padStart(2, '0');
+  const idx =
+    typeof monthIndex === 'number' && monthIndex >= 1 && monthIndex <= 12
+      ? monthIndex - 1
+      : now.getMonth();
+  const monthName = months[idx];
+  return `${dd}${mm}${yyyy}_${hh}${min}_${title}_${monthName}`;
+}
+
+export default exportFileName;

--- a/api/src/utils/months.ts
+++ b/api/src/utils/months.ts
@@ -1,0 +1,16 @@
+export const months = [
+  'Januari',
+  'Februari',
+  'Maret',
+  'April',
+  'Mei',
+  'Juni',
+  'Juli',
+  'Agustus',
+  'September',
+  'Oktober',
+  'November',
+  'Desember',
+];
+
+export default months;

--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -17,6 +17,7 @@ import MonthYearPicker from "../../components/ui/MonthYearPicker";
 import TableSkeleton from "../../components/ui/TableSkeleton";
 import { useAuth } from "../auth/useAuth";
 import { ROLES } from "../../utils/roles";
+import exportFileName from "../../utils/exportFileName";
 
 export default function LaporanHarianPage() {
   const { user } = useAuth();
@@ -105,7 +106,9 @@ export default function LaporanHarianPage() {
       const url = window.URL.createObjectURL(new Blob([res.data]));
       const link = document.createElement("a");
       link.href = url;
-      link.setAttribute("download", "laporan.xlsx");
+      const idx = bulan ? parseInt(bulan, 10) : undefined;
+      const name = `${exportFileName("LaporanHarian", idx)}.xlsx`;
+      link.setAttribute("download", name);
       document.body.appendChild(link);
       link.click();
       link.remove();

--- a/web/src/pages/monitoring/MissedReportsPage.jsx
+++ b/web/src/pages/monitoring/MissedReportsPage.jsx
@@ -6,6 +6,7 @@ import * as XLSX from "xlsx";
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
 import formatDate from "../../utils/formatDate";
+import exportFileName from "../../utils/exportFileName";
 
 const formatWita = (iso) =>
   new Date(iso).toLocaleString("id-ID", { timeZone: "Asia/Makassar" });
@@ -99,8 +100,8 @@ export default function MissedReportsPage() {
 
         currentY = doc.lastAutoTable.finalY + 10;
       });
-
-      doc.save("status_pelaporan_harian.pdf");
+      const name = `${exportFileName("LaporanTerlambat")}.pdf`;
+      doc.save(name);
     };
   };
 
@@ -114,7 +115,8 @@ export default function MissedReportsPage() {
     const ws = XLSX.utils.json_to_sheet(sheetData);
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, ws, "Status_Pelaporan");
-    XLSX.writeFile(wb, "status_pelaporan_harian.xlsx");
+    const name = `${exportFileName("LaporanTerlambat")}.xlsx`;
+    XLSX.writeFile(wb, name);
   };
 
   const renderList = (users) => (

--- a/web/src/utils/exportFileName.js
+++ b/web/src/utils/exportFileName.js
@@ -1,0 +1,16 @@
+import months from './months';
+
+export default function exportFileName(title, monthIndex) {
+  const now = new Date();
+  const dd = String(now.getDate()).padStart(2, '0');
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const yyyy = now.getFullYear();
+  const hh = String(now.getHours()).padStart(2, '0');
+  const min = String(now.getMinutes()).padStart(2, '0');
+  const idx =
+    typeof monthIndex === 'number' && monthIndex >= 1 && monthIndex <= 12
+      ? monthIndex - 1
+      : now.getMonth();
+  const monthName = months[idx];
+  return `${dd}${mm}${yyyy}_${hh}${min}_${title}_${monthName}`;
+}


### PR DESCRIPTION
## Summary
- add helper to generate export file names for server and web
- use formatted names in laporan export endpoint
- generate PDF/Excel with timestamped names in the UI

## Testing
- `npm test --prefix api` *(fails: jest not found)*
- `npm test --prefix web` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6888e8243260832b80ec9ea2422fc371