### PR TITLE
feat(web): split env configs for docker and local dev

### DIFF
--- a/web/.env.development
+++ b/web/.env.development
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:3000
+

--- a/web/.env.docker
+++ b/web/.env.docker
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:3002
+

--- a/web/README.md
+++ b/web/README.md
@@ -33,22 +33,22 @@ web/
    npm install
    ```
 2. **Konfigurasi variabel lingkungan**
-   ```bash
-   cp .env.example .env
-   # sesuaikan alamat backend
-   ```
+   File `.env` default mengarah ke backend container (`http://localhost:3002`).
+   Untuk menjalankan frontend di luar Docker dengan backend lokal (`http://localhost:3000`), gunakan `.env.development`.
+   Sebaliknya, konfigurasi `.env.docker` disediakan untuk lingkungan Docker.
+
    Variabel yang digunakan:
 
    | Nama          | Contoh nilai                 | Deskripsi                        |
    |---------------|------------------------------|----------------------------------|
    | `VITE_API_URL`| `http://localhost:3000`      | URL base API backend             |
 
-   Catatan: Jika backend berjalan pada port selain 3000 (mis. 3002),
-   sesuaikan `VITE_API_URL` menjadi `http://localhost:3002`.
+   Catatan: Sesuaikan `VITE_API_URL` bila backend berjalan pada port lain.
 
 3. **Menjalankan server development**
    ```bash
-   npm run dev
+   npm run dev                   # menggunakan .env.development
+   npm run dev -- --mode docker  # menggunakan .env.docker
    ```
    Aplikasi akan tersedia pada `http://localhost:5173`.
 


### PR DESCRIPTION
## Summary
- set default API URL to port 3002
- add .env.development and .env.docker for easier switching
- document env modes in README

## Testing
- `npm test --workspace web` *(fails: 5 failed, 10 passed)*
- `npm run lint --workspace web` *(fails: 4 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68ba136e60d48332845eca287f55a95d