### PR TITLE
Filter hidden users from monitoring data

### DIFF
--- a/web/src/pages/monitoring/components/TabContent.jsx
+++ b/web/src/pages/monitoring/components/TabContent.jsx
@@ -16,6 +16,10 @@ export default function TabContent({
   year,
   teamId = "",
 }) {
+  const isHiddenUser = ({ nama, role }) =>
+    (nama === "Admin Utama" && role === "admin") ||
+    (nama === "Yuda Agus Irianto" && role === "pimpinan");
+
   const [loading, setLoading] = useState(false);
   const [dailyData, setDailyData] = useState([]);
   const [weeklyMonthData, setWeeklyMonthData] = useState([]);
@@ -38,7 +42,7 @@ export default function TabContent({
         const res = await axios.get("/monitoring/harian/bulan", {
           params: { tanggal: first, teamId: teamId || undefined },
         });
-        setDailyData(res.data);
+        setDailyData(res.data.filter((u) => !isHiddenUser(u)));
       } catch (err) {
         handleAxiosError(err, "Gagal mengambil monitoring harian");
       } finally {
@@ -57,7 +61,7 @@ export default function TabContent({
         const res = await axios.get("/monitoring/mingguan/all", {
           params: { minggu, teamId: teamId || undefined },
         });
-        setWeeklyData(res.data);
+        setWeeklyData(res.data.filter((u) => !isHiddenUser(u)));
       } catch (err) {
         handleAxiosError(err, "Gagal mengambil monitoring mingguan");
       } finally {
@@ -76,7 +80,7 @@ export default function TabContent({
         const res = await axios.get("/monitoring/mingguan/bulan", {
           params: { tanggal: first, teamId: teamId || undefined },
         });
-        setWeeklyMonthData(res.data);
+        setWeeklyMonthData(res.data.filter((u) => !isHiddenUser(u)));
       } catch (err) {
         handleAxiosError(err, "Gagal mengambil monitoring mingguan per bulan");
       } finally {


### PR DESCRIPTION
## Summary
- add `isHiddenUser` helper to flag specific users
- filter out hidden users when loading daily and weekly monitoring data

## Testing
- `cd web && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68993bf2c4d08332a83e0c492a7c7484