### PR TITLE
Load WEB_URL from environment

### DIFF
--- a/.env
+++ b/.env
@@ -11,5 +11,6 @@ CORS_ORIGIN=https://semakin.databenuanta.id
 THROTTLE_TTL=900
 THROTTLE_LIMIT=1000
 VITE_API_URL=https://semakin.databenuanta.id
+WEB_URL=https://semakin.databenuanta.id
 FONNTE_TOKEN=pqQyusYWGSavsKMk9qAR
 WHATSAPP_API_URL=https://api.fonnte.com/send

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ SEMAKIN 6502 (Sistem Monitoring Kinerja) adalah aplikasi internal untuk mencata
 
 Sistem hanya mengenali keempat peran di atas.
 
+## Konfigurasi Lingkungan
+
+Beberapa pengaturan aplikasi dibaca dari berkas `.env`. Tambahkan entri berikut:
+
+- `WEB_URL` – URL dasar frontend yang digunakan backend untuk membentuk tautan pada notifikasi.
+
 ## Alur Penggunaan Umum
 
 1. **Admin** membuat tim dan akun pegawai.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       THROTTLE_LIMIT: ${THROTTLE_LIMIT}
       FONNTE_TOKEN: ${FONNTE_TOKEN}
       WHATSAPP_API_URL: ${WHATSAPP_API_URL}
-      WEB_URL: https://semakin.databenuanta.id
+      WEB_URL: ${WEB_URL}
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## Summary
- read WEB_URL from .env in docker-compose
- document WEB_URL variable and sample value

## Testing
- `npm test -w api` (fails: Cannot find module 'jest-util')
- `npm test -w web` (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_b_68b51e4ff5348332a06f927be0ee4f7b