### PR TITLE
fix: use stable key for daily matrix cells

### DIFF
--- a/web/src/pages/monitoring/DailyMatrix.jsx
+++ b/web/src/pages/monitoring/DailyMatrix.jsx
@@ -20,9 +20,9 @@ export const DailyMatrixRow = ({ user, boxClass, currentUser }) => {
       >
         {user.nama}
       </td>
-      {user.detail.map((day, i) => (
+      {user.detail.map((day) => (
         <td
-          key={i}
+          key={day.tanggal}
           title={day.count ? `${day.count} laporan` : ""}
           className={`px-4 py-2 border border-gray-300 dark:border-gray-600 ${boxClass(
             day


### PR DESCRIPTION
## Summary
- use date as key for DailyMatrix detail cells to ensure stable identity

## Testing
- `npm test --silent 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_b_688c43fbfa6c832b9b666bdbdec2b9c2