### PR TITLE
fix: guard user parsing in AuthProvider

### DIFF
--- a/web/src/pages/auth/useAuth.jsx
+++ b/web/src/pages/auth/useAuth.jsx
@@ -12,11 +12,22 @@ import camelizeKeys from "../../utils/camelizeKeys.js";
 
 const AuthContext = createContext();
 
+export function safeParseUser(userString) {
+  if (!userString) return null;
+  try {
+    return camelizeKeys(JSON.parse(userString));
+  } catch {
+    localStorage.removeItem("user");
+    sessionStorage.removeItem("user");
+    return null;
+  }
+}
+
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(() => {
     const u =
       localStorage.getItem("user") || sessionStorage.getItem("user");
-    return u ? camelizeKeys(JSON.parse(u)) : null;
+    return safeParseUser(u);
   });
 
   const verifyToken = useCallback(async () => {


### PR DESCRIPTION
## Summary
- add `safeParseUser` helper to sanitize stored user data
- ensure AuthProvider initializes safely when JSON parsing fails

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ba7bfa02a083328c1cf9df4e504dbb