### PR TITLE
Center date cells in daily monitoring table

### DIFF
--- a/web/src/__tests__/DailyMatrix.test.jsx
+++ b/web/src/__tests__/DailyMatrix.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import DailyMatrix from '../pages/monitoring/DailyMatrix';
+import { useAuth } from '../pages/auth/useAuth';
+
+jest.mock('../pages/auth/useAuth');
+
+const mockedUseAuth = useAuth;
+
+it('centers day cells', () => {
+  mockedUseAuth.mockReturnValue({ user: null });
+  const data = [
+    {
+      userId: 1,
+      nama: 'User 1',
+      detail: [
+        { tanggal: '2024-04-01T00:00:00.000Z', count: 1 }
+      ]
+    }
+  ];
+  render(<DailyMatrix data={data} monthIndex={3} year={2024} />);
+  const cell = screen.getByRole('cell', { name: '1' });
+  expect(cell).toHaveClass('text-center');
+});

--- a/web/src/__tests__/Dashboard.test.jsx
+++ b/web/src/__tests__/Dashboard.test.jsx
@@ -8,7 +8,9 @@ jest.mock('axios');
 jest.mock('../pages/auth/useAuth');
 jest.mock('../pages/dashboard/components/StatsSummary', () => () => <div />);
 jest.mock('../pages/dashboard/components/MonitoringTabs', () => {
+  // eslint-disable-next-line no-undef
   const React = require('react');
+  // eslint-disable-next-line no-undef
   const DailyOverview = require('../pages/dashboard/components/DailyOverview').default;
   return ({ dailyData }) => <DailyOverview data={dailyData} />;
 });

--- a/web/src/pages/monitoring/DailyMatrix.jsx
+++ b/web/src/pages/monitoring/DailyMatrix.jsx
@@ -25,7 +25,7 @@ export const DailyMatrixRow = ({ user, boxClass, currentUser }) => {
         <td
           key={day.tanggal}
           title={day.count ? `${day.count} laporan` : ""}
-          className={`px-4 py-2 border border-gray-300 dark:border-gray-600 ${boxClass(
+          className={`px-4 py-2 border border-gray-300 dark:border-gray-600 text-center ${boxClass(
             day
           )} truncate`}
         >

--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -12,6 +12,7 @@ import dayjs from "../../utils/dayjs";
 const formatWita = (iso) =>
   dayjs.utc(iso).tz("Asia/Makassar").format("DD MMM YYYY HH:mm:ss");
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const getWeekStarts = (month, year) => {
   const firstOfMonth = new Date(Date.UTC(year, month, 1));
   const monthEnd = new Date(Date.UTC(year, month + 1, 0));


### PR DESCRIPTION
## Summary
- center daily monitoring date cells for clearer alignment
- add tests verifying daily cells are centered

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897844c6898832bac3e491c996b993b