### PR TITLE
Enable Anggota to manage own tasks

### DIFF
--- a/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
@@ -25,8 +25,10 @@ export default function TugasTambahanDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { user } = useAuth();
-  const canManage = [ROLES.ADMIN, ROLES.KETUA].includes(user?.role);
   const [item, setItem] = useState(null);
+  const canManage =
+    [ROLES.ADMIN, ROLES.KETUA].includes(user?.role) ||
+    user?.id === item?.userId;
   const [editing, setEditing] = useState(false);
   const [kegiatan, setKegiatan] = useState([]);
   const [showUpload, setShowUpload] = useState(false);


### PR DESCRIPTION
## Summary
- compute `canManage` to allow admins, ketua, and task owners to edit/delete

## Testing
- `cd api && npm test`
- `cd web && npm test`


------
https://chatgpt.com/codex/tasks/task_b_6889e2158fd4832bb26c7e69e65878c5