### PR TITLE
chore: update build paths

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -15,4 +15,4 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/prisma ./prisma
 EXPOSE 3000
-CMD ["node","dist/main"]
+CMD ["node","dist/src/main"]

--- a/api/package.json
+++ b/api/package.json
@@ -2,9 +2,9 @@
   "name": "semakin-6502",
   "version": "1.0.0",
   "description": "Backend SEMAKIN 6502 - NestJS + Prisma",
-  "main": "dist/main.js",
+  "main": "dist/src/main.js",
   "scripts": {
-    "start": "node dist/main",
+    "start": "node dist/src/main.js",
     "start:dev": "nest start --watch",
     "build": "nest build -p tsconfig.build.json",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
## Summary
- fix entrypoint paths for production build
- align Docker CMD with compiled server location

## Testing
- `npm test` *(fails: Parameter 'u' implicitly has an 'any' type; etc.)*
- `npm run build` *(fails: Parameter 'm' implicitly has an 'any' type.)*
- `docker build -t api-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `node dist/src/main.js` *(fails: Config validation error: "WHATSAPP_API_URL" is required.)*

------
https://chatgpt.com/codex/tasks/task_b_68b9a5c936488332aef8b53d9114eb19