### PR TITLE
Fix overlapping columns in monitoring tables

### DIFF
--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -6,6 +6,7 @@ import {
   showSuccess,
   showError,
   handleAxiosError,
+  confirmCancel,
 } from "../../utils/alerts";
 import Pagination from "../../components/Pagination";
 import Modal from "../../components/ui/Modal";

--- a/web/src/pages/monitoring/DailyMatrix.jsx
+++ b/web/src/pages/monitoring/DailyMatrix.jsx
@@ -12,7 +12,7 @@ export const DailyMatrixRow = ({ user, boxClass, currentUser }) => {
           : "hover:bg-gray-50 dark:hover:bg-gray-700"
       }`}
     >
-      <td className="px-4 py-2 border text-left text-sm whitespace-nowrap font-medium">
+      <td className="px-4 py-2 border text-left text-sm whitespace-nowrap font-medium w-48 md:w-60">
         {user.nama}
       </td>
       {user.detail.map((day, i) => (
@@ -29,9 +29,8 @@ export const DailyMatrixRow = ({ user, boxClass, currentUser }) => {
 };
 
 const DailyMatrix = ({ data = [] }) => {
-  if (!Array.isArray(data) || data.length === 0) return null;
-
   const { user: currentUser } = useAuth();
+  if (!Array.isArray(data) || data.length === 0) return null;
 
   const year = new Date(data[0].detail[0].tanggal).getFullYear();
   const today = new Date().toISOString().slice(0, 10);
@@ -58,10 +57,10 @@ const DailyMatrix = ({ data = [] }) => {
 
   return (
     <div className="overflow-x-auto max-h-[60vh] overflow-y-auto w-full">
-      <table className="min-w-[1000px] w-full table-fixed border text-sm rounded shadow">
+      <table className="min-w-[1300px] w-full table-fixed border text-sm rounded shadow">
         <thead className="sticky top-0 bg-white dark:bg-gray-800 z-10 shadow-sm">
           <tr>
-            <th className="px-4 py-2 border text-left">Nama</th>
+            <th className="px-4 py-2 border text-left w-48 md:w-60">Nama</th>
             {Array.from({ length: dayCount }, (_, i) => (
               <th key={i} className="px-2 py-1 border text-center">
                 {i + 1}

--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -79,7 +79,7 @@ export default function MonitoringPage() {
     }
     setWeekStarts(starts);
     if (weekIndex >= starts.length) setWeekIndex(0);
-  }, [monthIndex, year]);
+  }, [monthIndex, year, weekIndex]);
 
   return (
     <div className="max-w-screen-xl mx-auto px-4 flex flex-col gap-4">

--- a/web/src/pages/monitoring/WeeklyMatrix.jsx
+++ b/web/src/pages/monitoring/WeeklyMatrix.jsx
@@ -13,7 +13,7 @@ export const WeeklyMatrixRow = ({ user, progressColor, weekCount, currentUser })
           : "hover:bg-gray-50 dark:hover:bg-gray-700"
       }`}
     >
-      <td className="p-2 border text-left whitespace-nowrap text-sm font-medium">
+      <td className="p-2 border text-left whitespace-nowrap text-sm font-medium w-48 md:w-60">
         {user.nama}
       </td>
       {user.weeks.slice(0, weekCount).map((w, i) => (
@@ -38,8 +38,8 @@ export const WeeklyMatrixRow = ({ user, progressColor, weekCount, currentUser })
 };
 
 const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek, selectedWeek }) => {
-  if (!Array.isArray(data) || data.length === 0) return null;
   const { user: currentUser } = useAuth();
+  if (!Array.isArray(data) || data.length === 0) return null;
   const progressColor = getProgressColor;
 
   return (
@@ -47,7 +47,7 @@ const WeeklyMatrix = ({ data = [], weeks = [], onSelectWeek, selectedWeek }) => 
       <table className="min-w-[1000px] w-full table-fixed text-xs border-collapse border rounded-lg shadow">
         <thead className="sticky top-0 bg-white dark:bg-gray-800 z-10 shadow-sm">
           <tr>
-            <th className="p-2 border text-left">Nama</th>
+            <th className="p-2 border text-left w-48 md:w-60">Nama</th>
             {weeks.map((_, i) => (
               <th
                 key={i}

--- a/web/src/pages/monitoring/components/MonthlyMatrix.jsx
+++ b/web/src/pages/monitoring/components/MonthlyMatrix.jsx
@@ -4,16 +4,16 @@ import months from "../../../utils/months";
 import { useAuth } from "../../auth/useAuth";
 
 const MonthlyMatrix = ({ data = [] }) => {
-  if (!Array.isArray(data) || data.length === 0) return null;
   const { user: currentUser } = useAuth();
+  if (!Array.isArray(data) || data.length === 0) return null;
   const progressColor = getProgressColor;
 
   return (
     <div className="overflow-x-auto overflow-y-auto md:overflow-visible mt-4 max-h-[60vh] w-full">
-      <table className="min-w-[1000px] w-full table-fixed text-xs border-collapse">
+      <table className="min-w-[800px] w-full table-fixed text-xs border-collapse">
         <thead className="sticky top-0 bg-white dark:bg-gray-800 z-10 shadow-sm">
           <tr>
-            <th className="p-2 border text-left">Nama</th>
+            <th className="p-2 border text-left w-48 md:w-60">Nama</th>
             {months.map((m, i) => (
               <th key={i} className="p-1 border text-center">
                 {m.slice(0, 3)}
@@ -31,7 +31,7 @@ const MonthlyMatrix = ({ data = [] }) => {
                   : "hover:bg-gray-50 dark:hover:bg-gray-700"
               }`}
             >
-              <td className="p-2 border text-left whitespace-nowrap text-sm font-medium">
+              <td className="p-2 border text-left whitespace-nowrap text-sm font-medium w-48 md:w-60">
                 {u.nama}
               </td>
               {u.months.map((m, i) => (

--- a/web/src/pages/monitoring/components/WeeklyProgressTable.jsx
+++ b/web/src/pages/monitoring/components/WeeklyProgressTable.jsx
@@ -3,8 +3,8 @@ import getProgressColor from "../../../utils/progressColor";
 import { useAuth } from "../../auth/useAuth";
 
 const WeeklyProgressTable = ({ data = [] }) => {
-  if (!Array.isArray(data) || data.length === 0) return null;
   const { user: currentUser } = useAuth();
+  if (!Array.isArray(data) || data.length === 0) return null;
   const progressColor = getProgressColor;
 
   return (
@@ -12,7 +12,7 @@ const WeeklyProgressTable = ({ data = [] }) => {
       <table className="min-w-[1000px] w-full table-fixed text-xs border-collapse border rounded-lg shadow">
         <thead className="sticky top-0 bg-white dark:bg-gray-800 z-10 shadow-sm">
           <tr>
-            <th className="p-2 border text-left">Nama</th>
+            <th className="p-2 border text-left w-48 md:w-60">Nama</th>
             <th className="p-2 border text-center">Tugas Selesai</th>
             <th className="p-2 border text-center">Total Tugas</th>
             <th className="p-2 border text-center">Capaian</th>
@@ -28,7 +28,7 @@ const WeeklyProgressTable = ({ data = [] }) => {
                   : "hover:bg-gray-50 dark:hover:bg-gray-700"
               }`}
             >
-              <td className="p-2 border text-left whitespace-nowrap text-sm font-medium">
+              <td className="p-2 border text-left whitespace-nowrap text-sm font-medium w-48 md:w-60">
                 {u.nama}
               </td>
               <td className="p-1 border">{u.selesai}</td>


### PR DESCRIPTION
## Summary
- widen `Nama` columns and add min width for daily and monthly tables
- ensure auth hooks run before early returns
- make weekly matrix effect depend on `weekIndex`
- import `confirmCancel` to fix lint error

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6889e9da4cf8832b8955555db87f43de