### PR TITLE
fix: correct KegiatanTambahan migration table name

### DIFF
--- a/api/prisma/migrations/20250829022910_widen_capaian_kegiatan/migration.sql
+++ b/api/prisma/migrations/20250829022910_widen_capaian_kegiatan/migration.sql
@@ -1,5 +1,5 @@
 -- AlterTable
-ALTER TABLE `kegiatantambahan` MODIFY `capaianKegiatan` TEXT NOT NULL;
+ALTER TABLE `KegiatanTambahan` MODIFY `capaianKegiatan` TEXT NOT NULL;
 
 -- AlterTable
 ALTER TABLE `LaporanHarian` MODIFY `capaianKegiatan` TEXT NOT NULL;


### PR DESCRIPTION
## Summary
- fix migration table name casing for KegiatanTambahan

## Testing
- `npm test` (fails: Parameter 'u' implicitly has an 'any' type, PenugasanService assign failing expectation)


------
https://chatgpt.com/codex/tasks/task_b_68b5bb7e73688332916924094dc9507c