### PR TITLE
feat: add production docker compose config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SEMAKIN 6502 (Sistem Monitoring Kinerja) adalah aplikasi internal untuk mencata
 ## Deployment
 
 1. Pastikan server sudah login ke registry yang menyimpan image, misalnya: `docker login ghcr.io`.
-2. Jalankan `./deploy.sh` untuk menarik image terbaru dan me-restart kontainer.
+2. Jalankan `./deploy.sh` (menggunakan `docker-compose -f docker-compose.prod.yml pull && docker-compose -f docker-compose.prod.yml up -d`) untuk menarik image terbaru dan me-restart kontainer.
 3. Untuk otomatisasi, Anda dapat memakai salah satu dari berikut:
    - **Watchtower** untuk memantau dan memperbarui image secara berkala.
    - **GitHub Actions**: workflow `deploy.yml` di repo ini akan mengeksekusi `deploy.sh` melalui SSH ketika image baru dipublikasikan.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-docker-compose pull
-docker-compose up -d
+docker-compose -f docker-compose.prod.yml pull
+docker-compose -f docker-compose.prod.yml up -d
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,44 @@
+version: "3.9"
+services:
+  mysql:
+    image: mysql:8
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./docker/mysql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+
+  backend:
+    image: ${REGISTRY_USERNAME}/semakin6502-backend:latest
+    environment:
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
+      DB_USER: ${DB_USER}
+      DB_PASS: ${DB_PASS}
+      DB_NAME: ${DB_NAME}
+      JWT_SECRET: ${JWT_SECRET}
+      PORT: ${PORT}
+      CORS_ORIGIN: ${CORS_ORIGIN}
+      THROTTLE_TTL: ${THROTTLE_TTL}
+      THROTTLE_LIMIT: ${THROTTLE_LIMIT}
+      FONNTE_TOKEN: ${FONNTE_TOKEN}
+      WHATSAPP_API_URL: ${WHATSAPP_API_URL}
+      WEB_URL: ${WEB_URL}
+    ports:
+      - "${BACKEND_PORT:-3000}:3000"
+    depends_on:
+      - mysql
+
+  frontend:
+    image: ${REGISTRY_USERNAME}/semakin6502-frontend:latest
+    ports:
+      - "5173:80"
+    depends_on:
+      - backend
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
## Summary
- add docker-compose.prod.yml using registry images
- update deploy script to use production compose file
- document production deployment commands

## Testing
- `python - <<'PY'
import yaml
with open('docker-compose.prod.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `bash -n deploy.sh`
- `docker compose -f docker-compose.prod.yml config` *(fails: command not found)*
- `pip install docker-compose` *(fails: Getting requirements to build wheel did not run successfully)*

------
https://chatgpt.com/codex/tasks/task_b_68b5409bf78483328ec3efa573bf0a3a