### PR TITLE
feat: add laporan endpoint for additional tasks

### DIFF
--- a/api/src/laporan/dto/submit-tambahan-laporan.dto.ts
+++ b/api/src/laporan/dto/submit-tambahan-laporan.dto.ts
@@ -1,0 +1,27 @@
+import { IsDateString, IsOptional, IsString } from "class-validator";
+
+export class SubmitTambahanLaporanDto {
+  @IsDateString()
+  tanggal!: string;
+
+  @IsString()
+  status!: string;
+
+  @IsString()
+  deskripsi!: string;
+
+  @IsString()
+  capaianKegiatan!: string;
+
+  @IsOptional()
+  @IsString()
+  buktiLink?: string;
+
+  @IsOptional()
+  @IsString()
+  catatan?: string;
+
+  @IsOptional()
+  @IsString()
+  pegawaiId?: string;
+}

--- a/api/src/laporan/laporan.module.ts
+++ b/api/src/laporan/laporan.module.ts
@@ -10,5 +10,6 @@ import { NotificationsModule } from "../notifications/notifications.module";
   imports: [NotificationsModule],
   controllers: [LaporanController, TambahanController],
   providers: [PrismaService, LaporanService, TambahanService],
+  exports: [TambahanService],
 })
 export class LaporanModule {}

--- a/api/src/laporan/tugas-tambahan.controller.ts
+++ b/api/src/laporan/tugas-tambahan.controller.ts
@@ -4,11 +4,13 @@ import {
   Get,
   Body,
   UseGuards,
+  UsePipes,
   Req,
   Param,
   Query,
   Put,
   Delete,
+  ValidationPipe,
 } from "@nestjs/common";
 import { Request } from "express";
 import { TambahanService } from "./tugas-tambahan.service";
@@ -18,6 +20,7 @@ import { Roles } from "../common/guards/roles.decorator";
 import { ROLES } from "../common/roles.constants";
 import { AddTambahanDto } from "./dto/add-tambahan.dto";
 import { UpdateTambahanDto } from "./dto/update-tambahan.dto";
+import { SubmitTambahanLaporanDto } from "./dto/submit-tambahan-laporan.dto";
 import { AuthRequestUser } from "../common/auth-request-user.interface";
 
 @Controller("tugas-tambahan")
@@ -45,6 +48,17 @@ export class TambahanController {
     @Query('userId') userId?: string,
   ) {
     return this.tambahanService.getAll({ teamId, userId });
+  }
+
+  @Post(":id/laporan")
+  @UsePipes(new ValidationPipe({ whitelist: true }))
+  addLaporan(
+    @Param("id") id: string,
+    @Body() body: SubmitTambahanLaporanDto,
+    @Req() req: Request
+  ) {
+    const u = req.user as AuthRequestUser;
+    return this.tambahanService.addLaporan(id, body, u.userId, u.role);
   }
 
   @Get(":id")


### PR DESCRIPTION
## Summary
- allow submitting daily report for additional tasks via POST /tugas-tambahan/:id/laporan
- add SubmitTambahanLaporanDto for validation and service logic to persist report
- export TambahanService from LaporanModule

## Testing
- `npm test`
- `npx ts-node test-endpoint.ts` *(mocked Prisma/guards, expecting HTTP 201)*

------
https://chatgpt.com/codex/tasks/task_b_688c7b2076dc832ba8a4cd06e74d0cfd