### PR TITLE
Skip notifications for pimpinan users

### DIFF
--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -38,6 +38,7 @@ export default function Layout() {
   const notifRef = useRef();
 
   const fetchNotifications = useCallback(async () => {
+    if (!user || user.role === ROLES.PIMPINAN) return;
     try {
       const res = await axios.get("/notifications");
       const data = res.data || [];
@@ -46,7 +47,7 @@ export default function Layout() {
     } catch (err) {
       console.error("Failed to fetch notifications", err);
     }
-  }, []);
+  }, [user]);
 
   useEffect(() => {
     fetchNotifications();


### PR DESCRIPTION
## Summary
- prevent calls to `/notifications` for roles that don't have notifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68898fab77c0832bb01cfb256a19de12