### PR TITLE
Prevent redundant tab updates

### DIFF
--- a/web/src/__tests__/MonitoringTabs.test.jsx
+++ b/web/src/__tests__/MonitoringTabs.test.jsx
@@ -1,5 +1,13 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import MonitoringTabs from "../pages/dashboard/components/MonitoringTabs";
+import months from "../utils/months";
+import userEvent from "@testing-library/user-event";
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
 
 jest.mock("../pages/dashboard/components/DailyOverview", () => () => (
   <div>Daily content</div>
@@ -32,4 +40,32 @@ test("switches between monitoring tabs", () => {
 
   fireEvent.click(screen.getByRole("tab", { name: /bulanan/i }));
   expect(screen.getByText(/Monthly content/i)).toBeInTheDocument();
+});
+
+test("changing month and week selections does not throw", async () => {
+  const onMonthChange = jest.fn();
+  const onWeekChange = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <MonitoringTabs
+      dailyData={[]}
+      weeklyList={[{ minggu: 1 }, { minggu: 2 }]}
+      weekIndex={0}
+      onWeekChange={onWeekChange}
+      monthIndex={0}
+      onMonthChange={onMonthChange}
+      monthlyData={[]}
+    />
+  );
+
+  await user.click(screen.getByRole("button", { name: months[0] }));
+  await user.click(await screen.findByText(months[1]));
+  expect(onMonthChange).toHaveBeenCalledWith(1);
+
+  await user.click(screen.getByRole("tab", { name: /mingguan/i }));
+
+  await user.click(screen.getByRole("button", { name: /Minggu 1/i }));
+  await user.click(await screen.findByText(/Minggu 2/i));
+  expect(onWeekChange).toHaveBeenCalledWith(1);
 });

--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -2,7 +2,7 @@ import MonitoringTabs from "./components/MonitoringTabs";
 import StatsSummary from "./components/StatsSummary";
 import { useAuth } from "../auth/useAuth";
 import axios from "axios";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { ROLES } from "../../utils/roles";
 import Button from "../../components/ui/Button";
 import { handleAxiosError } from "../../utils/alerts";
@@ -41,6 +41,24 @@ const Dashboard = () => {
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
   const [hasReportedToday, setHasReportedToday] = useState(false);
+
+  const handleMonthChange = useCallback(
+    (value) => {
+      if (value !== monthIndex) {
+        setMonthIndex(value);
+      }
+    },
+    [monthIndex]
+  );
+
+  const handleWeekChange = useCallback(
+    (value) => {
+      if (value !== weekIndex) {
+        setWeekIndex(value);
+      }
+    },
+    [weekIndex]
+  );
 
   useEffect(() => {
     const fetchAllData = async () => {
@@ -183,9 +201,9 @@ const Dashboard = () => {
         dailyData={dailyData}
         weeklyList={weeklyList}
         weekIndex={weekIndex}
-        onWeekChange={setWeekIndex}
+        onWeekChange={handleWeekChange}
         monthIndex={monthIndex}
-        onMonthChange={setMonthIndex}
+        onMonthChange={handleMonthChange}
         monthlyData={monthlyData}
       />
     </div>


### PR DESCRIPTION
## Summary
- memoize month and week handlers in Dashboard and pass them as callbacks
- add regression test ensuring monitoring tab selections don't throw

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688c1dfb0264832ba12a3aeba128275e