### PR TITLE
Allow empty WEB_URL

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -29,7 +29,7 @@ import { HealthController } from "./health.controller";
           COOKIE_SAMESITE: Joi.string().valid("lax", "strict", "none"),
           NODE_ENV: Joi.string(),
           CORS_ORIGIN: Joi.string(),
-          WEB_URL: Joi.string().uri().optional(),
+          WEB_URL: Joi.string().uri().allow("").optional(),
           FONNTE_TOKEN: Joi.string(),
           WHATSAPP_TOKEN: Joi.string(),
           WHATSAPP_API_URL: Joi.string().uri().required(),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
       THROTTLE_LIMIT: ${THROTTLE_LIMIT}
       FONNTE_TOKEN: ${FONNTE_TOKEN}
       WHATSAPP_API_URL: ${WHATSAPP_API_URL}
-      WEB_URL: ${WEB_URL} # optional
+${WEB_URL:+      WEB_URL: ${WEB_URL} # optional}
     ports:
       - "${BACKEND_PORT:-3000}:3000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       THROTTLE_LIMIT: ${THROTTLE_LIMIT}
       FONNTE_TOKEN: ${FONNTE_TOKEN}
       WHATSAPP_API_URL: ${WHATSAPP_API_URL}
-      WEB_URL: ${WEB_URL} # optional
+${WEB_URL:+      WEB_URL: ${WEB_URL} # optional}
     ports:
       - "${BACKEND_PORT:-3000}:3000"
     depends_on:


### PR DESCRIPTION
## Summary
- Allow empty `WEB_URL` in API configuration schema
- Inject `WEB_URL` into Docker Compose only when set to avoid blank value

## Testing
- `npm test` *(fails: Test Suites: 12 failed, 1 passed, 13 total)*
- `npm run lint` *(fails: 110 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68b5af0829d88332ad51dcf717f332c6