### PR TITLE
Add debug log when saving reports

### DIFF
--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -159,6 +159,7 @@ export default function PenugasanDetailPage() {
         fetchDetail();
       }, 200);
     } catch (err) {
+      console.error("Failed to save report", err?.response?.data || err);
       handleAxiosError(err, "Gagal menyimpan laporan");
     }
   };


### PR DESCRIPTION
## Summary
- log API error response when saving a report

## Testing
- `npm test --silent` in `api`
- `npm test --silent` in `web`


------
https://chatgpt.com/codex/tasks/task_b_688978a6f300832b99c6b7f2cd8b3a51