### PR TITLE
Add creator tracking for assignments

### DIFF
--- a/api/prisma/migrations/20250730000000_add_creator_field/migration.sql
+++ b/api/prisma/migrations/20250730000000_add_creator_field/migration.sql
@@ -1,0 +1,14 @@
+-- Add creatorId column to Penugasan
+ALTER TABLE `Penugasan`
+  ADD COLUMN `creatorId` INTEGER;
+
+-- Populate creatorId for existing rows
+UPDATE `Penugasan` SET `creatorId` = `pegawaiId` WHERE `creatorId` IS NULL;
+
+-- Make column required
+ALTER TABLE `Penugasan`
+  MODIFY `creatorId` INTEGER NOT NULL;
+
+-- Add foreign key constraint
+ALTER TABLE `Penugasan`
+  ADD CONSTRAINT `Penugasan_creatorId_fkey` FOREIGN KEY (`creatorId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -16,6 +16,7 @@ model User {
   role      String
   members   Member[]
   penugasan Penugasan[]        @relation("PenugasanUser")
+  createdPenugasan Penugasan[] @relation("PenugasanCreator")
   laporan   LaporanHarian[]
   tambahan  KegiatanTambahan[]
   notifications Notification[]
@@ -54,6 +55,7 @@ model Penugasan {
   id         Int             @id @default(autoincrement())
   kegiatanId Int
   pegawaiId  Int
+  creatorId  Int
   minggu     Int
   bulan      String
   tahun      Int
@@ -61,6 +63,7 @@ model Penugasan {
   status     String          @default("Belum")
   kegiatan   MasterKegiatan  @relation(fields: [kegiatanId], references: [id])
   pegawai    User            @relation(name: "PenugasanUser", fields: [pegawaiId], references: [id])
+  creator    User            @relation(name: "PenugasanCreator", fields: [creatorId], references: [id])
   laporan    LaporanHarian[]
 }
 

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -434,6 +434,10 @@ async function main() {
   ];
 
   const members = await prisma.member.findMany({ include: { user: true } });
+  const leaderByTeam = new Map<number, number>();
+  for (const m of members) {
+    if (m.isLeader) leaderByTeam.set(m.teamId, m.userId);
+  }
 
   // seed tugas tambahan linked to master kegiatan
   const tambahanRows: any[] = [];
@@ -493,6 +497,7 @@ async function main() {
           penugasanRows.push({
             kegiatanId: k.id,
             pegawaiId: m.userId,
+            creatorId: leaderByTeam.get(m.teamId) || m.userId,
             minggu: w,
             bulan: info.bulan,
             tahun: info.year,

--- a/api/src/kegiatan/penugasan.controller.ts
+++ b/api/src/kegiatan/penugasan.controller.ts
@@ -43,13 +43,15 @@ export class PenugasanController {
     @Query("bulan") bulan?: string,
     @Query("tahun") tahun?: string,
     @Query("minggu") minggu?: string,
+    @Query("creator") creator?: string,
   ) {
     const u = req.user as AuthRequestUser;
     const filter: any = {};
     if (bulan) filter.bulan = bulan;
     if (tahun) filter.tahun = parseInt(tahun, 10);
     if (minggu) filter.minggu = parseInt(minggu, 10);
-    return this.penugasanService.findAll(u.role, u.userId, filter);
+    const creatorId = creator ? parseInt(creator, 10) : undefined;
+    return this.penugasanService.findAll(u.role, u.userId, filter, creatorId);
   }
 
   @Get(":id")

--- a/api/src/kegiatan/penugasan.service.ts
+++ b/api/src/kegiatan/penugasan.service.ts
@@ -22,7 +22,8 @@ export class PenugasanService {
   findAll(
     role: string,
     userId: number,
-    filter: { bulan?: string; tahun?: number; minggu?: number }
+    filter: { bulan?: string; tahun?: number; minggu?: number },
+    creatorId?: number,
   ) {
     role = normalizeRole(role);
     const opts: any = {
@@ -36,6 +37,7 @@ export class PenugasanService {
     if (filter.bulan) opts.where.bulan = filter.bulan;
     if (filter.tahun) opts.where.tahun = filter.tahun;
     if (filter.minggu) opts.where.minggu = filter.minggu;
+    if (creatorId) opts.where.creatorId = creatorId;
 
     if (role === ROLES.ADMIN || role === ROLES.PIMPINAN) {
       // admins and top management can see all assignments
@@ -80,6 +82,7 @@ export class PenugasanService {
       data: {
         kegiatanId: data.kegiatanId,
         pegawaiId: data.pegawaiId,
+        creatorId: userId,
         minggu: data.minggu,
         bulan: String(data.bulan),
         tahun: data.tahun,
@@ -116,6 +119,7 @@ export class PenugasanService {
     const rows = data.pegawaiIds.map((pid: number) => ({
       kegiatanId: data.kegiatanId,
       pegawaiId: pid,
+      creatorId: userId,
       minggu: data.minggu,
       bulan: String(data.bulan),
       tahun: data.tahun,

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -133,6 +133,7 @@ export default function PenugasanPage() {
       if (filterBulan) params.bulan = filterBulan;
       if (filterTahun) params.tahun = filterTahun;
       if (filterMinggu) params.minggu = filterMinggu;
+      if (viewTab === "dariSaya") params.creator = user?.id;
       const penugasanReq = axios.get("/penugasan", { params });
       const teamsReq = axios.get("/teams").then(async (res) => {
         if (Array.isArray(res.data) && res.data.length === 0)
@@ -175,7 +176,7 @@ export default function PenugasanPage() {
     } finally {
       setLoading(false);
     }
-  }, [user, filterBulan, filterTahun, filterMinggu, canManage]);
+  }, [user, filterBulan, filterTahun, filterMinggu, canManage, viewTab]);
 
   useEffect(() => {
     fetchData();
@@ -214,8 +215,8 @@ export default function PenugasanPage() {
         ? p.kegiatan?.teamId === parseInt(filterTeam, 10)
         : true;
       if (viewTab === "mine") return matchesSearch && p.pegawaiId === user?.id;
-      if (viewTab === "anggota")
-        return matchesSearch && matchTeam && p.pegawaiId !== user?.id;
+      if (viewTab === "dariSaya")
+        return matchesSearch && matchTeam;
       return matchesSearch && matchTeam;
     });
   }, [penugasan, search, viewTab, user?.id, filterTeam]);
@@ -285,7 +286,7 @@ export default function PenugasanPage() {
         >
           {[
             { id: "mine", label: "Tugas Saya" },
-            ...(canManage ? [{ id: "anggota", label: "Dari Saya" }] : []),
+            ...(canManage ? [{ id: "dariSaya", label: "Dari Saya" }] : []),
             { id: "all", label: "Semua" },
           ].map((t) => (
             <button


### PR DESCRIPTION
## Summary
- track which user created a Penugasan
- allow filtering by assignment creator
- update frontend to request creator filtered data
- rename "anggota" tab to "dariSaya"
- add migration for creatorId

## Testing
- `npm test` in `api`
- `npm test` in `web`
- `npx prisma migrate dev --name add-creator-field` *(fails: 403 Forbidden)*
- `npm run seed` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6888dd34d6b8832b8a87814dd4f2d658