### PR TITLE
Add capaian kegiatan field

### DIFF
--- a/api/prisma/migrations/20250731000000_add_capaian_kegiatan/migration.sql
+++ b/api/prisma/migrations/20250731000000_add_capaian_kegiatan/migration.sql
@@ -1,0 +1,6 @@
+-- Add capaianKegiatan columns
+ALTER TABLE `LaporanHarian`
+  ADD COLUMN `capaianKegiatan` VARCHAR(191) NOT NULL DEFAULT '';
+
+ALTER TABLE `KegiatanTambahan`
+  ADD COLUMN `capaianKegiatan` VARCHAR(191) NOT NULL DEFAULT '';

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -72,6 +72,7 @@ model LaporanHarian {
   penugasanId Int
   tanggal     DateTime
   status      String
+  capaianKegiatan String @default("")
   deskripsi   String?
   buktiLink   String?
   catatan     String?
@@ -85,6 +86,7 @@ model KegiatanTambahan {
   nama                String
   tanggal             DateTime
   status              String
+  capaianKegiatan     String @default("")
   buktiLink           String?
   deskripsi           String?
   tanggalSelesai      DateTime?

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -467,6 +467,7 @@ async function main() {
         kegiatanId: k.id,
         teamId: m.teamId,
         deskripsi: `Tugas tambahan ${k.namaKegiatan}`,
+        capaianKegiatan: `Capaian ${k.namaKegiatan}`,
       });
     }
   }
@@ -555,6 +556,7 @@ async function main() {
                 pegawaiId: m.userId,
                 tanggal: date.toISOString(),
                 status: STATUS.SELESAI_DIKERJAKAN,
+                capaianKegiatan: `Capaian ${p.id}`,
               });
               selesaiIds.add(p.id);
             }
@@ -625,6 +627,7 @@ async function main() {
           pegawaiId: m.userId,
           tanggal: tanggal.toISOString(),
           status: STATUS.SELESAI_DIKERJAKAN,
+          capaianKegiatan: `Capaian ${penugasan.id}`,
         },
       });
     }

--- a/api/src/laporan/dto/add-tambahan.dto.ts
+++ b/api/src/laporan/dto/add-tambahan.dto.ts
@@ -21,6 +21,9 @@ export class AddTambahanDto {
   @IsString()
   deskripsi?: string;
 
+  @IsString()
+  capaianKegiatan!: string;
+
   @IsOptional()
   @Transform(({ value }) => (value === "" ? undefined : value))
   @IsDateString()

--- a/api/src/laporan/dto/submit-laporan.dto.ts
+++ b/api/src/laporan/dto/submit-laporan.dto.ts
@@ -13,6 +13,9 @@ export class SubmitLaporanDto {
   @IsString()
   deskripsi!: string;
 
+  @IsString()
+  capaianKegiatan!: string;
+
   @IsOptional()
   @IsString()
   buktiLink?: string;

--- a/api/src/laporan/dto/update-laporan.dto.ts
+++ b/api/src/laporan/dto/update-laporan.dto.ts
@@ -12,6 +12,10 @@ export class UpdateLaporanDto {
 
   @IsOptional()
   @IsString()
+  capaianKegiatan?: string;
+
+  @IsOptional()
+  @IsString()
   buktiLink?: string;
 
   @IsOptional()

--- a/api/src/laporan/dto/update-tambahan.dto.ts
+++ b/api/src/laporan/dto/update-tambahan.dto.ts
@@ -28,6 +28,11 @@ export class UpdateTambahanDto {
 
   @IsOptional()
   @Transform(({ value }) => (value === "" ? undefined : value))
+  @IsString()
+  capaianKegiatan?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === "" ? undefined : value))
   @IsDateString()
   tanggalSelesai?: string;
 

--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -111,6 +111,7 @@ export class LaporanService {
         pegawaiId: targetId,
         tanggal: new Date(data.tanggal),
         status: data.status,
+        capaianKegiatan: data.capaianKegiatan,
         deskripsi: data.deskripsi,
         buktiLink: data.buktiLink || undefined,
         catatan: data.catatan || undefined,
@@ -191,6 +192,7 @@ export class LaporanService {
       data: {
         tanggal: new Date(data.tanggal),
         status: data.status,
+        capaianKegiatan: data.capaianKegiatan,
         deskripsi: data.deskripsi,
         buktiLink: data.buktiLink,
         catatan: data.catatan,
@@ -279,6 +281,7 @@ export class LaporanService {
       tanggal: t.tanggal,
       status: t.status,
       deskripsi: t.deskripsi,
+      capaianKegiatan: t.capaianKegiatan,
       buktiLink: t.buktiLink,
       catatan: null,
       type: "tambahan",

--- a/api/src/laporan/tugas-tambahan.service.ts
+++ b/api/src/laporan/tugas-tambahan.service.ts
@@ -18,6 +18,7 @@ export class TambahanService {
         nama: master.namaKegiatan,
         tanggal: new Date(data.tanggal),
         status: data.status,
+        capaianKegiatan: data.capaianKegiatan,
         buktiLink: data.buktiLink,
         deskripsi: data.deskripsi,
         tanggalSelesai: data.tanggalSelesai ? new Date(data.tanggalSelesai) : undefined,

--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -54,6 +54,7 @@ export default function PenugasanDetailPage() {
     id: null,
     tanggal: new Date().toISOString().slice(0, 10),
     deskripsi: "",
+    capaianKegiatan: "",
     status: STATUS.BELUM, // Belum, Sedang Dikerjakan, Selesai Dikerjakan
     catatan: "",
     buktiLink: "",
@@ -123,6 +124,7 @@ export default function PenugasanDetailPage() {
       id: null,
       tanggal: new Date().toISOString().slice(0, 10),
       deskripsi: "",
+      capaianKegiatan: "",
       status: STATUS.BELUM,
       catatan: "",
       buktiLink: "",
@@ -134,6 +136,10 @@ export default function PenugasanDetailPage() {
     try {
       if (laporanForm.deskripsi.trim() === "") {
         showWarning("Lengkapi data", "Deskripsi wajib diisi");
+        return;
+      }
+      if (laporanForm.capaianKegiatan.trim() === "") {
+        showWarning("Lengkapi data", "Capaian Kegiatan wajib diisi");
         return;
       }
       if (
@@ -178,6 +184,7 @@ export default function PenugasanDetailPage() {
       id: item.id,
       tanggal: item.tanggal.slice(0, 10),
       deskripsi: item.deskripsi || "",
+      capaianKegiatan: item.capaianKegiatan || "",
       status: item.status,
       catatan: item.catatan || "",
       buktiLink: item.buktiLink || "",
@@ -573,6 +580,22 @@ export default function PenugasanDetailPage() {
                   placeholder="Tuliskan deskripsi kegiatan..."
                   required
                   className="w-full mt-1 rounded-md border px-4 py-2 bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+
+              <div>
+                <Label htmlFor="capaianKegiatan">Capaian Kegiatan <span className="text-red-500">*</span></Label>
+                <textarea
+                  id="capaianKegiatan"
+                  value={laporanForm.capaianKegiatan}
+                  onChange={(e) =>
+                    setLaporanForm({
+                      ...laporanForm,
+                      capaianKegiatan: e.target.value,
+                    })
+                  }
+                  className="form-input resize-y w-full min-h-[48px] border rounded px-3 py-2 bg-white dark:bg-gray-700 dark:text-white"
+                  required
                 />
               </div>
 

--- a/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
@@ -6,6 +6,7 @@ import {
   confirmDelete,
   confirmCancel,
   handleAxiosError,
+  showWarning,
 } from "../../utils/alerts";
 import { Pencil, Trash2 } from "lucide-react";
 import Select from "react-select";
@@ -40,6 +41,7 @@ export default function TugasTambahanDetailPage() {
     tanggal: "",
     status: STATUS.BELUM,
     deskripsi: "",
+    capaianKegiatan: "",
   });
 
   const fetchDetail = useCallback(async () => {
@@ -57,6 +59,7 @@ export default function TugasTambahanDetailPage() {
         tanggal: dRes.data.tanggal.slice(0, 10),
         status: dRes.data.status,
         deskripsi: dRes.data.deskripsi || "",
+        capaianKegiatan: dRes.data.capaianKegiatan || "",
       });
     } catch (err) {
       handleAxiosError(err, "Gagal mengambil data");
@@ -69,6 +72,10 @@ export default function TugasTambahanDetailPage() {
 
   const save = async () => {
     try {
+      if (form.capaianKegiatan.trim() === "") {
+        showWarning("Lengkapi data", "Capaian Kegiatan wajib diisi");
+        return;
+      }
       const payload = { ...form };
       Object.keys(payload).forEach((k) => {
         if (payload[k] === "") delete payload[k];
@@ -236,6 +243,17 @@ export default function TugasTambahanDetailPage() {
               value={form.deskripsi}
               onChange={(e) => setForm({ ...form, deskripsi: e.target.value })}
               className="form-input"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="capaianKegiatan" className="block text-sm mb-1">Capaian Kegiatan <span className="text-red-500">*</span></label>
+            <textarea
+              id="capaianKegiatan"
+              value={form.capaianKegiatan}
+              onChange={(e) => setForm({ ...form, capaianKegiatan: e.target.value })}
+              className="form-input resize-y w-full min-h-[48px] border rounded px-3 py-2 bg-white dark:bg-gray-700 dark:text-white"
+              required
             />
           </div>
           <div>

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo } from "react";
 import axios from "axios";
-import { showSuccess, handleAxiosError } from "../../utils/alerts";
+import { showSuccess, handleAxiosError, showWarning } from "../../utils/alerts";
 import { Plus, Eye, Check, X } from "lucide-react";
 import DataTable from "../../components/ui/DataTable";
 import { useNavigate } from "react-router-dom";
@@ -47,6 +47,7 @@ export default function TugasTambahanPage() {
     tanggal: new Date().toISOString().slice(0, 10),
     status: STATUS.BELUM,
     deskripsi: "",
+    capaianKegiatan: "",
   });
   const [search, setSearch] = useState("");
   const [filterBulan, setFilterBulan] = useState("");
@@ -143,6 +144,7 @@ export default function TugasTambahanPage() {
       tanggal: new Date().toISOString().slice(0, 10),
       status: STATUS.BELUM,
       deskripsi: "",
+      capaianKegiatan: "",
     });
     setKegiatan([]);
     setShowForm(true);
@@ -150,6 +152,10 @@ export default function TugasTambahanPage() {
 
   const save = async () => {
     if (!form.teamId || !form.kegiatanId || !form.tanggal) return;
+    if (form.capaianKegiatan.trim() === "") {
+      showWarning("Lengkapi data", "Capaian Kegiatan wajib diisi");
+      return;
+    }
     try {
       const payload = { ...form };
       delete payload.teamId;
@@ -485,10 +491,25 @@ export default function TugasTambahanPage() {
                 onChange={(e) =>
                   setForm({ ...form, deskripsi: e.target.value })
                 }
-                className="w-full border rounded-lg px-3 py-2 bg-white text-gray-900 
-            dark:bg-gray-700 dark:text-gray-100 
-            focus:outline-none focus:ring-2 focus:ring-blue-500 
+                className="w-full border rounded-lg px-3 py-2 bg-white text-gray-900
+            dark:bg-gray-700 dark:text-gray-100
+            focus:outline-none focus:ring-2 focus:ring-blue-500
             shadow-sm transition duration-150 ease-in-out resize-none"
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="capaianKegiatan" className="dark:text-gray-100">
+                Capaian Kegiatan <span className="text-red-500">*</span>
+              </Label>
+              <textarea
+                id="capaianKegiatan"
+                value={form.capaianKegiatan}
+                onChange={(e) =>
+                  setForm({ ...form, capaianKegiatan: e.target.value })
+                }
+                className="form-input resize-y w-full min-h-[48px] border rounded px-3 py-2 bg-white dark:bg-gray-700 dark:text-white"
+                required
               />
             </div>
 


### PR DESCRIPTION
## Summary
- add `capaianKegiatan` columns via new prisma migration
- handle `capaianKegiatan` in laporan and tugas tambahan services
- require `capaianKegiatan` in related DTOs
- show new textarea on laporan form and tugas tambahan forms

## Testing
- `npm --prefix api test` *(fails: Cannot find module 'jest-util')*
- `npm --prefix api run lint`
- `npm --prefix web test`
- `npm --prefix web run lint`

------
https://chatgpt.com/codex/tasks/task_b_6889818a0bd4832bbb7cf75584f651da