### PR TITLE
fix migration table name

### DIFF
--- a/api/prisma/migrations/20250829001757_widen_deskripsi_text/migration.sql
+++ b/api/prisma/migrations/20250829001757_widen_deskripsi_text/migration.sql
@@ -1,5 +1,5 @@
 -- DropForeignKey
-ALTER TABLE `laporanharian` DROP FOREIGN KEY `LaporanHarian_penugasanId_fkey`;
+ALTER TABLE `LaporanHarian` DROP FOREIGN KEY `LaporanHarian_penugasanId_fkey`;
 
 -- AddForeignKey
 ALTER TABLE `LaporanHarian` ADD CONSTRAINT `LaporanHarian_penugasanId_fkey` FOREIGN KEY (`penugasanId`) REFERENCES `Penugasan`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary
- ensure migration alters LaporanHarian table with correct casing

## Testing
- `docker-compose build backend` *(fails: ConnectionRefusedError: [Errno 111] Connection refused)*
- `docker-compose exec backend npx prisma migrate resolve --rolled-back 20250829001757_widen_deskripsi_text` *(fails: ConnectionRefusedError: [Errno 111] Connection refused)*
- `docker-compose exec backend npx prisma migrate deploy` *(fails: ConnectionRefusedError: [Errno 111] Connection refused)*
- `npm test --workspace api` *(fails: Cannot find module 'jest-util')*

------
https://chatgpt.com/codex/tasks/task_b_68b47f87335083328a609b9e3a394794