### PR TITLE
Add tests for optional laporan fields and sync failure

### DIFF
--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -118,7 +118,12 @@ export class LaporanService {
       },
     });
 
-    await this.syncPenugasanStatus(data.penugasanId);
+    try {
+      await this.syncPenugasanStatus(data.penugasanId);
+    } catch (err) {
+      // Ignore sync errors so laporan is still returned
+      console.error("Failed to sync penugasan status", err);
+    }
 
     return laporan;
   }


### PR DESCRIPTION
## Summary
- catch errors from `syncPenugasanStatus` so submission still succeeds
- test that missing optional fields are sent as `undefined`
- test that submission ignores `syncPenugasanStatus` errors

## Testing
- `npm test --prefix api`

------
https://chatgpt.com/codex/tasks/task_b_688993193830832ba80fd046d8b2634c