### PR TITLE
Add CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,37 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci --workspaces
+      - name: Lint API
+        run: npm run lint -w api
+      - name: Test API
+        run: npm test -w api
+      - name: Lint Web
+        run: npm run lint -w web
+      - name: Test Web
+        run: npm test -w web
+      - name: Build API image
+        run: docker build -t ${{ secrets.REGISTRY_USERNAME }}/semakin6502-backend:${{ github.sha }} api
+      - name: Build Web image
+        run: docker build -t ${{ secrets.REGISTRY_USERNAME }}/semakin6502-frontend:${{ github.sha }} web
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      - name: Push API image
+        run: docker push ${{ secrets.REGISTRY_USERNAME }}/semakin6502-backend:${{ github.sha }}
+      - name: Push Web image
+        run: docker push ${{ secrets.REGISTRY_USERNAME }}/semakin6502-frontend:${{ github.sha }}


### PR DESCRIPTION
## Summary
- add CI/CD workflow with linting, testing, and Docker image build/push

## Testing
- `npm run lint -w api` (failed: eslint . --ext .ts)
- `npm test -w api` (failed: Cannot find module 'jest-util')
- `npm run lint -w web` (failed: Cannot find package 'eslint-plugin-react-hooks')
- `npm test -w web` (failed: jest: not found)


------
https://chatgpt.com/codex/tasks/task_b_68b52084dc788332908b8eeb7e35cb17