### PR TITLE
Fix report permissions

### DIFF
--- a/web/src/pages/penugasan/PenugasanDetailPage.jsx
+++ b/web/src/pages/penugasan/PenugasanDetailPage.jsx
@@ -30,9 +30,11 @@ export default function PenugasanDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { user } = useAuth();
-  const canManage = [ROLES.ADMIN, ROLES.KETUA].includes(user?.role);
-  const canManageLaporan = user?.role !== ROLES.PIMPINAN;
   const [item, setItem] = useState(null);
+  const canManage = [ROLES.ADMIN, ROLES.KETUA].includes(user?.role);
+  const canManageLaporan =
+    [ROLES.ADMIN, ROLES.KETUA].includes(user?.role) ||
+    user?.id === item?.pegawaiId;
   const canAddReport =
     user?.role === ROLES.ADMIN ||
     user?.role === ROLES.KETUA ||


### PR DESCRIPTION
## Summary
- update `PenugasanDetailPage` to only show edit/delete buttons for admins, ketua, or the assigned user

## Testing
- `npm test` in `web`
- `npm run lint` in `web` *(fails: `Swal` not defined)*
- `npm test` in `api`
- `npm run lint` in `api`


------
https://chatgpt.com/codex/tasks/task_b_6889e216b4ec832b941bd9cb027e56da