### PR TITLE
test: cover full screen loading overlay

### DIFF
--- a/web/src/__tests__/Loading.test.jsx
+++ b/web/src/__tests__/Loading.test.jsx
@@ -12,3 +12,9 @@ it('supports custom message and size', () => {
   const svg = container.querySelector('svg');
   expect(svg).toHaveClass('h-8 w-8');
 });
+
+it('renders full screen overlay', () => {
+  const { container } = render(<Loading fullScreen />);
+  const overlay = container.firstChild;
+  expect(overlay).toHaveClass('fixed', 'inset-0');
+});


### PR DESCRIPTION
## Summary
- test full-screen Loading overlay renders with fixed inset-0 container

## Testing
- `cd web && npm test`


------
https://chatgpt.com/codex/tasks/task_b_689930a2389883328d240cde7dfaefb8