### PR TITLE
Add vertical scrolling to matrix tables

### DIFF
--- a/web/src/pages/monitoring/WeeklyMatrix.jsx
+++ b/web/src/pages/monitoring/WeeklyMatrix.jsx
@@ -43,7 +43,7 @@ const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek, selectedWeek }) => 
   const progressColor = getProgressColor;
 
   return (
-    <div className="overflow-x-auto md:overflow-visible max-h-[60vh] w-full">
+    <div className="overflow-x-auto overflow-y-auto md:overflow-visible max-h-[60vh] w-full">
       <table className="min-w-[1000px] w-full table-fixed text-xs border-collapse">
         <thead className="sticky top-0 bg-white dark:bg-gray-800 z-10 shadow-sm">
           <tr>

--- a/web/src/pages/monitoring/components/MonthlyMatrix.jsx
+++ b/web/src/pages/monitoring/components/MonthlyMatrix.jsx
@@ -9,7 +9,7 @@ const MonthlyMatrix = ({ data = [] }) => {
   const progressColor = getProgressColor;
 
   return (
-    <div className="overflow-x-auto md:overflow-visible mt-4 max-h-[60vh] w-full">
+    <div className="overflow-x-auto overflow-y-auto md:overflow-visible mt-4 max-h-[60vh] w-full">
       <table className="min-w-[1000px] w-full table-fixed text-xs border-collapse">
         <thead className="sticky top-0 bg-white dark:bg-gray-800 z-10 shadow-sm">
           <tr>


### PR DESCRIPTION
## Summary
- enable vertical scrolling for weekly and monthly matrix tables

## Testing
- `npm install --prefix web`
- `npm test --prefix web`


------
https://chatgpt.com/codex/tasks/task_b_6889f8c61888832b9e5e169b262edafa