### PR TITLE
fix: ensure personal tasks load correctly

### DIFF
--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -145,9 +145,10 @@ export default function PenugasanPage() {
         // ignore error
       }
     };
+    if (!user) return;
     if (!filterMinggu) initWeek();
     // eslint-disable-next-line
-  }, [filterBulan, filterTahun]);
+  }, [filterBulan, filterTahun, user]);
 
   useEffect(() => {
     if (!filterBulan || !filterTahun) {
@@ -176,6 +177,7 @@ export default function PenugasanPage() {
   }, [filterBulan, filterTahun, filterMinggu]);
 
   const fetchData = useCallback(async () => {
+    if (!user) return;
     try {
       setLoading(true);
       setError("");
@@ -230,7 +232,7 @@ export default function PenugasanPage() {
 
   useEffect(() => {
     fetchData();
-  }, [fetchData]);
+  }, [fetchData, user]);
 
   // --- Form Submit
   const save = async () => {
@@ -263,13 +265,24 @@ export default function PenugasanPage() {
       const matchTeam = filterTeam
         ? String(p.kegiatan?.teamId) === filterTeam
         : true;
-      if (viewTab === "mine") return matchesSearch && p.pegawaiId === user?.id;
+      if (viewTab === "mine")
+        return (
+          matchesSearch && String(p.pegawaiId) === String(user?.id)
+        );
       if (viewTab === "dariSaya")
         // Hanya penugasan yang dibuat oleh user (sudah dibatasi di params)
         // dan tidak menampilkan tugas dirinya sendiri
-        return matchesSearch && matchTeam && p.pegawaiId !== user?.id;
+        return (
+          matchesSearch &&
+          matchTeam &&
+          String(p.pegawaiId) !== String(user?.id)
+        );
       // viewTab === "all" -> tampilkan semua penugasan kecuali milik user yang login
-      return matchesSearch && matchTeam && p.pegawaiId !== user?.id;
+      return (
+        matchesSearch &&
+        matchTeam &&
+        String(p.pegawaiId) !== String(user?.id)
+      );
     });
   }, [penugasan, search, viewTab, user?.id, filterTeam]);
   const paginated = useMemo(

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -115,6 +115,7 @@ export default function TugasTambahanPage() {
   };
 
   const fetchData = async () => {
+    if (!user) return;
     try {
       setLoading(true);
       const params = {};
@@ -146,8 +147,8 @@ export default function TugasTambahanPage() {
   };
 
   useEffect(() => {
-    fetchData();
-  }, [filterTeam, user?.role]);
+    if (user) fetchData();
+  }, [filterTeam, user]);
 
   useEffect(() => {
     if (!filterBulan || !filterTahun) {


### PR DESCRIPTION
## Summary
- wait for authenticated user before fetching assignments
- defer additional-task loading until user data is available

## Testing
- `npm test --workspace web` *(fails: jest: not found)*
- `npm run lint --workspace web` *(fails: eslint-plugin-react-hooks missing)*

------
https://chatgpt.com/codex/tasks/task_b_68b5463cb7748332b81f8ed1c97c577d