### PR TITLE
chore: add payload logging for laporan submission

### DIFF
--- a/api/src/laporan/laporan.controller.ts
+++ b/api/src/laporan/laporan.controller.ts
@@ -34,6 +34,7 @@ export class LaporanController {
 
   @Post()
   submit(@Body() body: SubmitLaporanDto, @Req() req: Request) {
+    console.log('Payload:', body);
     const u = req.user as AuthRequestUser;
     return this.laporanService.submit(body, u.userId, u.role);
   }

--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -87,6 +87,7 @@ export class LaporanService {
     }
   }
   async submit(data: any, userId: string, role: string) {
+    console.log('Service Payload:', data);
     role = normalizeRole(role);
     if (role === ROLES.PIMPINAN) {
       throw new ForbiddenException("pimpinan tidak diizinkan");


### PR DESCRIPTION
## Summary
- log incoming payload in laporan controller
- log processed DTO in laporan service

## Testing
- `npm test`
- `npm run lint`
- `node -r dotenv/config dist/src/main.js` *(fails: PrismaClientInitializationError: Can't reach database server at `localhost:3306`)*

------
https://chatgpt.com/codex/tasks/task_b_688c7b1efe90832b816b7e66730467a6