### PR TITLE
Allow selecting any team on additional task form

### DIFF
--- a/api/src/teams/teams.controller.ts
+++ b/api/src/teams/teams.controller.ts
@@ -32,6 +32,11 @@ export class TeamsController {
     return this.teamsService.findByLeader(user.userId);
   }
 
+  @Get("all")
+  findAllPublic() {
+    return this.teamsService.findAllPublic();
+  }
+
   @Get("member")
   findMemberTeams(@Req() req: Request) {
     const user = req.user as AuthRequestUser;

--- a/api/src/teams/teams.service.ts
+++ b/api/src/teams/teams.service.ts
@@ -10,6 +10,13 @@ export class TeamsService {
     });
   }
 
+  findAllPublic() {
+    return this.prisma.team.findMany({
+      where: { namaTim: { notIn: ["Admin", "Pimpinan"] } },
+      include: { members: { include: { user: true } } },
+    });
+  }
+
   findByLeader(userId: number) {
     return this.prisma.team.findMany({
       where: { members: { some: { userId, isLeader: true } } },

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -80,12 +80,7 @@ export default function TugasTambahanPage() {
         user?.role === ROLES.ADMIN || user?.role === ROLES.KETUA
           ? axios.get("/master-kegiatan?limit=1000")
           : Promise.resolve({ data: [] }),
-        axios.get("/teams").then(async (res) => {
-          if (Array.isArray(res.data) && res.data.length === 0) {
-            return axios.get("/teams/member");
-          }
-          return res;
-        }),
+        axios.get("/teams/all"),
         user?.role === ROLES.ADMIN
           ? axios.get("/users")
           : Promise.resolve({ data: [] }),


### PR DESCRIPTION
## Summary
- expose new endpoint `/teams/all` to fetch all non-admin teams
- fetch full team list in additional task form

## Testing
- `npm test` within `api`
- `npm run lint` within `api` *(fails: Parsing error and unused vars)*
- `npm test` within `web`
- `npm run lint` within `web` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_688973f332b8832bb120c029c8eb1bc4