### PR TITLE
Include prisma seed in backend build output

### DIFF
--- a/api/tsconfig.build.json
+++ b/api/tsconfig.build.json
@@ -1,11 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "outDir": "./dist"
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "prisma/**/*"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- ensure prisma directory is included in API build output

## Testing
- `npm --prefix api run build` *(fails: Parameter 'm' implicitly has an 'any' type)*
- `docker-compose exec backend npm run seed` *(fails: ModuleNotFoundError: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_b_68b99e2657648332950d6655bb8bcef4