### PR TITLE
chore(web): add dockerignore

### DIFF
--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist


### PR DESCRIPTION
## Summary
- add `.dockerignore` to web workspace to prevent copying `node_modules` and `dist` into Docker images.

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b51e5a5cbc8332b3ebbd6a0b00690d