### PR TITLE
feat: add EmptyState component

### DIFF
--- a/web/src/components/ui/EmptyState.jsx
+++ b/web/src/components/ui/EmptyState.jsx
@@ -1,0 +1,28 @@
+import { ClipboardDocumentListIcon } from "@heroicons/react/24/outline";
+import Button from "./Button";
+
+export default function EmptyState({
+  icon = ClipboardDocumentListIcon,
+  title = "Tidak ada data",
+  message = "",
+  actionLabel,
+  onAction,
+}) {
+  const Icon = icon;
+  return (
+    <div className="py-10 flex flex-col items-center text-center">
+      <Icon className="h-12 w-12 text-gray-400 dark:text-gray-500" />
+      <h3 className="mt-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+        {title}
+      </h3>
+      {message && (
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">{message}</p>
+      )}
+      {actionLabel && onAction && (
+        <Button className="mt-6" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -28,6 +28,7 @@ import TableSkeleton from "../../components/ui/TableSkeleton";
 import { AnimatePresence, motion as Motion } from "framer-motion";
 import Spinner from "../../components/Spinner";
 import { STATUS } from "../../utils/status";
+import EmptyState from "../../components/ui/EmptyState";
 
 const EXCLUDED_TB_NAMES = ["Ayu Pinta Gabina Siregar", "Elly Astutik"];
 
@@ -71,7 +72,7 @@ export default function PenugasanPage() {
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(""); // NEW: error state
-  const { showForm, form, setForm, openCreate, closeForm, resetForm } =
+  const { showForm, form, setForm, openCreate: openForm, closeForm, resetForm } =
     useModalForm({
       kegiatanId: "",
       pegawaiIds: [],
@@ -390,7 +391,7 @@ export default function PenugasanPage() {
           </select>
           {canManage && (
             <Button
-              onClick={openCreate}
+              onClick={openForm}
               className="flex gap-2 items-center shadow-sm"
               variant="primary"
             >
@@ -414,10 +415,11 @@ export default function PenugasanPage() {
             </Button>
           </div>
         ) : paginated.length === 0 ? (
-          <div className="py-10 flex flex-col items-center text-gray-400 dark:text-gray-500">
-            <span className="mb-2 text-2xl">🙁</span>
-            <span className="text-sm">Belum ada penugasan ditemukan.</span>
-          </div>
+          <EmptyState
+            message="Belum ada penugasan untuk minggu ini"
+            actionLabel="Tambah Penugasan"
+            onAction={openForm}
+          />
         ) : (
           <DataTable
             columns={columns}


### PR DESCRIPTION
## Summary
- add reusable EmptyState component with action button
- show EmptyState when no weekly assignments on PenugasanPage

## Testing
- `npm test`
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*
- `npx eslint src/components/ui/EmptyState.jsx src/pages/penugasan/PenugasanPage.jsx`

------
https://chatgpt.com/codex/tasks/task_b_689780132b44832bbb5de3aaa17c0aa3