### PR TITLE
Log server errors in saveLaporan

### DIFF
--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -181,6 +181,9 @@ export default function PenugasanDetailPage() {
       }, 200);
     } catch (err) {
       console.error("Failed to save report", err?.response?.data || err);
+      if (err?.response?.status >= 500) {
+        console.error(err.response);
+      }
       handleAxiosError(err, "Gagal menyimpan laporan");
     } finally {
       setSaving(false);


### PR DESCRIPTION
## Summary
- log `err.response` when saving laporan if server responds with 5xx

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68899318bd38832bb64ba5faa51f538c