### PR TITLE
Show month selector on daily tab

### DIFF
--- a/web/src/__tests__/MonitoringPage.test.jsx
+++ b/web/src/__tests__/MonitoringPage.test.jsx
@@ -20,5 +20,7 @@ test('displays last update note', async () => {
     return Promise.resolve({ data: [] });
   });
   render(<MonitoringPage />);
-  expect(await screen.findByText(/Data terakhir diperbarui/i)).toBeInTheDocument();
+  expect(
+    await screen.findByText(/Terakhir diperbarui/i)
+  ).toBeInTheDocument();
 });

--- a/web/src/__tests__/MonitoringTabs.test.jsx
+++ b/web/src/__tests__/MonitoringTabs.test.jsx
@@ -1,13 +1,13 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import MonitoringTabs from "../pages/dashboard/components/MonitoringTabs";
 
-jest.mock("../components/dashboard/DailyOverview", () => () => (
+jest.mock("../pages/dashboard/components/DailyOverview", () => () => (
   <div>Daily content</div>
 ));
-jest.mock("../components/dashboard/WeeklyOverview", () => () => (
+jest.mock("../pages/dashboard/components/WeeklyOverview", () => () => (
   <div>Weekly content</div>
 ));
-jest.mock("../components/dashboard/MonthlyOverview", () => () => (
+jest.mock("../pages/dashboard/components/MonthlyOverview", () => () => (
   <div>Monthly content</div>
 ));
 

--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -84,8 +84,8 @@ const Dashboard = () => {
 
         const [dailyRes, weeklyArray, monthlyRes, tugasArray] =
           await Promise.all([
-            axios.get("/monitoring/harian", {
-              params: { tanggal, ...filters },
+            axios.get("/monitoring/harian/bulan", {
+              params: { tanggal: formatISO(monthStart), ...filters },
             }),
             Promise.all(weeklyPromises),
             axios.get("/monitoring/bulanan", {

--- a/web/src/pages/dashboard/components/MonitoringTabs.jsx
+++ b/web/src/pages/dashboard/components/MonitoringTabs.jsx
@@ -55,15 +55,15 @@ const MonitoringTabs = ({
           ))}
         </div>
 
-        {/* Controls for Mingguan */}
-        {tab === "mingguan" && (
+        {/* Controls for Harian & Mingguan */}
+        {["harian", "mingguan"].includes(tab) && (
           <div className="flex gap-4 flex-wrap">
             {/* Bulan */}
             <Listbox value={monthIndex} onChange={onMonthChange}>
               <div className="relative w-36">
                 <Listbox.Button
-                  className="w-full cursor-pointer rounded-lg bg-gray-50 dark:bg-gray-800 
-                    py-2 pl-4 pr-10 text-sm text-center border border-gray-300 dark:border-gray-600 
+                  className="w-full cursor-pointer rounded-lg bg-gray-50 dark:bg-gray-800
+                    py-2 pl-4 pr-10 text-sm text-center border border-gray-300 dark:border-gray-600
                     shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
                   <span className="block truncate">{months[monthIndex]}</span>
@@ -78,7 +78,7 @@ const MonitoringTabs = ({
                   leaveTo="opacity-0"
                 >
                   <Listbox.Options
-                    className="absolute z-50 mt-1 max-h-60 w-full overflow-auto 
+                    className="absolute z-50 mt-1 max-h-60 w-full overflow-auto
                       rounded-md bg-white dark:bg-gray-700 py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5"
                   >
                     {months.map((month, i) => (
@@ -117,12 +117,12 @@ const MonitoringTabs = ({
             </Listbox>
 
             {/* Minggu */}
-            {weeklyList.length > 0 && (
+            {tab === "mingguan" && weeklyList.length > 0 && (
               <Listbox value={weekIndex} onChange={onWeekChange}>
                 <div className="relative w-32">
                   <Listbox.Button
-                    className="w-full cursor-pointer rounded-lg bg-gray-50 dark:bg-gray-800 
-                      py-2 pl-4 pr-10 text-sm text-center border border-gray-300 dark:border-gray-600 
+                    className="w-full cursor-pointer rounded-lg bg-gray-50 dark:bg-gray-800
+                      py-2 pl-4 pr-10 text-sm text-center border border-gray-300 dark:border-gray-600
                       shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
                     <span className="block truncate">


### PR DESCRIPTION
## Summary
- show month selector on both daily and weekly monitoring tabs
- request monthly daily data using selected month
- correct monitoring tests to reflect new paths and text

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688ba0b85b70832bbb5939d47eba5c13