### PR TITLE
Parametrize backend port for Nginx

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,6 +52,8 @@ services:
     image: ${REGISTRY_USERNAME}/semakin6502-frontend:latest
     ports:
       - "5173:80"
+    environment:
+      - BACKEND_PORT=${BACKEND_PORT:-3002}
     depends_on:
       - backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,8 @@ services:
     image: semakin6502-frontend
     ports:
       - "5173:80"
+    environment:
+      - BACKEND_PORT=${BACKEND_PORT:-3002}
     depends_on:
       - backend
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,6 +9,6 @@ RUN npm run build
 
 FROM nginx:alpine AS runtime
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 EXPOSE 80
 

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,6 +1,9 @@
 server {
   listen 80;
   root /usr/share/nginx/html;
+  location /api {
+    proxy_pass http://backend:$BACKEND_PORT;
+  }
   location / {
     try_files $uri /index.html;
   }


### PR DESCRIPTION
## Summary
- Proxy API requests via `backend:$BACKEND_PORT` in Nginx config
- Template Nginx config and expose `BACKEND_PORT` in compose files

## Testing
- `npm test` (backend) *(fails: expect toHaveBeenCalledWith, missing deep equality)*
- `npm test` (frontend) *(fails: jest: not found)*
- `docker-compose build frontend` *(fails: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_b_68ba3b661f14833282f27d7ee635aa42