### PR TITLE
chore(api): use node16 module resolution

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "Node16",
     "target": "ES2020",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "outDir": "./dist",
     "rootDir": "./",
     "strict": true,


### PR DESCRIPTION
## Summary
- update API TypeScript config to Node16 module resolution and module

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module 'jest-util')*

------
https://chatgpt.com/codex/tasks/task_b_68b51b8b07e08332955f10d808ad1153