### PR TITLE
Adjust deployment trigger and configure GHCR

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,15 +26,16 @@ jobs:
       - name: Test Web
         run: npm test -w web
       - name: Build API image
-        run: docker build -t ${{ secrets.REGISTRY_USERNAME }}/semakin6502-backend:${{ github.sha }} api
+        run: docker build -t ghcr.io/${{ github.repository_owner }}/semakin6502-backend:${{ github.sha }} api
       - name: Build Web image
-        run: docker build -t ${{ secrets.REGISTRY_USERNAME }}/semakin6502-frontend:${{ github.sha }} web
+        run: docker build -t ghcr.io/${{ github.repository_owner }}/semakin6502-frontend:${{ github.sha }} web
       - name: Login to registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push API image
-        run: docker push ${{ secrets.REGISTRY_USERNAME }}/semakin6502-backend:${{ github.sha }}
+        run: docker push ghcr.io/${{ github.repository_owner }}/semakin6502-backend:${{ github.sha }}
       - name: Push Web image
-        run: docker push ${{ secrets.REGISTRY_USERNAME }}/semakin6502-frontend:${{ github.sha }}
+        run: docker push ghcr.io/${{ github.repository_owner }}/semakin6502-frontend:${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,13 @@
 name: Deploy
 
 on:
-  registry_package:
-    types: [published]
+  workflow_run:
+    workflows: ["CI/CD"]
+    types: [completed]
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Execute remote deploy script


### PR DESCRIPTION
## Summary
- trigger deploy on completed CI/CD workflow
- push Docker images to GHCR

## Testing
- `npm test -w api` (fails: Cannot find module 'jest-util')
- `npm test -w web` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_b_68b54097bec48332becbc0d970ab7a77