### PR TITLE
chore: drop compose file version

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   mysql:
     image: mysql:8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   mysql:
     image: mysql:8


### PR DESCRIPTION
## Summary
- remove obsolete `version` field from docker-compose files to use Compose specification defaults

## Testing
- `docker-compose config`
- `docker-compose -f docker-compose.prod.yml config`


------
https://chatgpt.com/codex/tasks/task_b_68b5a91f833c8332a9af3e8375903e82