### PR TITLE
Adjust filter bar alignment

### DIFF
--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -206,7 +206,7 @@ export default function LaporanHarianPage() {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-end gap-2">
+      <div>
         <SearchInput
           value={query}
           onChange={(e) => {
@@ -216,6 +216,8 @@ export default function LaporanHarianPage() {
           placeholder="Cari..."
           ariaLabel="Cari"
         />
+      </div>
+      <div className="flex justify-end items-center gap-2 mb-4">
         <MonthYearPicker
           month={bulan}
           onMonthChange={(val) => {


### PR DESCRIPTION
## Summary
- move search input to its own row
- right-align month picker, week selector, and export button

## Testing
- `npm test --silent` in `web`
- `npm test --silent` in `api`
- `npm run lint` *(fails: 'Swal' and 'require' not defined)*

------
https://chatgpt.com/codex/tasks/task_b_6889e23f9c04832b8ece5b516932c819