### PR TITLE
fix: avoid redundant week index update

### DIFF
--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -150,7 +150,7 @@ const Dashboard = () => {
           !!dailyRes.data.find((d) => d.tanggal === tanggal)?.adaKegiatan
         );
         setWeeklyList(normalizedWeeks);
-        setWeekIndex(currentIndex);
+        setWeekIndex((prev) => (prev !== currentIndex ? currentIndex : prev));
         setMonthlyData(monthlyRes.data);
       } catch (error) {
         if (error?.response && [401, 403].includes(error.response.status)) {


### PR DESCRIPTION
## Summary
- prevent unnecessary `weekIndex` updates in Dashboard fetch logic to avoid update-depth errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688c28f072a0832bb1ed31a1a814d959