### PR TITLE
feat: remove notifications when penugasan deleted

### DIFF
--- a/api/src/kegiatan/penugasan.service.ts
+++ b/api/src/kegiatan/penugasan.service.ts
@@ -393,6 +393,7 @@ export class PenugasanService {
         "Hapus laporan harian penugasan ini terlebih dahulu"
       );
     await this.prisma.penugasan.delete({ where: { id } });
+    await this.notifications.deleteByLink(`/tugas-mingguan/${id}`);
     await this.invalidateCache(PENUGASAN_CACHE_KEYS);
     return { success: true };
   }

--- a/api/src/notifications/notifications.service.ts
+++ b/api/src/notifications/notifications.service.ts
@@ -32,4 +32,10 @@ export class NotificationsService {
       data: { isRead: true },
     });
   }
+
+  deleteByLink(link: string) {
+    return this.prisma.notification.deleteMany({
+      where: { link },
+    });
+  }
 }

--- a/api/test/notifications.service.spec.ts
+++ b/api/test/notifications.service.spec.ts
@@ -6,6 +6,7 @@ jest.mock('ulid', () => ({ ulid: () => '1' }));
 const prisma = {
   notification: {
     create: jest.fn(),
+    deleteMany: jest.fn(),
   },
 } as any;
 
@@ -25,6 +26,19 @@ describe('NotificationsService create', () => {
       data: { id: '1', userId: 'u1', text: 'text', link: '/link' },
     });
     expect(res).toEqual({ id: '1' });
+  });
+});
+
+describe('NotificationsService deleteByLink', () => {
+  it('deletes notifications by link', async () => {
+    prisma.notification.deleteMany.mockResolvedValue({ count: 1 });
+
+    const res = await notifications.deleteByLink('/foo');
+
+    expect(prisma.notification.deleteMany).toHaveBeenCalledWith({
+      where: { link: '/foo' },
+    });
+    expect(res).toEqual({ count: 1 });
   });
 });
 


### PR DESCRIPTION
## Summary
- add `deleteByLink` to notifications service
- clear notifications when penugasan is removed
- cover notification deletion in tests

## Testing
- `npm test` *(fails: Parameter 'u' implicitly has an 'any' type; ...)*

------
https://chatgpt.com/codex/tasks/task_b_68b58f33ae7c83328cd314a67e16dd20