### PR TITLE
Handle empty data in weekly monitoring tables

### DIFF
--- a/web/src/pages/monitoring/WeeklyMatrix.jsx
+++ b/web/src/pages/monitoring/WeeklyMatrix.jsx
@@ -61,8 +61,7 @@ const WeeklyMatrix = ({
   selectedWeek,
 }) => {
   const { user: currentUser } = useAuth();
-  if (!Array.isArray(data) || data.length === 0) return null;
-
+  const safeData = Array.isArray(data) ? data : [];
   const progressColor = getProgressColor;
 
   return (
@@ -89,15 +88,26 @@ const WeeklyMatrix = ({
           </tr>
         </thead>
         <tbody>
-          {data.map((u) => (
-            <WeeklyMatrixRow
-              key={u.userId}
-              user={u}
-              progressColor={progressColor}
-              weekCount={weeks.length}
-              currentUser={currentUser}
-            />
-          ))}
+          {safeData.length === 0 ? (
+            <tr>
+              <td
+                colSpan={weeks.length + 1}
+                className="p-4 text-center text-gray-500"
+              >
+                Belum ada data
+              </td>
+            </tr>
+          ) : (
+            safeData.map((u) => (
+              <WeeklyMatrixRow
+                key={u.userId}
+                user={u}
+                progressColor={progressColor}
+                weekCount={weeks.length}
+                currentUser={currentUser}
+              />
+            ))
+          )}
         </tbody>
       </table>
     </div>

--- a/web/src/pages/monitoring/components/WeeklyProgressTable.jsx
+++ b/web/src/pages/monitoring/components/WeeklyProgressTable.jsx
@@ -4,8 +4,7 @@ import { useAuth } from "../../auth/useAuth";
 
 const WeeklyProgressTable = ({ data = [] }) => {
   const { user: currentUser } = useAuth();
-  if (!Array.isArray(data) || data.length === 0) return null;
-
+  const rows = Array.isArray(data) ? data : [];
   const progressColor = getProgressColor;
 
   return (
@@ -26,50 +25,61 @@ const WeeklyProgressTable = ({ data = [] }) => {
           </tr>
         </thead>
         <tbody>
-          {data.map((u) => {
-            const isCurrentUser =
-              currentUser &&
-              (u.userId === currentUser.id || u.nama === currentUser.nama);
-
-            return (
-              <tr
-                key={u.userId}
-                className={`text-center transition-colors duration-200 border-b border-gray-200 dark:border-gray-700 ${
-                  isCurrentUser
-                    ? "bg-yellow-50 dark:bg-yellow-900 border-l-4 border-yellow-400"
-                    : "hover:bg-gray-100 dark:hover:bg-gray-700"
-                }`}
+          {rows.length === 0 ? (
+            <tr>
+              <td
+                colSpan={4}
+                className="p-4 text-center text-gray-500"
               >
-                <td
-                  className="sticky left-0 bg-white dark:bg-gray-800 z-10 px-4 py-2 text-left font-semibold border-r border-gray-300 dark:border-gray-700 w-60 md:w-72 whitespace-nowrap overflow-hidden text-ellipsis"
-                  title={u.nama}
+                Belum ada data
+              </td>
+            </tr>
+          ) : (
+            rows.map((u) => {
+              const isCurrentUser =
+                currentUser &&
+                (u.userId === currentUser.id || u.nama === currentUser.nama);
+
+              return (
+                <tr
+                  key={u.userId}
+                  className={`text-center transition-colors duration-200 border-b border-gray-200 dark:border-gray-700 ${
+                    isCurrentUser
+                      ? "bg-yellow-50 dark:bg-yellow-900 border-l-4 border-yellow-400"
+                      : "hover:bg-gray-100 dark:hover:bg-gray-700"
+                  }`}
                 >
-                  {u.nama}
-                </td>
-                <td className="px-4 py-2 border-r">{u.selesai}</td>
-                <td className="px-4 py-2 border-r">{u.total}</td>
-                <td className="px-4 py-2 border-r space-y-1">
-                  <div
-                    role="progressbar"
-                    aria-valuenow={u.persen}
-                    aria-valuemin="0"
-                    aria-valuemax="100"
-                    className="w-full bg-gray-200 dark:bg-gray-700 rounded h-2 overflow-hidden"
+                  <td
+                    className="sticky left-0 bg-white dark:bg-gray-800 z-10 px-4 py-2 text-left font-semibold border-r border-gray-300 dark:border-gray-700 w-60 md:w-72 whitespace-nowrap overflow-hidden text-ellipsis"
+                    title={u.nama}
                   >
+                    {u.nama}
+                  </td>
+                  <td className="px-4 py-2 border-r">{u.selesai}</td>
+                  <td className="px-4 py-2 border-r">{u.total}</td>
+                  <td className="px-4 py-2 border-r space-y-1">
                     <div
-                      className={`${progressColor(
-                        u.persen
-                      )} h-2 transition-all duration-300`}
-                      style={{ width: `${u.persen}%` }}
-                    />
-                  </div>
-                  <span className="text-xs font-medium text-center block">
-                    {u.persen}%
-                  </span>
-                </td>
-              </tr>
-            );
-          })}
+                      role="progressbar"
+                      aria-valuenow={u.persen}
+                      aria-valuemin="0"
+                      aria-valuemax="100"
+                      className="w-full bg-gray-200 dark:bg-gray-700 rounded h-2 overflow-hidden"
+                    >
+                      <div
+                        className={`${progressColor(
+                          u.persen
+                        )} h-2 transition-all duration-300`}
+                        style={{ width: `${u.persen}%` }}
+                      />
+                    </div>
+                    <span className="text-xs font-medium text-center block">
+                      {u.persen}%
+                    </span>
+                  </td>
+                </tr>
+              );
+            })
+          )}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- render WeeklyMatrix and WeeklyProgressTable even without data
- show "Belum ada data" placeholder rows when lists are empty

## Testing
- `npm test`
- `npm run lint` *(fails: react-refresh/only-export-components in MonitoringPage.jsx)*

------
https://chatgpt.com/codex/tasks/task_b_6897803504e4832ba8f2dd89cbf0fa21