### PR TITLE
test: cover monitoring zero-data cases

### DIFF
--- a/api/src/monitoring/monitoring.service.ts
+++ b/api/src/monitoring/monitoring.service.ts
@@ -207,6 +207,25 @@ export class MonitoringService {
     ).filter((r: { pegawai?: { username?: string } }) =>
       !r.pegawai?.username?.startsWith("demo"),
     );
+    if (records.length === 0) {
+      const users =
+        (await this.prisma.user.findMany({
+          where: teamId ? { members: { some: { teamId } } } : {},
+          orderBy: { nama: "asc" },
+        })) || [];
+      return users
+        .filter((u: { username?: string }) =>
+          !u.username?.startsWith("demo"),
+        )
+        .map((u: { id: string; nama: string }) => {
+          const detail = [] as { tanggal: string; count: number }[];
+          for (let d = 1; d <= end.getUTCDate(); d++) {
+            const date = new Date(Date.UTC(year, month, d));
+            detail.push({ tanggal: date.toISOString(), count: 0 });
+          }
+          return { userId: u.id, nama: u.nama, detail };
+        });
+    }
 
     const byUser: Record<
       string,
@@ -255,6 +274,24 @@ export class MonitoringService {
     ).filter((r: { pegawai?: { username?: string } }) =>
       !r.pegawai?.username?.startsWith("demo"),
     );
+    if (records.length === 0) {
+      const users =
+        (await this.prisma.user.findMany({
+          where: teamId ? { members: { some: { teamId } } } : {},
+          orderBy: { nama: "asc" },
+        })) || [];
+      return users
+        .filter((u: { username?: string }) =>
+          !u.username?.startsWith("demo"),
+        )
+        .map((u: { id: string; nama: string }) => ({
+          userId: u.id,
+          nama: u.nama,
+          selesai: 0,
+          total: 0,
+          persen: 0,
+        }));
+    }
 
     const byUser: Record<
       string,
@@ -305,6 +342,24 @@ export class MonitoringService {
     ).filter((r: { pegawai?: { username?: string } }) =>
       !r.pegawai?.username?.startsWith("demo"),
     );
+    if (records.length === 0) {
+      const users =
+        (await this.prisma.user.findMany({
+          where: teamId ? { members: { some: { teamId } } } : {},
+          orderBy: { nama: "asc" },
+        })) || [];
+      return users
+        .filter((u: { username?: string }) =>
+          !u.username?.startsWith("demo"),
+        )
+        .map((u: { id: string; nama: string }) => ({
+          userId: u.id,
+          nama: u.nama,
+          selesai: 0,
+          total: 0,
+          persen: 0,
+        }));
+    }
 
     const byUser: Record<
       string,
@@ -363,6 +418,27 @@ export class MonitoringService {
     ).filter((r: { pegawai?: { username?: string } }) =>
       !r.pegawai?.username?.startsWith("demo"),
     );
+    if (records.length === 0) {
+      const users =
+        (await this.prisma.user.findMany({
+          where: teamId ? { members: { some: { teamId } } } : {},
+          orderBy: { nama: "asc" },
+        })) || [];
+      const emptyWeeks = weekStarts.map(() => ({
+        selesai: 0,
+        total: 0,
+        persen: 0,
+      }));
+      return users
+        .filter((u: { username?: string }) =>
+          !u.username?.startsWith("demo"),
+        )
+        .map((u: { id: string; nama: string }) => ({
+          userId: u.id,
+          nama: u.nama,
+          weeks: emptyWeeks,
+        }));
+    }
 
     const byUser: Record<
       string,

--- a/api/test/monitoring.service.spec.ts
+++ b/api/test/monitoring.service.spec.ts
@@ -27,6 +27,19 @@ describe('MonitoringService aggregated', () => {
     ]);
   });
 
+  it('harianAll returns zero metrics for all users when no reports', async () => {
+    prisma.laporanHarian.findMany.mockResolvedValue([]);
+    prisma.user.findMany.mockResolvedValue([
+      { id: '1', nama: 'A' },
+      { id: '2', nama: 'B' },
+    ]);
+    const res = await service.harianAll('2024-05-01');
+    expect(res).toEqual([
+      { userId: '1', nama: 'A', selesai: 0, total: 0, persen: 0 },
+      { userId: '2', nama: 'B', selesai: 0, total: 0, persen: 0 },
+    ]);
+  });
+
   it('mingguanAll aggregates and sorts', async () => {
     prisma.laporanHarian.findMany.mockResolvedValue([
       { pegawaiId: '2', status: STATUS.SELESAI_DIKERJAKAN, pegawai: { nama: 'B' } },
@@ -37,6 +50,19 @@ describe('MonitoringService aggregated', () => {
     expect(res).toEqual([
       { userId: '1', nama: 'A', selesai: 1, total: 2, persen: 50 },
       { userId: '2', nama: 'B', selesai: 1, total: 1, persen: 100 },
+    ]);
+  });
+
+  it('mingguanAll returns zero metrics for all users when no reports', async () => {
+    prisma.laporanHarian.findMany.mockResolvedValue([]);
+    prisma.user.findMany.mockResolvedValue([
+      { id: '1', nama: 'A' },
+      { id: '2', nama: 'B' },
+    ]);
+    const res = await service.mingguanAll('2024-05-01');
+    expect(res).toEqual([
+      { userId: '1', nama: 'A', selesai: 0, total: 0, persen: 0 },
+      { userId: '2', nama: 'B', selesai: 0, total: 0, persen: 0 },
     ]);
   });
 
@@ -94,6 +120,23 @@ describe('MonitoringService aggregated', () => {
     expect(res[1].detail[0]).toEqual({ tanggal: '2024-05-01T00:00:00.000Z', count: 1 });
   });
 
+  it('harianBulan returns zero counts for all users when no reports', async () => {
+    prisma.laporanHarian.findMany.mockResolvedValue([]);
+    prisma.user.findMany.mockResolvedValue([
+      { id: '1', nama: 'A' },
+      { id: '2', nama: 'B' },
+    ]);
+    const res = await service.harianBulan('2024-05-10');
+    const zeroDetail = Array.from({ length: 31 }, (_, i) => ({
+      tanggal: new Date(Date.UTC(2024, 4, i + 1)).toISOString(),
+      count: 0,
+    }));
+    expect(res).toEqual([
+      { userId: '1', nama: 'A', detail: zeroDetail },
+      { userId: '2', nama: 'B', detail: zeroDetail },
+    ]);
+  });
+
   it('mingguanBulan aggregates per week', async () => {
     prisma.laporanHarian.findMany.mockResolvedValue([
       {
@@ -139,6 +182,21 @@ describe('MonitoringService aggregated', () => {
           { selesai: 0, total: 0, persen: 0 },
         ],
       },
+    ]);
+  });
+
+  it('mingguanBulan returns zero weeks for all users when no reports', async () => {
+    prisma.laporanHarian.findMany.mockResolvedValue([]);
+    prisma.user.findMany.mockResolvedValue([
+      { id: '1', nama: 'A' },
+      { id: '2', nama: 'B' },
+    ]);
+    const res = await service.mingguanBulan('2024-05-10');
+    const zeroWeeks = () =>
+      Array.from({ length: 5 }, () => ({ selesai: 0, total: 0, persen: 0 }));
+    expect(res).toEqual([
+      { userId: '1', nama: 'A', weeks: zeroWeeks() },
+      { userId: '2', nama: 'B', weeks: zeroWeeks() },
     ]);
   });
 


### PR DESCRIPTION
## Summary
- handle zero-report scenarios in monitoring service so all users are returned with zeroed metrics
- add tests for no-data cases in harianAll, mingguanAll, harianBulan, and mingguanBulan

## Testing
- `cd api && npm test`

------
https://chatgpt.com/codex/tasks/task_b_689786b2f5d4832bb32f31baf06e53e6