### PR TITLE
Add deployment script and action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy
+
+on:
+  registry_package:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Execute remote deploy script
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          script: |
+            cd ${{ secrets.DEPLOY_PATH }}
+            ./deploy.sh
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ SEMAKIN 6502 (Sistem Monitoring Kinerja) adalah aplikasi internal untuk mencata
 2. Jalankan `docker-compose up` untuk membangun dan menjalankan seluruh layanan.
 3. Setelah kontainer berjalan, API dapat diakses di `http://localhost:3000` dan antarmuka web di `http://localhost:5173`.
 
+## Deployment
+
+1. Pastikan server sudah login ke registry yang menyimpan image, misalnya: `docker login ghcr.io`.
+2. Jalankan `./deploy.sh` untuk menarik image terbaru dan me-restart kontainer.
+3. Untuk otomatisasi, Anda dapat memakai salah satu dari berikut:
+   - **Watchtower** untuk memantau dan memperbarui image secara berkala.
+   - **GitHub Actions**: workflow `deploy.yml` di repo ini akan mengeksekusi `deploy.sh` melalui SSH ketika image baru dipublikasikan.
+
 ## Peran & Hak Akses
 
 | Peran        | Deskripsi Singkat                            |

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+docker-compose pull
+docker-compose up -d
+


### PR DESCRIPTION
## Summary
- add deploy.sh to pull and restart docker containers
- document and automate deployment via GitHub Actions

## Testing
- `npm test` (api) *(fails: missing jest-util)*
- `npm test` (web) *(fails: 4 failing suites)*

------
https://chatgpt.com/codex/tasks/task_b_68b520859a548332bf2b564b3c0326e6