### PR TITLE
Normalize daily dashboard data to include all days

### DIFF
--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -106,9 +106,34 @@ const Dashboard = () => {
         let partial = false;
 
         if (dailyRes.status === "fulfilled") {
-          setDailyData(dailyRes.value.data);
+          const apiDaily = Array.isArray(dailyRes.value.data)
+            ? dailyRes.value.data.filter(
+                (d) => d.tanggal && !isNaN(new Date(d.tanggal))
+              )
+            : [];
+
+          const apiMap = apiDaily.reduce((acc, cur) => {
+            acc[cur.tanggal] = cur;
+            return acc;
+          }, {});
+
+          const normalized = [];
+          for (
+            let d = new Date(monthStart);
+            d <= monthEnd;
+            d.setDate(d.getDate() + 1)
+          ) {
+            const tgl = formatISO(new Date(d));
+            normalized.push({
+              adaKegiatan: false,
+              ...apiMap[tgl],
+              tanggal: tgl,
+            });
+          }
+
+          setDailyData(normalized);
           setHasReportedToday(
-            !!dailyRes.value.data.find((d) => d.tanggal === tanggal)?.adaKegiatan
+            !!normalized.find((d) => d.tanggal === tanggal)?.adaKegiatan
           );
         } else {
           partial = true;


### PR DESCRIPTION
## Summary
- build complete date list for selected month and merge with daily API results
- default days to `adaKegiatan: false` and ensure `tanggal` validity
- feed normalized daily data into `MonitoringTabs`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688c3cf0abcc832b947bc9843e00dc13