### PR TITLE
Revamp monitoring tables

### DIFF
--- a/web/src/pages/monitoring/DailyMatrix.jsx
+++ b/web/src/pages/monitoring/DailyMatrix.jsx
@@ -7,12 +7,13 @@ export const DailyMatrixRow = ({ user, boxClass, currentUser }) => {
   return (
     <tr
       className={`text-center transition-colors ${
-        isCurrentUser ? "bg-yellow-50 dark:bg-yellow-900" : "hover:bg-gray-50 dark:hover:bg-gray-700"
+        isCurrentUser
+          ? "bg-yellow-50 dark:bg-yellow-900 border-l-4 border-yellow-400"
+          : "hover:bg-gray-50 dark:hover:bg-gray-700"
       }`}
     >
       <td className="px-4 py-2 border text-left text-sm whitespace-nowrap font-medium">
         {user.nama}
-        {isCurrentUser && <span className="ml-1 text-xs">🟢 Kamu</span>}
       </td>
       {user.detail.map((day, i) => (
         <td
@@ -56,9 +57,9 @@ const DailyMatrix = ({ data = [] }) => {
   const dayCount = data[0].detail.length;
 
   return (
-    <div className="overflow-x-auto max-h-[60vh] overflow-y-auto">
-      <table className="min-w-full border text-sm rounded shadow">
-        <thead className="bg-gray-100 dark:bg-gray-800 sticky top-0 z-10">
+    <div className="overflow-x-auto max-h-[60vh] overflow-y-auto w-full">
+      <table className="min-w-[1000px] w-full table-fixed border text-sm rounded shadow">
+        <thead className="sticky top-0 bg-white dark:bg-gray-800 z-10 shadow-sm">
           <tr>
             <th className="px-4 py-2 border text-left">Nama</th>
             {Array.from({ length: dayCount }, (_, i) => (

--- a/web/src/pages/monitoring/WeeklyMatrix.jsx
+++ b/web/src/pages/monitoring/WeeklyMatrix.jsx
@@ -8,12 +8,13 @@ export const WeeklyMatrixRow = ({ user, progressColor, weekCount, currentUser })
   return (
     <tr
       className={`text-center transition-colors ${
-        isCurrentUser ? "bg-yellow-50 dark:bg-yellow-900" : "hover:bg-gray-50 dark:hover:bg-gray-700"
+        isCurrentUser
+          ? "bg-yellow-50 dark:bg-yellow-900 border-l-4 border-yellow-400"
+          : "hover:bg-gray-50 dark:hover:bg-gray-700"
       }`}
     >
       <td className="p-2 border text-left whitespace-nowrap text-sm font-medium">
         {user.nama}
-        {isCurrentUser && <span className="ml-1 text-xs">🟢 Kamu</span>}
       </td>
       {user.weeks.slice(0, weekCount).map((w, i) => (
         <td key={i} className="p-1 border space-y-1">
@@ -42,9 +43,9 @@ const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek, selectedWeek }) => 
   const progressColor = getProgressColor;
 
   return (
-    <div className="overflow-auto md:overflow-visible max-h-[60vh]">
-      <table className="min-w-full text-xs border-collapse">
-        <thead className="sticky top-0 bg-gray-100 dark:bg-gray-800 z-10">
+    <div className="overflow-x-auto md:overflow-visible max-h-[60vh] w-full">
+      <table className="min-w-[1000px] w-full table-fixed text-xs border-collapse">
+        <thead className="sticky top-0 bg-white dark:bg-gray-800 z-10 shadow-sm">
           <tr>
             <th className="p-2 border text-left">Nama</th>
             {weeks.map((_, i) => (

--- a/web/src/pages/monitoring/components/MonthlyMatrix.jsx
+++ b/web/src/pages/monitoring/components/MonthlyMatrix.jsx
@@ -9,9 +9,9 @@ const MonthlyMatrix = ({ data = [] }) => {
   const progressColor = getProgressColor;
 
   return (
-    <div className="overflow-auto md:overflow-visible mt-4 max-h-[60vh]">
-      <table className="min-w-full text-xs border-collapse">
-        <thead className="sticky top-0 bg-gray-100 dark:bg-gray-800 z-10">
+    <div className="overflow-x-auto md:overflow-visible mt-4 max-h-[60vh] w-full">
+      <table className="min-w-[1000px] w-full table-fixed text-xs border-collapse">
+        <thead className="sticky top-0 bg-white dark:bg-gray-800 z-10 shadow-sm">
           <tr>
             <th className="p-2 border text-left">Nama</th>
             {months.map((m, i) => (
@@ -27,15 +27,12 @@ const MonthlyMatrix = ({ data = [] }) => {
               key={u.userId}
               className={`text-center transition-colors ${
                 currentUser && (u.userId === currentUser.id || u.nama === currentUser.nama)
-                  ? "bg-yellow-50 dark:bg-yellow-900"
+                  ? "bg-yellow-50 dark:bg-yellow-900 border-l-4 border-yellow-400"
                   : "hover:bg-gray-50 dark:hover:bg-gray-700"
               }`}
             >
               <td className="p-2 border text-left whitespace-nowrap text-sm font-medium">
                 {u.nama}
-                {currentUser && (u.userId === currentUser.id || u.nama === currentUser.nama) && (
-                  <span className="ml-1 text-xs">🟢 Kamu</span>
-                )}
               </td>
               {u.months.map((m, i) => (
                 <td key={i} className="p-1 border space-y-1">

--- a/web/src/pages/monitoring/components/TabContent.jsx
+++ b/web/src/pages/monitoring/components/TabContent.jsx
@@ -22,11 +22,11 @@ export default function TabContent({
   const [weeklyMonthData, setWeeklyMonthData] = useState([]);
   const [weeklyData, setWeeklyData] = useState([]);
   const [monthlyData, setMonthlyData] = useState([]);
-  const [weeklyMode, setWeeklyMode] = useState("matrix");
+  const [weeklyMode, setWeeklyMode] = useState("summary");
 
   useEffect(() => {
     if (activeTab === "mingguan") {
-      setWeeklyMode("matrix");
+      setWeeklyMode("summary");
     }
   }, [activeTab]);
 

--- a/web/src/pages/monitoring/components/WeeklyProgressTable.jsx
+++ b/web/src/pages/monitoring/components/WeeklyProgressTable.jsx
@@ -8,9 +8,9 @@ const WeeklyProgressTable = ({ data = [] }) => {
   const progressColor = getProgressColor;
 
   return (
-    <div className="overflow-auto md:overflow-visible mt-4 max-h-[60vh]">
-      <table className="min-w-full text-xs border-collapse">
-        <thead className="sticky top-0 bg-gray-100 dark:bg-gray-800 z-10">
+    <div className="overflow-x-auto md:overflow-visible mt-4 max-h-[60vh] w-full">
+      <table className="min-w-[1000px] w-full table-fixed text-xs border-collapse">
+        <thead className="sticky top-0 bg-white dark:bg-gray-800 z-10 shadow-sm">
           <tr>
             <th className="p-2 border text-left">Nama</th>
             <th className="p-2 border text-center">Tugas Selesai</th>
@@ -24,15 +24,12 @@ const WeeklyProgressTable = ({ data = [] }) => {
               key={u.userId}
               className={`text-center transition-colors ${
                 currentUser && (u.userId === currentUser.id || u.nama === currentUser.nama)
-                  ? "bg-yellow-50 dark:bg-yellow-900"
+                  ? "bg-yellow-50 dark:bg-yellow-900 border-l-4 border-yellow-400"
                   : "hover:bg-gray-50 dark:hover:bg-gray-700"
               }`}
             >
               <td className="p-2 border text-left whitespace-nowrap text-sm font-medium">
                 {u.nama}
-                {currentUser && (u.userId === currentUser.id || u.nama === currentUser.nama) && (
-                  <span className="ml-1 text-xs">🟢 Kamu</span>
-                )}
               </td>
               <td className="p-1 border">{u.selesai}</td>
               <td className="p-1 border">{u.total}</td>


### PR DESCRIPTION
## Summary
- modernize monitoring tables with sticky headers and scroll containers
- highlight the logged-in user row without extra text
- open Weekly tab on *Ringkasan Minggu Ini*

## Testing
- `npm test` within `api`
- `npm test` within `web`


------
https://chatgpt.com/codex/tasks/task_b_6889e7104ba4832b9819b2953a43de74