### PR TITLE
Add WEB_URL to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ THROTTLE_LIMIT=1000
 VITE_API_URL=
 FONNTE_TOKEN=
 WHATSAPP_API_URL=
+WEB_URL=http://localhost:5173 # Frontend base URL used in notification links


### PR DESCRIPTION
## Summary
- add `WEB_URL` configuration to `.env.example` for frontend notification links

## Testing
- `npm test --workspace api` *(fails: Cannot find module 'jest-util')*
- `npm test --workspace web` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b53bc926408332ac35c7b1c59a9742