### PR TITLE
docs: explain custom API port configuration

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,2 +1,8 @@
-# API URL when the application runs in production
-VITE_API_URL=https://semakin.databenuanta.id
+# API URL for local development; adjust port as needed.
+VITE_API_URL=http://localhost:3000
+
+# Example: if backend runs on port 3002
+# VITE_API_URL=http://localhost:3002
+
+# API URL for production deployment
+# VITE_API_URL=https://semakin.databenuanta.id

--- a/web/README.md
+++ b/web/README.md
@@ -43,6 +43,9 @@ web/
    |---------------|------------------------------|----------------------------------|
    | `VITE_API_URL`| `http://localhost:3000`      | URL base API backend             |
 
+   Catatan: Jika backend berjalan pada port selain 3000 (mis. 3002),
+   sesuaikan `VITE_API_URL` menjadi `http://localhost:3002`.
+
 3. **Menjalankan server development**
    ```bash
    npm run dev


### PR DESCRIPTION
## Summary
- note that `VITE_API_URL` must match backend port, e.g., http://localhost:3002
- provide `.env` example showing custom API port for development

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'Cell'))*
- `npm run lint` *(fails: 13 problems (2 errors, 11 warnings))*

------
https://chatgpt.com/codex/tasks/task_b_68b521458ecc8332bbec9a05d180bff3