### PR TITLE
Handle unexpected user responses

### DIFF
--- a/web/src/__tests__/UsersPage.test.jsx
+++ b/web/src/__tests__/UsersPage.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import UsersPage from '../pages/users/UsersPage';
+import { useAuth } from '../pages/auth/useAuth';
+import axios from 'axios';
+
+jest.mock('axios');
+jest.mock('../pages/auth/useAuth');
+jest.mock('../components/ui/DataTable', () => ({ data }) => (
+  <div data-testid="data-table">{JSON.stringify(data)}</div>
+));
+jest.mock('../components/SearchInput', () => () => <div />);
+jest.mock('../components/Pagination', () => () => <div />);
+jest.mock('../components/ui/SelectDataShow', () => () => <div />);
+jest.mock('../components/ui/TableSkeleton', () => () => <div />);
+
+test('handles non-array responses from /users', async () => {
+  useAuth.mockReturnValue({ user: { role: 'admin' } });
+  axios.get.mockImplementation((url) => {
+    if (url === '/users') return Promise.resolve({ data: {} });
+    return Promise.resolve({ data: [] });
+  });
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  render(<UsersPage />);
+
+  await waitFor(() => expect(axios.get).toHaveBeenCalledWith('/users'));
+  await waitFor(() => expect(screen.getByTestId('data-table').textContent).toBe('[]'));
+  await waitFor(() => expect(warn).toHaveBeenCalledWith('Unexpected users response', {}));
+
+  warn.mockRestore();
+});

--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -49,7 +49,11 @@ export default function UsersPage() {
     try {
       setLoading(true);
       const res = await axios.get("/users");
-      setUsers(res.data);
+      const data = Array.isArray(res.data) ? res.data : [];
+      if (!Array.isArray(res.data)) {
+        console.warn("Unexpected users response", res.data);
+      }
+      setUsers(data);
     } catch (err) {
       handleAxiosError(err, "Gagal mengambil pengguna");
     } finally {


### PR DESCRIPTION
## Summary
- guard UsersPage fetchUsers against non-array API responses and log unexpected payloads
- add a unit test ensuring non-array /users responses are handled gracefully

## Testing
- `npm test` (fails: TugasTambahanPage.test.jsx, FilterToolbar.test.jsx, PanduanPage.test.jsx, MonitoringPage.test.jsx, MissedReportsPage.test.jsx)
- `npm test src/__tests__/UsersPage.test.jsx`


------
https://chatgpt.com/codex/tasks/task_b_68bc510a3fc88332bc001c6eb6df0c67