### PR TITLE
chore(api): use CommonJS modules

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "module": "Node16",
+    "module": "CommonJS",
     "target": "ES2020",
-    "moduleResolution": "node16",
+    "moduleResolution": "node",
     "outDir": "./dist",
     "rootDir": "./",
     "strict": true,


### PR DESCRIPTION
## Summary
- switch TypeScript to CommonJS modules and Node resolution to match runtime

## Testing
- `npm run build` *(fails: parameter implicitly has an 'any' type, missing Prisma exports)*

------
https://chatgpt.com/codex/tasks/task_b_68b6aa8737d48332827ba933dd0f8cba