### PR TITLE
Validate teams API response

### DIFF
--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -35,10 +35,19 @@ export default function TeamsPage() {
     try {
       setLoading(true);
       let res = await axios.get("/teams");
-      if (Array.isArray(res.data) && res.data.length === 0) {
+      let data = res.data;
+      if (!Array.isArray(data)) {
+        showWarning("Data tidak valid", "Format data tim tidak valid");
+        data = [];
+      } else if (data.length === 0) {
         res = await axios.get("/teams/member");
+        data = res.data;
+        if (!Array.isArray(data)) {
+          showWarning("Data tidak valid", "Format data tim tidak valid");
+          data = [];
+        }
       }
-      setTeams(res.data);
+      setTeams(data);
     } catch (err) {
       handleAxiosError(err, "Gagal mengambil tim");
     } finally {


### PR DESCRIPTION
## Summary
- warn when `/teams` or `/teams/member` responses are not arrays
- default to empty array to keep filters safe

## Testing
- `npm test` *(fails: 5 failed, 11 passed)*
- `npm run lint` *(fails: 4 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68bc51715d1c8332b5132da8758578ff