### PR TITLE
feat: handle empty bukti link and catatan

### DIFF
--- a/api/src/laporan/dto/submit-laporan.dto.ts
+++ b/api/src/laporan/dto/submit-laporan.dto.ts
@@ -1,3 +1,4 @@
+import { Transform } from "class-transformer";
 import { IsDateString, IsOptional, IsString } from "class-validator";
 
 export class SubmitLaporanDto {
@@ -17,10 +18,12 @@ export class SubmitLaporanDto {
   capaianKegiatan!: string;
 
   @IsOptional()
+  @Transform(({ value }) => (value === null || value === "" ? undefined : value))
   @IsString()
   buktiLink?: string;
 
   @IsOptional()
+  @Transform(({ value }) => (value === null || value === "" ? undefined : value))
   @IsString()
   catatan?: string;
 

--- a/api/src/laporan/dto/update-laporan.dto.ts
+++ b/api/src/laporan/dto/update-laporan.dto.ts
@@ -1,3 +1,4 @@
+import { Transform } from "class-transformer";
 import { IsDateString, IsOptional, IsString } from "class-validator";
 
 export class UpdateLaporanDto {
@@ -15,10 +16,12 @@ export class UpdateLaporanDto {
   capaianKegiatan?: string;
 
   @IsOptional()
+  @Transform(({ value }) => (value === null || value === "" ? undefined : value))
   @IsString()
   buktiLink?: string;
 
   @IsOptional()
+  @Transform(({ value }) => (value === null || value === "" ? undefined : value))
   @IsString()
   catatan?: string;
 


### PR DESCRIPTION
## Summary
- allow `buktiLink` and `catatan` to accept null or empty strings via transformer

## Testing
- `npm test`
- `JWT_SECRET=dummy DATABASE_URL=mysql://user:pass@localhost:3306/db node dist/src/main.js` *(fails: Prisma can't reach database)*

------
https://chatgpt.com/codex/tasks/task_b_688c7b1cbde8832bbed71d9195389429