### PR TITLE
refactor: use base url env

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -10,6 +10,8 @@ const userPhones: Record<string, string> = userPhonesData;
 
 const prisma = new PrismaClient();
 
+const BASE_URL = process.env.BASE_URL || "https://semakin.databenuanta.id";
+
 const BASE_DATE = new Date("2025-08-17T00:00:00Z");
 BASE_DATE.setUTCHours(0, 0, 0, 0);
 
@@ -506,9 +508,7 @@ async function main() {
         tanggal: date.toISOString(),
         status,
         buktiLink:
-          status === STATUS.BELUM
-            ? undefined
-            : "https://example.com/bukti",
+          status === STATUS.BELUM ? undefined : `${BASE_URL}/bukti`,
         userId: m.userId,
         kegiatanId: k.id,
         teamId: m.teamId,
@@ -532,7 +532,7 @@ async function main() {
       status: t.status,
       capaianKegiatan: t.capaianKegiatan,
       buktiLink:
-        t.status === STATUS.BELUM ? undefined : "https://example.com/bukti",
+        t.status === STATUS.BELUM ? undefined : `${BASE_URL}/bukti`,
     }));
 
     await prisma.laporanHarian.createMany({
@@ -628,7 +628,7 @@ async function main() {
                 tanggal: date.toISOString(),
                 status: STATUS.SELESAI_DIKERJAKAN,
                 capaianKegiatan: `Capaian ${p.id}`,
-                buktiLink: "https://example.com/bukti",
+                buktiLink: `${BASE_URL}/bukti`,
               });
               selesaiIds.add(p.id);
             }
@@ -702,7 +702,7 @@ async function main() {
           tanggal: tanggal.toISOString(),
           status: STATUS.SELESAI_DIKERJAKAN,
           capaianKegiatan: `Capaian ${penugasan.id}`,
-          buktiLink: "https://semakin.databenuanta.id",
+          buktiLink: BASE_URL,
         },
       });
     }

--- a/api/test/whatsapp.service.spec.ts
+++ b/api/test/whatsapp.service.spec.ts
@@ -1,6 +1,8 @@
 import { WhatsappService } from "../src/notifications/whatsapp.service";
 import { ConfigService } from "@nestjs/config";
 
+const BASE_URL = process.env.BASE_URL || "https://semakin.databenuanta.id";
+
 describe("WhatsappService retries", () => {
   let service: WhatsappService;
   let fetchMock: jest.Mock;
@@ -12,7 +14,7 @@ describe("WhatsappService retries", () => {
           return "token";
         }
         if (key === "WHATSAPP_API_URL") {
-          return "https://semakin.databenuanta.id";
+          return BASE_URL;
         }
         return undefined;
       },

--- a/web/src/__tests__/TugasTambahanDetailPage.test.jsx
+++ b/web/src/__tests__/TugasTambahanDetailPage.test.jsx
@@ -4,6 +4,8 @@ import axios from "axios";
 
 jest.mock("axios");
 
+const BASE_URL = process.env.BASE_URL || "https://semakin.databenuanta.id";
+
 const mockNavigate = jest.fn();
 
 jest.mock("react-router-dom", () => ({
@@ -50,7 +52,7 @@ test("renders fields in correct order with grid layout", async () => {
           deskripsi: "Desc",
           kegiatan: { team: { namaTim: "Tim A" } },
           tanggalSelesai: "2024-01-05",
-          buktiLink: "https://semakin.databenuanta.id",
+          buktiLink: BASE_URL,
         },
       });
     }


### PR DESCRIPTION
## Summary
- replace hardcoded WhatsApp API URL in tests with BASE_URL env fallback
- use BASE_URL env for buktiLink generation in seed script
- swap TugasTambahanDetailPage test buktiLink to BASE_URL env

## Testing
- `npm test --workspaces` *(fails: Cannot find module 'jest-util'; 4 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_b_68b51bafdcc48332a0bd6a7e236bcdcb