### PR TITLE
Include Prisma seed in build output

### DIFF
--- a/api/tsconfig.build.json
+++ b/api/tsconfig.build.json
@@ -4,6 +4,12 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["prisma/**/*", "node_modules", "dist", "test"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test"
+  ]
 }


### PR DESCRIPTION
## Summary
- remove prisma directory from TypeScript build exclusions so seed.ts compiles

## Testing
- `npm run build` (fails: Parameter 't' implicitly has an 'any' type)
- `npm test` (fails: 4 failed, 9 passed)
- `docker-compose build backend` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_b_68b9851f58b4833299ede9e51f254b45