### PR TITLE
Normalize daily monitoring dates

### DIFF
--- a/web/src/__tests__/Dashboard.test.jsx
+++ b/web/src/__tests__/Dashboard.test.jsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Dashboard from '../pages/dashboard/Dashboard';
+import { useAuth } from '../pages/auth/useAuth';
+import axios from 'axios';
+
+jest.mock('axios');
+jest.mock('../pages/auth/useAuth');
+jest.mock('../pages/dashboard/components/StatsSummary', () => () => <div />);
+jest.mock('../pages/dashboard/components/MonitoringTabs', () => {
+  const React = require('react');
+  const DailyOverview = require('../pages/dashboard/components/DailyOverview').default;
+  return ({ dailyData }) => <DailyOverview data={dailyData} />;
+});
+
+const mockedUseAuth = useAuth;
+
+beforeAll(() => {
+  jest.useFakeTimers().setSystemTime(new Date('2024-04-15T00:00:00.000Z'));
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+test('dates with reports appear green', async () => {
+  mockedUseAuth.mockReturnValue({ user: { role: 'admin' } });
+  axios.get.mockImplementation((url) => {
+    if (url === '/monitoring/harian') {
+      return Promise.resolve({
+        data: [{ tanggal: '2024-04-02T00:00:00.000Z', adaKegiatan: true }],
+      });
+    }
+    if (url === '/monitoring/mingguan') {
+      return Promise.resolve({
+        data: {
+          tanggal: '2024-04-01 - 2024-04-07',
+          detail: [],
+          totalSelesai: 0,
+          totalTugas: 0,
+          totalProgress: 0,
+        },
+      });
+    }
+    if (url === '/monitoring/bulanan') {
+      return Promise.resolve({ data: [] });
+    }
+    if (url === '/monitoring/penugasan/minggu') {
+      return Promise.resolve({ data: {} });
+    }
+    return Promise.resolve({ data: [] });
+  });
+
+  render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>
+  );
+
+  const dayText = await screen.findByText(/02 April 2024/);
+  const dayBox = dayText.parentElement;
+  expect(dayBox).toHaveClass('bg-green-100');
+});
+

--- a/web/src/pages/dashboard/Dashboard.jsx
+++ b/web/src/pages/dashboard/Dashboard.jsx
@@ -100,7 +100,7 @@ const Dashboard = () => {
 
         const [dailyRes, weeklyArrayRes, monthlyRes, tugasArrayRes] =
           await Promise.allSettled([
-            axios.get("/monitoring/harian/bulan", {
+            axios.get("/monitoring/harian", {
               params: { tanggal: formatISO(monthStart), ...filters },
             }),
             Promise.allSettled(weeklyPromises),
@@ -120,7 +120,8 @@ const Dashboard = () => {
             : [];
 
           const apiMap = apiDaily.reduce((acc, cur) => {
-            acc[cur.tanggal] = cur;
+            const key = new Date(cur.tanggal).toISOString().slice(0, 10);
+            acc[key] = { ...cur, tanggal: key };
             return acc;
           }, {});
 
@@ -131,11 +132,9 @@ const Dashboard = () => {
             d.setDate(d.getDate() + 1)
           ) {
             const tgl = formatISO(new Date(d));
-            normalized.push({
-              adaKegiatan: false,
-              ...apiMap[tgl],
-              tanggal: tgl,
-            });
+            normalized.push(
+              apiMap[tgl] || { adaKegiatan: false, tanggal: tgl }
+            );
           }
 
           setDailyData(normalized);


### PR DESCRIPTION
## Summary
- fetch daily monitoring data from `/monitoring/harian`
- normalize `tanggal` keys when building daily data so activity flags copy correctly
- add dashboard test ensuring reported days are highlighted

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689780040a94832b99b2dd822a637304