### PR TITLE
fix prisma seed imports for Node16

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,8 +1,8 @@
 import "dotenv/config";
 import { PrismaClient } from "@prisma/client";
-import { hashPassword } from "../src/common/hash";
-import { STATUS } from "../src/common/status.constants";
-import { getHolidays } from "../src/utils/holidays";
+import { hashPassword } from "../src/common/hash.js";
+import { STATUS } from "../src/common/status.constants.js";
+import { getHolidays } from "../src/utils/holidays.js";
 import { ulid } from "ulid";
 import userPhonesData from "./user-phones.json";
 


### PR DESCRIPTION
## Summary
- add explicit `.js` extensions to Prisma seed imports for Node16 compatibility

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate` *(fails: Failed to fetch the engine file)*
- `npm run build` *(fails: Module '@prisma/client' has no exported member 'User')*
- `npm test` *(fails: 4 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68b6aa8507c48332a2e9bda3674c9c3a