### PR TITLE
docs: document WhatsApp env vars

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -18,3 +18,13 @@ THROTTLE_LIMIT=100
 
 # Redis cache
 REDIS_URL=redis://localhost:6379
+
+# WhatsApp integration
+# Base URL for the WhatsApp API
+WHATSAPP_API_URL=https://fonnte.com/api
+# Fonnte API token (use this if sending via Fonnte)
+FONNTE_TOKEN=your_fonnte_token_here
+# Generic WhatsApp API token (alternative provider)
+WHATSAPP_TOKEN=your_whatsapp_token_here
+# Enable phone number validation (true/false, default true)
+PHONE_VALIDATION_ENABLED=true

--- a/api/README.md
+++ b/api/README.md
@@ -55,8 +55,10 @@ api/
     | `WEB_URL`          | Base URL frontend untuk menyusun tautan di notifikasi                          |
     | `THROTTLE_TTL`     | Masa berlaku rate limiting dalam detik (opsional, default `900`)               |
     | `THROTTLE_LIMIT`   | Jumlah request per TTL (opsional, default `100`)                               |
-    | `FONNTE_TOKEN`/`WHATSAPP_TOKEN` | Token API WhatsApp, salah satu wajib diisi                         |
+    | `FONNTE_TOKEN`     | Token API Fonnte (opsional, salah satu dari ini atau `WHATSAPP_TOKEN` wajib diisi) |
+    | `WHATSAPP_TOKEN`   | Token API WhatsApp generik (opsional, salah satu dari ini atau `FONNTE_TOKEN` wajib diisi) |
     | `WHATSAPP_API_URL` | URL endpoint API WhatsApp                                                      |
+    | `PHONE_VALIDATION_ENABLED` | `true` untuk validasi nomor telepon (opsional, default `true`)         |
     | `COOKIE_DOMAIN`    | Domain cookie (opsional)                                                       |
     | `COOKIE_SAMESITE`  | Nilai SameSite cookie (opsional)                                               |
 


### PR DESCRIPTION
## Summary
- add WhatsApp API url, tokens, and phone validation to env example
- document new WhatsApp and phone validation vars in API readme

## Testing
- `npm test` *(fails: Test Suites: 4 failed, 9 passed)*
- `npm run lint` *(fails: 110 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68b5a91e410c8332934dcec328a137d5