### PR TITLE
feat(api): stop leader notifications on task completion

### DIFF
--- a/api/src/laporan/laporan.service.ts
+++ b/api/src/laporan/laporan.service.ts
@@ -100,23 +100,6 @@ export class LaporanService {
             where: { id: penugasanId },
             data: { status: STATUS.SELESAI_DIKERJAKAN },
           });
-
-          const leaders = await this.prisma.member.findMany({
-            where: { teamId: pen.kegiatan.teamId, isLeader: true },
-            select: { userId: true },
-          });
-          const text = `${
-            pen.pegawai?.nama ?? "Seorang pegawai"
-          } telah menyelesaikan penugasan ${pen.kegiatan.namaKegiatan}`;
-          await Promise.all(
-            leaders.map((l: { userId: string }) =>
-              this.notifications.create(
-                l.userId,
-                text,
-                `/tugas-mingguan/${pen.id}`
-              )
-            )
-          );
         }
         return;
       }

--- a/api/test/laporan.service.spec.ts
+++ b/api/test/laporan.service.spec.ts
@@ -101,7 +101,6 @@ describe('LaporanService submit', () => {
       pegawaiId: id1,
       kegiatan: { teamId: id1 },
     });
-    prisma.member.findMany.mockResolvedValue([]);
     prisma.laporanHarian.create.mockResolvedValue({ id: id11 });
     prisma.laporanHarian.findFirst.mockResolvedValueOnce({
       status: STATUS.SELESAI_DIKERJAKAN,
@@ -115,6 +114,8 @@ describe('LaporanService submit', () => {
       where: { id: id1 },
       data: { status: STATUS.SELESAI_DIKERJAKAN },
     });
+    expect(prisma.member.findMany).not.toHaveBeenCalled();
+    expect(notifications.create).not.toHaveBeenCalled();
   });
 
   it('returns laporan when optional fields missing', async () => {


### PR DESCRIPTION
## Summary
- remove leader notification generation in laporan service when a task is completed
- test that completing a task no longer triggers leader notifications

## Testing
- `npm test --workspaces --if-present` *(fails: Parameter 'u' implicitly has an 'any' type; Expected: "08123", "Halo, Budi!", etc.; Monitoring tests, web app tests)*

------
https://chatgpt.com/codex/tasks/task_b_68b58e03fad883329a2e013d7cd1cd88