### PR TITLE
Raise error on unexpected notifications response

### DIFF
--- a/web/src/pages/layout/Layout.jsx
+++ b/web/src/pages/layout/Layout.jsx
@@ -7,7 +7,7 @@ import { useTheme } from "../../theme/useTheme.jsx";
 import Swal from "sweetalert2";
 import confirmAlert from "../../utils/confirmAlert";
 import axios from "axios";
-import { ToastContainer } from "react-toastify";
+import { ToastContainer, toast } from "react-toastify";
 import {
   FaBell,
   FaMoon,
@@ -43,14 +43,15 @@ export default function Layout() {
     if (!user || user.role === ROLES.PIMPINAN) return;
     try {
       const res = await axios.get("/notifications");
-      const data = Array.isArray(res.data) ? res.data : [];
       if (!Array.isArray(res.data)) {
-        console.warn("Unexpected notifications response", res.data);
+        throw new Error("Unexpected notifications response");
       }
+      const data = res.data;
       setNotifications(data);
       setNotifCount(data.filter((n) => !n.isRead).length);
     } catch (err) {
       console.error("Failed to fetch notifications", err);
+      toast.error("Gagal memuat notifikasi");
     }
     }, [user]);
 


### PR DESCRIPTION
## Summary
- validate notifications API response and surface failure to users

## Testing
- `npm test` (fails: Test Suites: 5 failed, 11 passed, 16 total)
- `npm run lint` (fails: 4 errors, 12 warnings)


------
https://chatgpt.com/codex/tasks/task_b_68bc510763048332b7baedbe83515a3b