### PR TITLE
Seed with ULIDs and random assignments

### DIFF
--- a/api/prisma/migrations/20250801000000_use_ulid/migration.sql
+++ b/api/prisma/migrations/20250801000000_use_ulid/migration.sql
@@ -1,0 +1,116 @@
+-- Drop existing tables to recreate with string IDs
+DROP TABLE IF EXISTS `Notification`;
+DROP TABLE IF EXISTS `KegiatanTambahan`;
+DROP TABLE IF EXISTS `LaporanHarian`;
+DROP TABLE IF EXISTS `Penugasan`;
+DROP TABLE IF EXISTS `MasterKegiatan`;
+DROP TABLE IF EXISTS `Member`;
+DROP TABLE IF EXISTS `Team`;
+DROP TABLE IF EXISTS `User`;
+DROP TABLE IF EXISTS `Role`;
+
+CREATE TABLE `User` (
+  `id` VARCHAR(191) NOT NULL,
+  `nama` VARCHAR(191) NOT NULL,
+  `username` VARCHAR(191) NOT NULL,
+  `email` VARCHAR(191) NOT NULL,
+  `password` VARCHAR(191) NOT NULL,
+  `role` VARCHAR(191) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `User_username_key`(`username`),
+  UNIQUE INDEX `User_email_key`(`email`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `Team` (
+  `id` VARCHAR(191) NOT NULL,
+  `namaTim` VARCHAR(191) NOT NULL,
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `Member` (
+  `id` VARCHAR(191) NOT NULL,
+  `userId` VARCHAR(191) NOT NULL,
+  `teamId` VARCHAR(191) NOT NULL,
+  `isLeader` BOOLEAN NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `Member_userId_teamId_key`(`userId`,`teamId`),
+  CONSTRAINT `Member_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `Member_teamId_fkey` FOREIGN KEY (`teamId`) REFERENCES `Team`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `MasterKegiatan` (
+  `id` VARCHAR(191) NOT NULL,
+  `teamId` VARCHAR(191) NOT NULL,
+  `namaKegiatan` VARCHAR(191) NOT NULL,
+  `deskripsi` VARCHAR(191),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `MasterKegiatan_teamId_fkey` FOREIGN KEY (`teamId`) REFERENCES `Team`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `Penugasan` (
+  `id` VARCHAR(191) NOT NULL,
+  `kegiatanId` VARCHAR(191) NOT NULL,
+  `pegawaiId` VARCHAR(191) NOT NULL,
+  `creatorId` VARCHAR(191) NOT NULL,
+  `minggu` INTEGER NOT NULL,
+  `bulan` VARCHAR(191) NOT NULL,
+  `tahun` INTEGER NOT NULL,
+  `deskripsi` VARCHAR(191),
+  `status` VARCHAR(191) NOT NULL DEFAULT 'Belum',
+  PRIMARY KEY (`id`),
+  CONSTRAINT `Penugasan_kegiatanId_fkey` FOREIGN KEY (`kegiatanId`) REFERENCES `MasterKegiatan`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `Penugasan_pegawaiId_fkey` FOREIGN KEY (`pegawaiId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `Penugasan_creatorId_fkey` FOREIGN KEY (`creatorId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `LaporanHarian` (
+  `id` VARCHAR(191) NOT NULL,
+  `penugasanId` VARCHAR(191) NOT NULL,
+  `tanggal` DATETIME(3) NOT NULL,
+  `status` VARCHAR(191) NOT NULL,
+  `capaianKegiatan` VARCHAR(191) NOT NULL DEFAULT '',
+  `deskripsi` VARCHAR(191),
+  `buktiLink` VARCHAR(191),
+  `catatan` VARCHAR(191),
+  `pegawaiId` VARCHAR(191) NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `LaporanHarian_penugasanId_fkey` FOREIGN KEY (`penugasanId`) REFERENCES `Penugasan`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `LaporanHarian_pegawaiId_fkey` FOREIGN KEY (`pegawaiId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `KegiatanTambahan` (
+  `id` VARCHAR(191) NOT NULL,
+  `nama` VARCHAR(191) NOT NULL,
+  `tanggal` DATETIME(3) NOT NULL,
+  `status` VARCHAR(191) NOT NULL,
+  `capaianKegiatan` VARCHAR(191) NOT NULL DEFAULT '',
+  `buktiLink` VARCHAR(191),
+  `deskripsi` VARCHAR(191),
+  `tanggalSelesai` DATETIME(3),
+  `tanggalSelesaiAkhir` DATETIME(3),
+  `userId` VARCHAR(191) NOT NULL,
+  `kegiatanId` VARCHAR(191) NOT NULL,
+  `teamId` VARCHAR(191) NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `KegiatanTambahan_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `KegiatanTambahan_kegiatanId_fkey` FOREIGN KEY (`kegiatanId`) REFERENCES `MasterKegiatan`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `KegiatanTambahan_teamId_fkey` FOREIGN KEY (`teamId`) REFERENCES `Team`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `Role` (
+  `id` VARCHAR(191) NOT NULL,
+  `name` VARCHAR(191) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `Role_name_key`(`name`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `Notification` (
+  `id` VARCHAR(191) NOT NULL,
+  `userId` VARCHAR(191) NOT NULL,
+  `text` VARCHAR(191) NOT NULL,
+  `link` VARCHAR(191),
+  `isRead` BOOLEAN NOT NULL DEFAULT FALSE,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `Notification_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/api/src/kegiatan/penugasan.service.ts
+++ b/api/src/kegiatan/penugasan.service.ts
@@ -22,7 +22,7 @@ export class PenugasanService {
 
   findAll(
     _role: string,
-    _userId: number,
+    _userId: string,
     filter: { bulan?: string; tahun?: number; minggu?: number },
     creatorId?: string,
   ) {

--- a/api/src/monitoring/monitoring.controller.ts
+++ b/api/src/monitoring/monitoring.controller.ts
@@ -41,8 +41,8 @@ export class MonitoringController {
     }
     const user = req?.user as AuthRequestUser;
     const role = user?.role;
-    const tId = teamId ? parseInt(teamId, 10) : undefined;
-    let uId = userId ? parseInt(userId, 10) : undefined;
+    const tId = teamId;
+    let uId = userId;
 
     if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
       const uid = user.userId;
@@ -75,7 +75,7 @@ export class MonitoringController {
     }
     const user = req?.user as AuthRequestUser;
     const role = user?.role;
-    const tId = teamId ? parseInt(teamId, 10) : undefined;
+    const tId = teamId;
 
     if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
@@ -98,7 +98,7 @@ export class MonitoringController {
     }
     const user = req?.user as AuthRequestUser;
     const role = user?.role;
-    const tId = teamId ? parseInt(teamId, 10) : undefined;
+    const tId = teamId;
 
     if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
@@ -122,8 +122,8 @@ export class MonitoringController {
     }
     const user = req?.user as AuthRequestUser;
     const role = user?.role;
-    const tId = teamId ? parseInt(teamId, 10) : undefined;
-    let uId = userId ? parseInt(userId, 10) : undefined;
+    const tId = teamId;
+    let uId = userId;
 
     if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
       const uid = user.userId;
@@ -156,7 +156,7 @@ export class MonitoringController {
     }
     const user = req?.user as AuthRequestUser;
     const role = user?.role;
-    const tId = teamId ? parseInt(teamId, 10) : undefined;
+    const tId = teamId;
 
     if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
@@ -180,8 +180,8 @@ export class MonitoringController {
     }
     const user = req?.user as AuthRequestUser;
     const role = user?.role;
-    const tId = teamId ? parseInt(teamId, 10) : undefined;
-    let uId = userId ? parseInt(userId, 10) : undefined;
+    const tId = teamId;
+    let uId = userId;
 
     if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
       const uid = user.userId;
@@ -214,7 +214,7 @@ export class MonitoringController {
     }
     const user = req?.user as AuthRequestUser;
     const role = user?.role;
-    const tId = teamId ? parseInt(teamId, 10) : undefined;
+    const tId = teamId;
 
     if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
@@ -238,8 +238,8 @@ export class MonitoringController {
     }
     const user = req?.user as AuthRequestUser;
     const role = user?.role;
-    const tId = teamId ? parseInt(teamId, 10) : undefined;
-    let uId = userId ? parseInt(userId, 10) : undefined;
+    const tId = teamId;
+    let uId = userId;
 
     if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN) {
       const uid = user.userId;
@@ -273,7 +273,7 @@ export class MonitoringController {
     }
     const user = req?.user as AuthRequestUser;
     const role = user?.role;
-    const tId = teamId ? parseInt(teamId, 10) : undefined;
+    const tId = teamId;
 
     if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
@@ -296,7 +296,7 @@ export class MonitoringController {
     }
     const user = req?.user as AuthRequestUser;
     const role = user?.role;
-    const tId = teamId ? parseInt(teamId, 10) : undefined;
+    const tId = teamId;
 
     if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({
@@ -315,7 +315,7 @@ export class MonitoringController {
   ) {
     const user = req?.user as AuthRequestUser;
     const role = user?.role;
-    const tId = teamId ? parseInt(teamId, 10) : undefined;
+    const tId = teamId;
 
     if (role !== ROLES.ADMIN && role !== ROLES.PIMPINAN && tId) {
       const member = await this.prisma.member.findFirst({

--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -17,7 +17,7 @@ export class MonitoringService {
     });
     return latest?.tanggal || null;
   }
-  async harian(tanggal: string, teamId?: number, userId?: number) {
+  async harian(tanggal: string, teamId?: string, userId?: string) {
     const base = new Date(tanggal);
     if (isNaN(base.getTime()))
       throw new BadRequestException("tanggal tidak valid");
@@ -56,7 +56,7 @@ export class MonitoringService {
     return result;
   }
 
-  async mingguan(minggu: string, teamId?: number, userId?: number) {
+  async mingguan(minggu: string, teamId?: string, userId?: string) {
     const start = new Date(minggu);
     const offset = (start.getDay() + 6) % 7; // days since Monday
     start.setDate(start.getDate() - offset);
@@ -154,7 +154,7 @@ export class MonitoringService {
     };
   }
 
-  async bulanan(year: string, teamId?: number, userId?: number) {
+  async bulanan(year: string, teamId?: string, userId?: string) {
     const yr = parseInt(year, 10);
     if (isNaN(yr)) throw new BadRequestException("year tidak valid");
 
@@ -181,7 +181,7 @@ export class MonitoringService {
     return results;
   }
 
-  async harianBulan(tanggal: string, teamId?: number) {
+  async harianBulan(tanggal: string, teamId?: string) {
     const base = new Date(tanggal);
     if (isNaN(base.getTime()))
       throw new BadRequestException("tanggal tidak valid");
@@ -208,7 +208,7 @@ export class MonitoringService {
     );
 
     const byUser: Record<
-      number,
+      string,
       { nama: string; counts: Record<string, number> }
     > = {};
     for (const r of records) {
@@ -231,12 +231,12 @@ export class MonitoringService {
             count: v.counts[dateStr] || 0,
           });
         }
-        return { userId: Number(id), nama: v.nama, detail };
+        return { userId: id, nama: v.nama, detail };
       })
       .sort((a, b) => a.nama.localeCompare(b.nama));
   }
 
-  async harianAll(tanggal: string, teamId?: number) {
+  async harianAll(tanggal: string, teamId?: string) {
     const date = new Date(tanggal);
     if (isNaN(date.getTime()))
       throw new BadRequestException("tanggal tidak valid");
@@ -257,7 +257,7 @@ export class MonitoringService {
     );
 
     const byUser: Record<
-      number,
+      string,
       { nama: string; selesai: number; total: number }
     > = {};
 
@@ -270,7 +270,7 @@ export class MonitoringService {
 
     return Object.entries(byUser)
       .map(([id, v]) => ({
-        userId: Number(id),
+        userId: id,
         nama: v.nama,
         selesai: v.selesai,
         total: v.total,
@@ -279,7 +279,7 @@ export class MonitoringService {
       .sort((a, b) => a.nama.localeCompare(b.nama));
   }
 
-  async mingguanAll(minggu: string, teamId?: number) {
+  async mingguanAll(minggu: string, teamId?: string) {
     const start = new Date(minggu);
     const offset = (start.getDay() + 6) % 7;
     start.setDate(start.getDate() - offset);
@@ -305,7 +305,7 @@ export class MonitoringService {
     );
 
     const byUser: Record<
-      number,
+      string,
       { nama: string; selesai: number; total: number }
     > = {};
 
@@ -318,7 +318,7 @@ export class MonitoringService {
 
     return Object.entries(byUser)
       .map(([id, v]) => ({
-        userId: Number(id),
+        userId: id,
         nama: v.nama,
         selesai: v.selesai,
         total: v.total,
@@ -327,7 +327,7 @@ export class MonitoringService {
       .sort((a, b) => a.nama.localeCompare(b.nama));
   }
 
-  async mingguanBulan(tanggal: string, teamId?: number) {
+  async mingguanBulan(tanggal: string, teamId?: string) {
     const base = new Date(tanggal);
     if (isNaN(base.getTime()))
       throw new BadRequestException("tanggal tidak valid");
@@ -361,7 +361,7 @@ export class MonitoringService {
     );
 
     const byUser: Record<
-      number,
+      string,
       {
         nama: string;
         perWeek: Record<number, { selesai: number; total: number }>;
@@ -388,15 +388,15 @@ export class MonitoringService {
           const persen = w.total > 0 ? 100 : 0;
           return { selesai: w.selesai, total: w.total, persen };
         });
-        return { userId: Number(id), nama: v.nama, weeks };
+        return { userId: id, nama: v.nama, weeks };
       })
       .sort((a, b) => a.nama.localeCompare(b.nama));
   }
 
   async penugasanMinggu(
     minggu: string,
-    teamId?: number,
-    userId?: number,
+    teamId?: string,
+    userId?: string,
   ) {
     const start = new Date(minggu);
     const offset = (start.getDay() + 6) % 7;
@@ -430,8 +430,8 @@ export class MonitoringService {
 
   async penugasanBulan(
     tanggal: string,
-    teamId?: number,
-    userId?: number,
+    teamId?: string,
+    userId?: string,
   ) {
     const base = new Date(tanggal);
     if (isNaN(base.getTime()))
@@ -477,7 +477,7 @@ export class MonitoringService {
     });
   }
 
-  async bulananAll(year: string, teamId?: number, bulan?: string) {
+  async bulananAll(year: string, teamId?: string, bulan?: string) {
     const yr = parseInt(year, 10);
     if (isNaN(yr)) throw new BadRequestException("year tidak valid");
 
@@ -500,7 +500,7 @@ export class MonitoringService {
     );
     
     const byUser: Record<
-      number,
+      string,
       { nama: string; selesai: number; total: number }
     > = {};
 
@@ -513,7 +513,7 @@ export class MonitoringService {
 
     return Object.entries(byUser)
       .map(([id, v]) => ({
-        userId: Number(id),
+        userId: id,
         nama: v.nama,
         selesai: v.selesai,
         total: v.total,
@@ -522,7 +522,7 @@ export class MonitoringService {
       .sort((a, b) => a.nama.localeCompare(b.nama));
   }
 
-  async bulananMatrix(year: string, teamId?: number) {
+  async bulananMatrix(year: string, teamId?: string) {
     const yr = parseInt(year, 10);
     if (isNaN(yr)) throw new BadRequestException("year tidak valid");
 
@@ -539,7 +539,7 @@ export class MonitoringService {
     );
 
     const byUser: Record<
-      number,
+      string,
       { nama: string; perMonth: Record<number, { selesai: number; total: number }> }
     > = {};
 
@@ -561,12 +561,12 @@ export class MonitoringService {
           const persen = m.total ? Math.round((m.selesai / m.total) * 100) : 0;
           return { selesai: m.selesai, total: m.total, persen };
         });
-        return { userId: Number(id), nama: v.nama, months };
+        return { userId: id, nama: v.nama, months };
       })
       .sort((a, b) => a.nama.localeCompare(b.nama));
   }
 
-  async laporanTerlambat(teamId?: number) {
+  async laporanTerlambat(teamId?: string) {
     const whereUser: any = {
       NOT: { role: { in: [ROLES.ADMIN, ROLES.PIMPINAN] } },
     };
@@ -583,7 +583,7 @@ export class MonitoringService {
 
     const result = { day1: [], day3: [], day7: [] } as Record<
       'day1' | 'day3' | 'day7',
-      { userId: number; nama: string; lastDate: string | null }[]
+      { userId: string; nama: string; lastDate: string | null }[]
     >;
 
     for (const u of users) {

--- a/api/test/auth.controller.spec.ts
+++ b/api/test/auth.controller.spec.ts
@@ -15,9 +15,9 @@ describe('AuthController login', () => {
 
   it('sets cookie and returns user', async () => {
     const res: any = { cookie: jest.fn() };
-    service.login.mockResolvedValue({ access_token: 'tok', user: { id: 1 } });
+    service.login.mockResolvedValue({ access_token: 'tok', user: { id: '1' } });
     const result = await controller.login({ identifier: 'a', password: 'b' } as any, res);
-    expect(result).toEqual({ user: { id: 1 } });
+    expect(result).toEqual({ user: { id: '1' } });
     expect(res.cookie).toHaveBeenCalledWith('token', 'tok', expect.any(Object));
   });
 
@@ -39,10 +39,10 @@ describe('AuthController logout', () => {
 
 describe('AuthController me', () => {
   it('returns current user', async () => {
-    const req: any = { user: { userId: 1 } };
-    service.me.mockResolvedValue({ id: 1 });
+    const req: any = { user: { userId: '1' } };
+    service.me.mockResolvedValue({ id: '1' });
     const result = await controller.me(req);
-    expect(service.me).toHaveBeenCalledWith(1);
-    expect(result).toEqual({ user: { id: 1 } });
+    expect(service.me).toHaveBeenCalledWith('1');
+    expect(result).toEqual({ user: { id: '1' } });
   });
 });

--- a/api/test/auth.service.spec.ts
+++ b/api/test/auth.service.spec.ts
@@ -22,8 +22,8 @@ describe('AuthService login', () => {
 });
 
 test('returns token and user on success', async () => {
-  prisma.user.findFirst.mockResolvedValue({
-    id: 1,
+    prisma.user.findFirst.mockResolvedValue({
+    id: '1',
     email: 'a',
     username: 'a',
     password: bcrypt.hashSync('b', 1),
@@ -31,7 +31,7 @@ test('returns token and user on success', async () => {
   });
   const result = await service.login('a', 'b');
   expect(result).toHaveProperty('access_token');
-  expect(result.user).toHaveProperty('id', 1);
+  expect(result.user).toHaveProperty('id', '1');
   expect(prisma.user.findFirst).toHaveBeenCalled();
   expect(jwtService.sign).toHaveBeenCalled();
 });
@@ -43,32 +43,32 @@ describe('AuthService me', () => {
 
   it('throws NotFoundException when user missing', async () => {
     prisma.user.findUnique.mockResolvedValue(null);
-    await expect(service.me(1)).rejects.toThrow(NotFoundException);
+    await expect(service.me('1')).rejects.toThrow(NotFoundException);
   });
 
   it('returns sanitized user', async () => {
     prisma.user.findUnique.mockResolvedValue({
-      id: 1,
+      id: '1',
       nama: 'A',
       username: 'a',
       email: 'a@b.c',
       password: 'x',
       role: 'admin',
-      members: [{ teamId: 2, team: { namaTim: 'Tim' } }],
+      members: [{ teamId: '2', team: { namaTim: 'Tim' } }],
     });
-    const res = await service.me(1);
+    const res = await service.me('1');
     expect(prisma.user.findUnique).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { id: '1' },
       include: { members: { include: { team: true } } },
     });
     expect(res).toEqual({
-      id: 1,
+      id: '1',
       nama: 'A',
       username: 'a',
       email: 'a@b.c',
       role: 'admin',
-      members: [{ teamId: 2, team: { namaTim: 'Tim' } }],
-      teamId: 2,
+      members: [{ teamId: '2', team: { namaTim: 'Tim' } }],
+      teamId: '2',
       teamName: 'Tim',
     });
     expect(res).not.toHaveProperty('password');

--- a/api/test/laporan.service.spec.ts
+++ b/api/test/laporan.service.spec.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
 
 describe('LaporanService submit', () => {
   const data = {
-    penugasanId: 1,
+    penugasanId: '1',
     tanggal: '2024-05-01',
     status: STATUS.BELUM,
     deskripsi: 'test',
@@ -41,75 +41,75 @@ describe('LaporanService submit', () => {
 
   it('throws ForbiddenException when not assignment owner', async () => {
     prisma.penugasan.findUnique.mockResolvedValue({
-      id: 1,
-      pegawaiId: 2,
-      kegiatan: { teamId: 1 },
+      id: '1',
+      pegawaiId: '2',
+      kegiatan: { teamId: '1' },
     });
-    await expect(service.submit(data as any, 1, ROLES.ANGGOTA)).rejects.toThrow(ForbiddenException);
+    await expect(service.submit(data as any, '1', ROLES.ANGGOTA)).rejects.toThrow(ForbiddenException);
   });
 
   it('allows admin to submit for other user', async () => {
     prisma.penugasan.findUnique.mockResolvedValue({
-      id: 1,
-      pegawaiId: 2,
-      kegiatan: { teamId: 1 },
+      id: '1',
+      pegawaiId: '2',
+      kegiatan: { teamId: '1' },
     });
-    prisma.laporanHarian.create.mockResolvedValue({ id: 10 });
+    prisma.laporanHarian.create.mockResolvedValue({ id: '10' });
     prisma.laporanHarian.findFirst.mockResolvedValue(null);
     prisma.penugasan.update.mockResolvedValue({});
 
-    const res = await service.submit(data as any, 1, ROLES.ADMIN);
+    const res = await service.submit(data as any, '1', ROLES.ADMIN);
 
-    expect(res).toEqual({ id: 10 });
+    expect(res).toEqual({ id: '10' });
     expect(prisma.laporanHarian.create).toHaveBeenCalled();
     expect(prisma.penugasan.update).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { id: '1' },
       data: { status: STATUS.BELUM },
     });
   });
 
   it('sets assignment status to selesai when any report finished', async () => {
     prisma.penugasan.findUnique.mockResolvedValue({
-      id: 1,
-      pegawaiId: 1,
-      kegiatan: { teamId: 1 },
+      id: '1',
+      pegawaiId: '1',
+      kegiatan: { teamId: '1' },
     });
     prisma.member.findMany.mockResolvedValue([]);
-    prisma.laporanHarian.create.mockResolvedValue({ id: 11 });
+    prisma.laporanHarian.create.mockResolvedValue({ id: '11' });
     prisma.laporanHarian.findFirst.mockResolvedValueOnce({
       status: STATUS.SELESAI_DIKERJAKAN,
     });
     prisma.penugasan.update.mockResolvedValue({});
 
-    await service.submit(data as any, 1, ROLES.ANGGOTA);
+    await service.submit(data as any, '1', ROLES.ANGGOTA);
 
     expect(prisma.penugasan.update).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { id: '1' },
       data: { status: STATUS.SELESAI_DIKERJAKAN },
     });
   });
 
   it('returns laporan when optional fields missing', async () => {
     prisma.penugasan.findUnique.mockResolvedValue({
-      id: 1,
-      pegawaiId: 1,
-      kegiatan: { teamId: 1 },
+      id: '1',
+      pegawaiId: '1',
+      kegiatan: { teamId: '1' },
     });
-    prisma.laporanHarian.create.mockResolvedValue({ id: 12 });
+    prisma.laporanHarian.create.mockResolvedValue({ id: '12' });
     prisma.laporanHarian.findFirst.mockResolvedValue(null);
     prisma.penugasan.update.mockResolvedValue({});
 
     const payload = {
-      penugasanId: 1,
+      penugasanId: '1',
       tanggal: '2024-05-02',
       status: STATUS.BELUM,
       deskripsi: 'd',
       capaianKegiatan: 'cap',
     } as any;
 
-    const res = await service.submit(payload, 1, ROLES.ANGGOTA);
+    const res = await service.submit(payload, '1', ROLES.ANGGOTA);
 
-    expect(res).toEqual({ id: 12 });
+    expect(res).toEqual({ id: '12' });
     expect(prisma.laporanHarian.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -122,18 +122,18 @@ describe('LaporanService submit', () => {
 
   it('ignores errors from syncPenugasanStatus', async () => {
     prisma.penugasan.findUnique.mockResolvedValue({
-      id: 1,
-      pegawaiId: 1,
-      kegiatan: { teamId: 1 },
+      id: '1',
+      pegawaiId: '1',
+      kegiatan: { teamId: '1' },
     });
-    prisma.laporanHarian.create.mockResolvedValue({ id: 13 });
+    prisma.laporanHarian.create.mockResolvedValue({ id: '13' });
     const spy = jest
       .spyOn<any, any>(service as any, 'syncPenugasanStatus')
       .mockRejectedValue(new Error('fail'));
 
-    const res = await service.submit(data as any, 1, ROLES.ANGGOTA);
+    const res = await service.submit(data as any, '1', ROLES.ANGGOTA);
 
-    expect(res).toEqual({ id: 13 });
+    expect(res).toEqual({ id: '13' });
     expect(spy).toHaveBeenCalled();
   });
 });
@@ -141,12 +141,12 @@ describe('LaporanService submit', () => {
 describe('LaporanService update', () => {
   it('throws ForbiddenException when updating others report', async () => {
     prisma.laporanHarian.findUnique.mockResolvedValue({
-      id: 1,
-      pegawaiId: 2,
-      penugasanId: 1,
-      penugasan: { kegiatan: { teamId: 1 } },
+      id: '1',
+      pegawaiId: '2',
+      penugasanId: '1',
+      penugasan: { kegiatan: { teamId: '1' } },
     });
-    const action = service.update(1, { tanggal: '2024-05-01', status: STATUS.BELUM } as any, 3, ROLES.ANGGOTA);
+    const action = service.update('1', { tanggal: '2024-05-01', status: STATUS.BELUM } as any, '3', ROLES.ANGGOTA);
     await expect(action).rejects.toThrow(ForbiddenException);
   });
 });
@@ -154,23 +154,23 @@ describe('LaporanService update', () => {
 describe('LaporanService remove', () => {
   it('throws NotFoundException when report not found', async () => {
     prisma.laporanHarian.findUnique.mockResolvedValue(null);
-    await expect(service.remove(1, 1, ROLES.ADMIN)).rejects.toThrow(NotFoundException);
+    await expect(service.remove('1', '1', ROLES.ADMIN)).rejects.toThrow(NotFoundException);
   });
 
   it('allows leader to remove others report', async () => {
     prisma.laporanHarian.findUnique.mockResolvedValue({
-      id: 1,
-      pegawaiId: 2,
-      penugasanId: 1,
-      penugasan: { kegiatan: { teamId: 1 } },
+      id: '1',
+      pegawaiId: '2',
+      penugasanId: '1',
+      penugasan: { kegiatan: { teamId: '1' } },
     });
-    prisma.member.findFirst.mockResolvedValue({ id: 1 });
+    prisma.member.findFirst.mockResolvedValue({ id: '1' });
     prisma.laporanHarian.delete.mockResolvedValue({});
     prisma.laporanHarian.findFirst.mockResolvedValue(null);
     prisma.penugasan.update.mockResolvedValue({});
 
-    const res = await service.remove(1, 3, ROLES.KETUA);
-    expect(prisma.laporanHarian.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+    const res = await service.remove('1', '3', ROLES.KETUA);
+    expect(prisma.laporanHarian.delete).toHaveBeenCalledWith({ where: { id: '1' } });
     expect(res).toEqual({ success: true });
   });
 });
@@ -179,7 +179,7 @@ describe('LaporanService getByMonthWeek', () => {
   it('merges additional tasks when requested', async () => {
     prisma.laporanHarian.findMany.mockResolvedValue([
       {
-        id: 1,
+        id: '1',
         tanggal: new Date('2024-05-01'),
         status: STATUS.BELUM,
         deskripsi: 'laporan',
@@ -188,7 +188,7 @@ describe('LaporanService getByMonthWeek', () => {
     ]);
     prisma.kegiatanTambahan.findMany.mockResolvedValue([
       {
-        id: 2,
+        id: '2',
         tanggal: new Date('2024-05-02'),
         status: STATUS.BELUM,
         nama: 'tambahan',
@@ -198,11 +198,11 @@ describe('LaporanService getByMonthWeek', () => {
       },
     ]);
 
-    const res = await service.getByMonthWeek(1, '5', undefined, true);
+    const res = await service.getByMonthWeek('1', '5', undefined, true);
 
     expect(prisma.kegiatanTambahan.findMany).toHaveBeenCalled();
     expect(res.length).toBe(2);
-    const tambahan = res.find((r: any) => r.id === 2);
+    const tambahan = res.find((r: any) => r.id === '2');
     expect(tambahan.type).toBe('tambahan');
   });
 });

--- a/api/test/master-kegiatan.service.spec.ts
+++ b/api/test/master-kegiatan.service.spec.ts
@@ -23,18 +23,18 @@ describe('MasterKegiatanService findAll', () => {
 
   it('returns items containing teamId', async () => {
     prisma.masterKegiatan.findMany.mockResolvedValue([
-      { id: 1, teamId: 2, namaKegiatan: 'Test' },
+      { id: '1', teamId: '2', namaKegiatan: 'Test' },
     ]);
     prisma.masterKegiatan.count.mockResolvedValue(1);
 
-    const result = await service.findAll({ page: 1, limit: 10, teamId: 2 });
+    const result = await service.findAll({ page: 1, limit: 10, teamId: '2' });
 
     expect(prisma.masterKegiatan.findMany).toHaveBeenCalledWith({
-      where: { teamId: 2 },
+      where: { teamId: '2' },
       include: { team: true },
       skip: 0,
       take: 10,
     });
-    expect(result.data[0]).toHaveProperty('teamId', 2);
+    expect(result.data[0]).toHaveProperty('teamId', '2');
   });
 });

--- a/api/test/monitoring.service.spec.ts
+++ b/api/test/monitoring.service.spec.ts
@@ -16,27 +16,27 @@ describe('MonitoringService aggregated', () => {
 
   it('harianAll aggregates and sorts by name', async () => {
     prisma.laporanHarian.findMany.mockResolvedValue([
-      { pegawaiId: 2, status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'B' } },
-      { pegawaiId: 1, status: STATUS.BELUM, pegawai: { nama: 'A' } },
-      { pegawaiId: 1, status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'A' } },
+      { pegawaiId: '2', status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'B' } },
+      { pegawaiId: '1', status: STATUS.BELUM, pegawai: { nama: 'A' } },
+      { pegawaiId: '1', status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'A' } },
     ]);
     const res = await service.harianAll('2024-05-01');
     expect(res).toEqual([
-      { userId: 1, nama: 'A', selesai: 1, total: 2, persen: 50 },
-      { userId: 2, nama: 'B', selesai: 1, total: 1, persen: 100 },
+      { userId: '1', nama: 'A', selesai: 1, total: 2, persen: 50 },
+      { userId: '2', nama: 'B', selesai: 1, total: 1, persen: 100 },
     ]);
   });
 
   it('mingguanAll aggregates and sorts', async () => {
     prisma.laporanHarian.findMany.mockResolvedValue([
-      { pegawaiId: 2, status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'B' } },
-      { pegawaiId: 1, status: STATUS.BELUM, pegawai: { nama: 'A' } },
-      { pegawaiId: 1, status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'A' } },
+      { pegawaiId: '2', status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'B' } },
+      { pegawaiId: '1', status: STATUS.BELUM, pegawai: { nama: 'A' } },
+      { pegawaiId: '1', status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'A' } },
     ]);
     const res = await service.mingguanAll('2024-05-01');
     expect(res).toEqual([
-      { userId: 1, nama: 'A', selesai: 1, total: 2, persen: 50 },
-      { userId: 2, nama: 'B', selesai: 1, total: 1, persen: 100 },
+      { userId: '1', nama: 'A', selesai: 1, total: 2, persen: 50 },
+      { userId: '2', nama: 'B', selesai: 1, total: 1, persen: 100 },
     ]);
   });
 
@@ -66,26 +66,26 @@ describe('MonitoringService aggregated', () => {
 
   it('bulananAll aggregates and passes bulan filter', async () => {
     prisma.penugasan.findMany.mockResolvedValue([
-      { pegawaiId: 2, bulan: '1', status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'B' } },
-      { pegawaiId: 1, bulan: '1', status: STATUS.BELUM, pegawai: { nama: 'A' } },
-      { pegawaiId: 1, bulan: '1', status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'A' } },
+      { pegawaiId: '2', bulan: '1', status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'B' } },
+      { pegawaiId: '1', bulan: '1', status: STATUS.BELUM, pegawai: { nama: 'A' } },
+      { pegawaiId: '1', bulan: '1', status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'A' } },
     ]);
-    const res = await service.bulananAll('2024', 3, '1');
+    const res = await service.bulananAll('2024', '3', '1');
     expect(prisma.penugasan.findMany).toHaveBeenCalledWith({
-      where: { tahun: 2024, bulan: '1', kegiatan: { teamId: 3 } },
+      where: { tahun: 2024, bulan: '1', kegiatan: { teamId: '3' } },
       include: { pegawai: true },
     });
     expect(res).toEqual([
-      { userId: 1, nama: 'A', selesai: 1, total: 2, persen: 50 },
-      { userId: 2, nama: 'B', selesai: 1, total: 1, persen: 100 },
+      { userId: '1', nama: 'A', selesai: 1, total: 2, persen: 50 },
+      { userId: '2', nama: 'B', selesai: 1, total: 1, persen: 100 },
     ]);
   });
 
   it('harianBulan groups by user and counts records', async () => {
     prisma.laporanHarian.findMany.mockResolvedValue([
-      { pegawaiId: 1, tanggal: new Date('2024-05-02'), pegawai: { nama: 'A' } },
-      { pegawaiId: 1, tanggal: new Date('2024-05-02'), pegawai: { nama: 'A' } },
-      { pegawaiId: 2, tanggal: new Date('2024-05-01'), pegawai: { nama: 'B' } },
+      { pegawaiId: '1', tanggal: new Date('2024-05-02'), pegawai: { nama: 'A' } },
+      { pegawaiId: '1', tanggal: new Date('2024-05-02'), pegawai: { nama: 'A' } },
+      { pegawaiId: '2', tanggal: new Date('2024-05-01'), pegawai: { nama: 'B' } },
     ]);
     const res = await service.harianBulan('2024-05-10');
     expect(res.map((u) => u.nama)).toEqual(['A', 'B']);
@@ -97,19 +97,19 @@ describe('MonitoringService aggregated', () => {
   it('mingguanBulan aggregates per week', async () => {
     prisma.laporanHarian.findMany.mockResolvedValue([
       {
-        pegawaiId: 1,
+        pegawaiId: '1',
         tanggal: new Date('2024-05-02'),
         status: STATUS.SELESAI_DIKERJAKAN,
         pegawai: { nama: 'A' },
       },
       {
-        pegawaiId: 1,
+        pegawaiId: '1',
         tanggal: new Date('2024-05-08'),
         status: STATUS.BELUM,
         pegawai: { nama: 'A' },
       },
       {
-        pegawaiId: 2,
+        pegawaiId: '2',
         tanggal: new Date('2024-05-15'),
         status: STATUS.SELESAI_DIKERJAKAN,
         pegawai: { nama: 'B' },
@@ -118,7 +118,7 @@ describe('MonitoringService aggregated', () => {
     const res = await service.mingguanBulan('2024-05-10');
     expect(res).toEqual([
       {
-        userId: 1,
+        userId: '1',
         nama: 'A',
         weeks: [
           { selesai: 1, total: 1, persen: 100 },
@@ -129,7 +129,7 @@ describe('MonitoringService aggregated', () => {
         ],
       },
       {
-        userId: 2,
+        userId: '2',
         nama: 'B',
         weeks: [
           { selesai: 0, total: 0, persen: 0 },
@@ -178,26 +178,26 @@ describe('MonitoringService aggregated', () => {
     expect(spy).toHaveBeenCalledTimes(12);
     expect(res[0]).toEqual({ bulan: 'Januari', persen: 67 });
 
-    const resUser = await service.bulanan('2024', undefined, 1);
+    const resUser = await service.bulanan('2024', undefined, '1');
     expect(resUser[0]).toEqual({ bulan: 'Januari', persen: 67 });
   });
 
   it('bulananMatrix aggregates per month', async () => {
     prisma.penugasan.findMany.mockResolvedValue([
       {
-        pegawaiId: 1,
+        pegawaiId: '1',
         bulan: '1',
         status: STATUS.SELESAI_DIKERJAKAN,
         pegawai: { nama: 'A' },
       },
       {
-        pegawaiId: 1,
+        pegawaiId: '1',
         bulan: '2',
         status: STATUS.BELUM,
         pegawai: { nama: 'A' },
       },
       {
-        pegawaiId: 2,
+        pegawaiId: '2',
         bulan: '1',
         status: STATUS.SELESAI_DIKERJAKAN,
         pegawai: { nama: 'B' },
@@ -208,7 +208,7 @@ describe('MonitoringService aggregated', () => {
     const zero = { selesai: 0, total: 0, persen: 0 };
     expect(res).toEqual([
       {
-        userId: 1,
+        userId: '1',
         nama: 'A',
         months: [
           { selesai: 1, total: 1, persen: 100 },
@@ -217,7 +217,7 @@ describe('MonitoringService aggregated', () => {
         ],
       },
       {
-        userId: 2,
+        userId: '2',
         nama: 'B',
         months: [
           { selesai: 1, total: 1, persen: 100 },
@@ -231,13 +231,13 @@ describe('MonitoringService aggregated', () => {
     jest.useFakeTimers().setSystemTime(new Date('2024-05-10'));
     prisma.user.findMany.mockResolvedValue([
       {
-        id: 1,
+        id: '1',
         nama: 'A',
         role: ROLES.ANGGOTA,
         laporan: [{ tanggal: new Date('2024-05-02') }],
       },
       {
-        id: 2,
+        id: '2',
         nama: 'B',
         role: ROLES.KETUA,
         laporan: [{ tanggal: new Date('2024-05-05') }],
@@ -247,10 +247,10 @@ describe('MonitoringService aggregated', () => {
     const res = await service.laporanTerlambat();
 
     expect(res.day7).toEqual([
-      { userId: 1, nama: 'A', lastDate: '2024-05-02' },
+      { userId: '1', nama: 'A', lastDate: '2024-05-02' },
     ]);
     expect(res.day3).toEqual([
-      { userId: 2, nama: 'B', lastDate: '2024-05-05' },
+      { userId: '2', nama: 'B', lastDate: '2024-05-05' },
     ]);
     expect(res.day1).toEqual([]);
     jest.useRealTimers();
@@ -258,11 +258,11 @@ describe('MonitoringService aggregated', () => {
 
   it('laporanTerlambat merges role filter with team filter', async () => {
     prisma.user.findMany.mockResolvedValue([]);
-    await service.laporanTerlambat(1);
+    await service.laporanTerlambat('1');
     expect(prisma.user.findMany).toHaveBeenCalledWith({
       where: {
         NOT: { role: { in: [ROLES.ADMIN, ROLES.PIMPINAN] } },
-        members: { some: { teamId: 1 } },
+        members: { some: { teamId: '1' } },
       },
       include: { laporan: { orderBy: { tanggal: 'desc' }, take: 1 } },
       orderBy: { nama: 'asc' },

--- a/api/test/penugasan.service.spec.ts
+++ b/api/test/penugasan.service.spec.ts
@@ -18,13 +18,13 @@ describe("PenugasanService remove", () => {
 
   it("throws BadRequestException when laporan harian exists", async () => {
     prisma.penugasan.findUnique.mockResolvedValue({
-      id: 1,
-      kegiatan: { teamId: 2 },
+      id: '1',
+      kegiatan: { teamId: '2' },
     });
-    prisma.member.findFirst.mockResolvedValue({ id: 1 });
+    prisma.member.findFirst.mockResolvedValue({ id: '1' });
     prisma.laporanHarian.count.mockResolvedValue(1);
 
-    const action = service.remove(1, 1, "admin");
+    const action = service.remove('1', '1', "admin");
     await expect(action).rejects.toThrow(BadRequestException);
     await expect(action).rejects.toThrow(
       "Hapus laporan harian penugasan ini terlebih dahulu"

--- a/api/test/teams.service.spec.ts
+++ b/api/test/teams.service.spec.ts
@@ -15,24 +15,26 @@ beforeEach(() => {
 describe('TeamsService findOne', () => {
   it('throws NotFoundException when team missing', async () => {
     prisma.team.findUnique.mockResolvedValue(null);
-    await expect(service.findOne(1)).rejects.toThrow(NotFoundException);
+    await expect(service.findOne('1')).rejects.toThrow(NotFoundException);
   });
 
   it('returns team when found', async () => {
-    prisma.team.findUnique.mockResolvedValue({ id: 1 });
-    const res = await service.findOne(1);
-    expect(res).toEqual({ id: 1 });
+    prisma.team.findUnique.mockResolvedValue({ id: '1' });
+    const res = await service.findOne('1');
+    expect(res).toEqual({ id: '1' });
   });
 });
 
 describe('TeamsService addMember', () => {
   it('creates member with given data', async () => {
-    prisma.member.create.mockResolvedValue({ id: 2 });
-    const data = { user_id: 3, isLeader: true };
-    const res = await service.addMember(1, data);
-    expect(prisma.member.create).toHaveBeenCalledWith({
-      data: { teamId: 1, userId: 3, isLeader: true },
-    });
-    expect(res).toEqual({ id: 2 });
+    prisma.member.create.mockResolvedValue({ id: '2' });
+    const data = { user_id: '3', isLeader: true };
+    const res = await service.addMember('1', data);
+    expect(prisma.member.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ teamId: '1', userId: '3', isLeader: true }),
+      }),
+    );
+    expect(res).toEqual({ id: '2' });
   });
 });


### PR DESCRIPTION
## Summary
- use `ulid` IDs when seeding roles, users, teams, members, activities, assignments, and daily reports
- switch leader lookup and completion tracking to string-based maps/sets
- replace numeric ID math with `randomInt` selections
- recreate database tables with string `VARCHAR` identifiers to accept ULID-based seeds
- convert monitoring and penugasan modules to operate on string IDs and update tests accordingly

## Testing
- `npm test`
- `npm run lint` *(fails: 'IsInt' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_b_688ba8cdab2c832bb36d15d61fd70e7e