### PR TITLE
Fix table name casing in Prisma migration

### DIFF
--- a/api/prisma/migrations/20250829022910_widen_capaian_kegiatan/migration.sql
+++ b/api/prisma/migrations/20250829022910_widen_capaian_kegiatan/migration.sql
@@ -2,4 +2,4 @@
 ALTER TABLE `kegiatantambahan` MODIFY `capaianKegiatan` TEXT NOT NULL;
 
 -- AlterTable
-ALTER TABLE `laporanharian` MODIFY `capaianKegiatan` TEXT NOT NULL;
+ALTER TABLE `LaporanHarian` MODIFY `capaianKegiatan` TEXT NOT NULL;


### PR DESCRIPTION
## Summary
- use correct `LaporanHarian` table name in migration file

## Testing
- `docker-compose exec backend npx prisma migrate deploy` *(fails: ConnectionRefusedError (Docker daemon not running))*

------
https://chatgpt.com/codex/tasks/task_b_68b47f89213883328525f029d0bf5189