### PR TITLE
docs: add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 SEMAKIN 6502 (Sistem Monitoring Kinerja) adalah aplikasi internal untuk mencatat aktivitas harian pegawai, memberi tugas mingguan maupun tambahan, serta menampilkan rekap kinerja bagi pimpinan.
 
+## Instalasi
+
+1. Salin berkas contoh `.env` (misalnya dari `api/.env.example`) ke direktori root sebagai `.env` dan sesuaikan variabel seperti kredensial database serta `PORT` (bawaan 3000).
+2. Jalankan `docker-compose up` untuk membangun dan menjalankan seluruh layanan.
+3. Setelah kontainer berjalan, API dapat diakses di `http://localhost:3000` dan antarmuka web di `http://localhost:5173`.
+
 ## Peran & Hak Akses
 
 | Peran        | Deskripsi Singkat                            |


### PR DESCRIPTION
## Summary
- document how to run the project using `docker-compose up`
- explain preparing `.env` and the ports for API and web app

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b51e5cf910833296669385f8d0ea8a