### PR TITLE
refactor dashboard to use monthly aggregated monitoring

### DIFF
--- a/web/src/__tests__/MonitoringTabs.test.jsx
+++ b/web/src/__tests__/MonitoringTabs.test.jsx
@@ -3,7 +3,7 @@ import MonitoringTabs from "../pages/dashboard/components/MonitoringTabs";
 import months from "../utils/months";
 import userEvent from "@testing-library/user-event";
 
-global.ResizeObserver = class {
+globalThis.ResizeObserver = class {
   observe() {}
   unobserve() {}
   disconnect() {}


### PR DESCRIPTION
## Summary
- replace per-week monitoring calls with monthly aggregated endpoints in dashboard
- derive weekly summaries and assignments on the client
- fix test linting by scoping ResizeObserver to globalThis

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688c2cb001c4832bb2e9448329f858b0