### PR TITLE
Ensure laporan payload sends empty strings

### DIFF
--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -154,9 +154,11 @@ export default function PenugasanDetailPage() {
         return;
       }
 
-      const payload = { ...laporanForm };
-      if (payload.buktiLink === "") delete payload.buktiLink;
-      if (payload.catatan === "") delete payload.catatan;
+      const payload = {
+        ...laporanForm,
+        buktiLink: laporanForm.buktiLink || "",
+        catatan: laporanForm.catatan || "",
+      };
 
       if (laporanForm.id) {
         await axios.put(`/laporan-harian/${laporanForm.id}`, payload);


### PR DESCRIPTION
## Summary
- update laporan saving logic so optional `buktiLink` and `catatan` are always sent

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68898dd9f0e0832b9abf1f1ea6449196