### PR TITLE
Restrict team filtering for leaders

### DIFF
--- a/web/src/__tests__/FilterToolbar.test.jsx
+++ b/web/src/__tests__/FilterToolbar.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import FilterToolbar from "../pages/monitoring/components/FilterToolbar";
+import { useAuth } from "../pages/auth/useAuth";
+
+jest.mock("../pages/auth/useAuth");
+const mockedUseAuth = useAuth;
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("hides team selector for team leader", () => {
+  mockedUseAuth.mockReturnValue({ user: { role: "ketua", teamId: "1" } });
+  render(
+    <FilterToolbar
+      tab="harian"
+      monthlyMode="current"
+      monthIndex={0}
+      setMonthIndex={() => {}}
+      weekIndex={0}
+      setWeekIndex={() => {}}
+      weekStarts={[]}
+      year={2024}
+      setYear={() => {}}
+      teamId="1"
+      setTeamId={() => {}}
+      teams={[{ id: "1", namaTim: "Tim A" }]}
+    />
+  );
+  expect(screen.queryByLabelText(/Pilih Tim/i)).not.toBeInTheDocument();
+});
+
+test("shows team selector for admin", () => {
+  mockedUseAuth.mockReturnValue({ user: { role: "admin" } });
+  render(
+    <FilterToolbar
+      tab="harian"
+      monthlyMode="current"
+      monthIndex={0}
+      setMonthIndex={() => {}}
+      weekIndex={0}
+      setWeekIndex={() => {}}
+      weekStarts={[]}
+      year={2024}
+      setYear={() => {}}
+      teamId=""
+      setTeamId={() => {}}
+      teams={[]}
+    />
+  );
+  expect(screen.getByLabelText(/Pilih Tim/i)).toBeInTheDocument();
+});

--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -9,6 +9,7 @@ import { FaFilePdf } from "react-icons/fa";
 import { exportMonthlyCurrentPDF, exportMonthlyYearPDF } from "./export/pdfTable";
 import Legend from "../../components/ui/Legend";
 import { useAuth } from "../auth/useAuth";
+import { ROLES } from "../../utils/roles";
 import axios from "axios";
 import { handleAxiosError } from "../../utils/alerts";
 import formatWita from "../../utils/formatWita";
@@ -36,13 +37,16 @@ export const getWeekStarts = (month, year) => {
 export default function MonitoringPage() {
   const location = useLocation();
   const navigate = useNavigate();
+  const { user } = useAuth();
   const initFromQuery = useRef(false);
   const [tab, setTab] = useState("harian");
   const [monthIndex, setMonthIndex] = useState(new Date().getMonth());
   const [weekIndex, setWeekIndex] = useState(0);
   const [weekStarts, setWeekStarts] = useState([]);
   const [year, setYear] = useState(new Date().getFullYear());
-  const [teamId, setTeamId] = useState("");
+  const [teamId, setTeamId] = useState(
+    user?.role === ROLES.KETUA ? user.teamId : ""
+  );
   const [teams, setTeams] = useState([]);
   const [lastUpdate, setLastUpdate] = useState("");
   const [monthlyMode, setMonthlyMode] = useState("current"); // 'current' | 'year'
@@ -56,7 +60,6 @@ export default function MonitoringPage() {
       ? "Capaian Mingguan Pegawai"
       : "Capaian Bulanan Pegawai";
 
-  const { user } = useAuth();
 
   // Ambil semua daftar tim untuk filter
   useEffect(() => {
@@ -70,6 +73,12 @@ export default function MonitoringPage() {
     };
     fetchTeams();
   }, [user?.role]);
+
+  useEffect(() => {
+    if (user?.role === ROLES.KETUA) {
+      setTeamId(user.teamId);
+    }
+  }, [user]);
 
   // Ambil waktu update terakhir
   useEffect(() => {

--- a/web/src/pages/monitoring/components/FilterToolbar.jsx
+++ b/web/src/pages/monitoring/components/FilterToolbar.jsx
@@ -1,6 +1,8 @@
 import { Listbox } from "@headlessui/react";
 import { ChevronUpDownIcon, CheckIcon } from "@heroicons/react/20/solid";
 import months from "../../../utils/months";
+import { useAuth } from "../../auth/useAuth";
+import { ROLES } from "../../../utils/roles";
 
 export default function FilterToolbar({
   tab,
@@ -16,6 +18,7 @@ export default function FilterToolbar({
   setTeamId,
   teams = [],
 }) {
+  const { user } = useAuth();
   const currentYear = new Date().getFullYear();
   const yearOptions = Array.from({ length: 5 }, (_, i) => currentYear - 2 + i);
 
@@ -158,74 +161,76 @@ export default function FilterToolbar({
       )}
 
       {/* Filter Tim */}
-      <div className="w-40">
-        <Listbox value={teamId} onChange={setTeamId}>
-          <div className="relative">
-            <Listbox.Button className={baseButtonClass} aria-label="Pilih Tim">
-              <span className="block truncate">
-                {(() => {
-                  if (!teamId) return "Semua Tim";
-                  const t = teams.find((x) => x.id === teamId);
-                  return t ? t.namaTim : "Semua Tim";
-                })()}
-              </span>
-              <span className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
-                <ChevronUpDownIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
-              </span>
-            </Listbox.Button>
-            <Listbox.Options className={baseOptionsClass}>
-              <Listbox.Option
-                key="all"
-                value=""
-                className={({ active }) =>
-                  `relative cursor-pointer select-none py-2 pl-10 pr-4 ${
-                    active
-                      ? "bg-blue-100 dark:bg-gray-600 text-blue-900 dark:text-white"
-                      : "text-gray-900 dark:text-gray-100"
-                  }`
-                }
-              >
-                {({ selected }) => (
-                  <>
-                    <span className={`block truncate ${selected ? "font-medium" : "font-normal"}`}>Semua Tim</span>
-                    {selected && (
-                      <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-blue-600 dark:text-blue-400">
-                        <CheckIcon className="h-4 w-4" aria-hidden="true" />
-                      </span>
-                    )}
-                  </>
-                )}
-              </Listbox.Option>
-              {teams
-                .filter((t) => t.namaTim !== "Pimpinan")
-                .map((t) => (
-                  <Listbox.Option
-                    key={t.id}
-                    value={t.id}
-                    className={({ active }) =>
-                      `relative cursor-pointer select-none py-2 pl-10 pr-4 ${
-                        active
-                          ? "bg-blue-100 dark:bg-gray-600 text-blue-900 dark:text-white"
-                          : "text-gray-900 dark:text-gray-100"
-                      }`
-                    }
-                  >
-                    {({ selected }) => (
-                      <>
-                        <span className={`block truncate ${selected ? "font-medium" : "font-normal"}`}>{t.namaTim}</span>
-                        {selected && (
-                          <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-blue-600 dark:text-blue-400">
-                            <CheckIcon className="h-4 w-4" aria-hidden="true" />
-                          </span>
-                        )}
-                      </>
-                    )}
-                  </Listbox.Option>
-                ))}
-            </Listbox.Options>
-          </div>
-        </Listbox>
-      </div>
+      {user?.role !== ROLES.KETUA && (
+        <div className="w-40">
+          <Listbox value={teamId} onChange={setTeamId}>
+            <div className="relative">
+              <Listbox.Button className={baseButtonClass} aria-label="Pilih Tim">
+                <span className="block truncate">
+                  {(() => {
+                    if (!teamId) return "Semua Tim";
+                    const t = teams.find((x) => x.id === teamId);
+                    return t ? t.namaTim : "Semua Tim";
+                  })()}
+                </span>
+                <span className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
+                  <ChevronUpDownIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+                </span>
+              </Listbox.Button>
+              <Listbox.Options className={baseOptionsClass}>
+                <Listbox.Option
+                  key="all"
+                  value=""
+                  className={({ active }) =>
+                    `relative cursor-pointer select-none py-2 pl-10 pr-4 ${
+                      active
+                        ? "bg-blue-100 dark:bg-gray-600 text-blue-900 dark:text-white"
+                        : "text-gray-900 dark:text-gray-100"
+                    }`
+                  }
+                >
+                  {({ selected }) => (
+                    <>
+                      <span className={`block truncate ${selected ? "font-medium" : "font-normal"}`}>Semua Tim</span>
+                      {selected && (
+                        <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-blue-600 dark:text-blue-400">
+                          <CheckIcon className="h-4 w-4" aria-hidden="true" />
+                        </span>
+                      )}
+                    </>
+                  )}
+                </Listbox.Option>
+                {teams
+                  .filter((t) => t.namaTim !== "Pimpinan")
+                  .map((t) => (
+                    <Listbox.Option
+                      key={t.id}
+                      value={t.id}
+                      className={({ active }) =>
+                        `relative cursor-pointer select-none py-2 pl-10 pr-4 ${
+                          active
+                            ? "bg-blue-100 dark:bg-gray-600 text-blue-900 dark:text-white"
+                            : "text-gray-900 dark:text-gray-100"
+                        }`
+                      }
+                    >
+                      {({ selected }) => (
+                        <>
+                          <span className={`block truncate ${selected ? "font-medium" : "font-normal"}`}>{t.namaTim}</span>
+                          {selected && (
+                            <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-blue-600 dark:text-blue-400">
+                              <CheckIcon className="h-4 w-4" aria-hidden="true" />
+                            </span>
+                          )}
+                        </>
+                      )}
+                    </Listbox.Option>
+                  ))}
+              </Listbox.Options>
+            </div>
+          </Listbox>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- default monitoring view to the leader's own team
- hide team selector for team leaders to prevent cross-team requests
- add tests for team selector visibility by role

## Testing
- `npm test` *(fails: TypeError in TugasTambahanPage.test.jsx, missing elements in PanduanPage.test.jsx, not implemented canvas in MonitoringPage.test.jsx, and others)*
- `npm test -- src/__tests__/FilterToolbar.test.jsx`
- `npm run lint` *(fails: 4 errors, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68b547635e688332a020c55d54f422d8