### PR TITLE
Use locale-based date formatting for API requests

### DIFF
--- a/web/src/pages/dashboard/components/DailyOverview.jsx
+++ b/web/src/pages/dashboard/components/DailyOverview.jsx
@@ -11,7 +11,7 @@ const DailyOverview = ({ data = [] }) => {
     (day) => !isNaN(new Date(day.tanggal))
   );
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = new Date().toLocaleDateString("en-CA");
   const currentYear = new Date(today).getFullYear();
 
   const formatDate = (iso) => {

--- a/web/src/pages/dashboard/components/StatsSummary.jsx
+++ b/web/src/pages/dashboard/components/StatsSummary.jsx
@@ -4,7 +4,7 @@ import React from "react";
 const StatsSummary = ({ weeklyData }) => {
   if (!weeklyData) return null;
 
-  const todayStr = new Date().toISOString().slice(0, 10);
+  const todayStr = new Date().toLocaleDateString("en-CA");
   const today = weeklyData.detail?.find((d) => d.tanggal === todayStr) || {};
 
   const tugasHariIni = today.selesai || 0;

--- a/web/src/pages/monitoring/DailyMatrix.jsx
+++ b/web/src/pages/monitoring/DailyMatrix.jsx
@@ -40,7 +40,7 @@ const DailyMatrix = ({ data = [] }) => {
   if (!Array.isArray(data) || data.length === 0) return null;
 
   const year = new Date(data[0].detail[0].tanggal).getFullYear();
-  const today = new Date().toISOString().slice(0, 10);
+  const today = new Date().toLocaleDateString("en-CA");
   const HOLIDAYS = getHolidays(year);
 
   const isWeekend = (iso) => {

--- a/web/src/pages/monitoring/components/TabContent.jsx
+++ b/web/src/pages/monitoring/components/TabContent.jsx
@@ -35,8 +35,7 @@ export default function TabContent({
       try {
         setLoading(true);
         const first = new Date(new Date().getFullYear(), monthIndex, 1)
-          .toISOString()
-          .slice(0, 10);
+          .toLocaleDateString("en-CA");
         const res = await axios.get("/monitoring/harian/bulan", {
           params: { tanggal: first, teamId: teamId || undefined },
         });
@@ -55,7 +54,7 @@ export default function TabContent({
       if (!weekStarts.length || activeTab !== "mingguan") return;
       try {
         setLoading(true);
-        const minggu = weekStarts[weekIndex].toISOString().slice(0, 10);
+        const minggu = weekStarts[weekIndex].toLocaleDateString("en-CA");
         const res = await axios.get("/monitoring/mingguan/all", {
           params: { minggu, teamId: teamId || undefined },
         });
@@ -75,8 +74,7 @@ export default function TabContent({
       try {
         setLoading(true);
         const first = new Date(new Date().getFullYear(), monthIndex, 1)
-          .toISOString()
-          .slice(0, 10);
+          .toLocaleDateString("en-CA");
         const res = await axios.get("/monitoring/mingguan/bulan", {
           params: { tanggal: first, teamId: teamId || undefined },
         });

--- a/web/src/pages/penugasan/WeeklyTasksPage.jsx
+++ b/web/src/pages/penugasan/WeeklyTasksPage.jsx
@@ -11,7 +11,7 @@ export default function WeeklyTasksPage() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const today = new Date().toISOString().slice(0, 10);
+        const today = new Date().toLocaleDateString("en-CA");
         const res = await axios.get("/penugasan/minggu/all", { params: { minggu: today } });
         const list = [];
         (res.data || []).forEach((u) => {


### PR DESCRIPTION
## Summary
- Format current date using `toLocaleDateString('en-CA')` in dashboard and monitoring components.
- Use the same formatting when sending `tanggal` and `minggu` parameters to API endpoints.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688c43e663ec832b9b3015e3fb5b0715