### PR TITLE
Fix modal auto-focus loop

### DIFF
--- a/web/src/components/ui/Modal.jsx
+++ b/web/src/components/ui/Modal.jsx
@@ -6,14 +6,20 @@ export default function Modal({
   widthClass = "w-full max-w-md",
   titleId,
   descriptionId,
+  initialFocusRef,
 }) {
   const containerRef = useRef(null);
+  const onCloseRef = useRef(onClose);
   const [visible, setVisible] = useState(false);
   const [closing, setClosing] = useState(false);
 
   useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
     function handleKey(e) {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
       if (e.key === "Tab") {
         const focusable = containerRef.current?.querySelectorAll(
           "a[href], button, textarea, input, select, [tabindex]:not([tabindex='-1'])"
@@ -34,15 +40,19 @@ export default function Modal({
     const firstInput = containerRef.current?.querySelector(
       "a[href], button, textarea, input, select, [tabindex]:not([tabindex='-1'])"
     );
-    firstInput?.focus();
+    if (initialFocusRef?.current) {
+      initialFocusRef.current.focus();
+    } else {
+      firstInput?.focus();
+    }
     setTimeout(() => setVisible(true), 10);
     return () => document.removeEventListener("keydown", handleKey);
-  }, [onClose]);
+  }, []);
 
   function handleClose() {
     setClosing(true);
     setVisible(false);
-    setTimeout(onClose, 300);
+    setTimeout(() => onCloseRef.current(), 300);
   }
 
   return (

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -95,8 +95,8 @@ export default function PenugasanPage() {
   const [viewTab, setViewTab] = useState("mine");
   const [formTouched, setFormTouched] = useState(false); // for validation
 
-  // --- Refs for autofocus
-  const firstInputRef = useRef();
+  // --- Ref for initial focus
+  const descriptionRef = useRef();
 
   // --- Fetch Logic
   useEffect(() => {
@@ -450,7 +450,7 @@ export default function PenugasanPage() {
           <Modal
             onClose={closeForm}
             titleId="penugasan-form-title"
-            initialFocusRef={firstInputRef}
+            initialFocusRef={descriptionRef}
           >
             <motion.div
               initial={{ opacity: 0, scale: 0.98 }}
@@ -510,8 +510,6 @@ export default function PenugasanPage() {
                     placeholder="Pilih kegiatan..."
                     isSearchable
                     noOptionsMessage={() => "Tidak ditemukan."}
-                    ref={firstInputRef}
-                    autoFocus
                   />
                   {formTouched && !form.kegiatanId && (
                     <span className="text-xs text-red-500">
@@ -588,6 +586,7 @@ export default function PenugasanPage() {
                   <Label htmlFor="deskripsi">Deskripsi Penugasan</Label>
                   <textarea
                     id="deskripsi"
+                    ref={descriptionRef}
                     value={form.deskripsi}
                     onChange={(e) =>
                       setForm({ ...form, deskripsi: e.target.value })


### PR DESCRIPTION
## Summary
- ensure Modal uses stable onClose handler and supports `initialFocusRef`
- remove autoFocus from `PenugasanPage` select and use description textarea for initial focus

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6889711c4ca8832b960c40616ce98cf9