### PR TITLE
feat: add build tsconfig

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node dist/main",
     "start:dev": "nest start --watch",
-    "build": "nest build",
+    "build": "nest build -p tsconfig.build.json",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint": "eslint . --ext .ts",
     "test": "jest --coverage",

--- a/api/tsconfig.build.json
+++ b/api/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["prisma/**/*", "node_modules", "dist", "test"]
+}


### PR DESCRIPTION
## Summary
- add tsconfig for building the API
- use custom tsconfig when building

## Testing
- `npx prisma generate` *(fails: Failed to fetch the engine file - 403 Forbidden)*
- `npm run build` *(fails: Module '"@prisma/client"' has no exported member 'User')*


------
https://chatgpt.com/codex/tasks/task_b_68b6af61f3c483328b1d110cdb49001c