### PR TITLE
Handle optional buktiLink

### DIFF
--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -138,17 +138,21 @@ export default function PenugasanDetailPage() {
       }
       if (
         laporanForm.status === STATUS.SELESAI_DIKERJAKAN &&
-        !laporanForm.buktiLink.trim()
+        !(typeof laporanForm.buktiLink === "string" ? laporanForm.buktiLink : "").trim()
       ) {
         showWarning("Lengkapi data", "Link bukti wajib diisi");
         return;
       }
 
+      const payload = { ...laporanForm };
+      if (payload.buktiLink === "") delete payload.buktiLink;
+      if (payload.catatan === "") delete payload.catatan;
+
       if (laporanForm.id) {
-        await axios.put(`/laporan-harian/${laporanForm.id}`, laporanForm);
+        await axios.put(`/laporan-harian/${laporanForm.id}`, payload);
       } else {
         await axios.post("/laporan-harian", {
-          ...laporanForm,
+          ...payload,
           penugasanId: parseInt(id, 10),
           pegawaiId: item.pegawaiId,
         });


### PR DESCRIPTION
## Summary
- ensure `laporanForm.buktiLink` is a string
- remove empty `buktiLink` and `catatan` from request payload

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6889808a5f30832baf8874316244c78b