### PR TITLE
feat: update API URL configuration

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,8 +1,7 @@
-# API URL for local development; adjust port as needed.
-VITE_API_URL=http://localhost:3000
+# API URL for production deployment (must use HTTPS)
+VITE_API_URL=https://semakin.databenuanta.id
 
+# For local development, comment the line above and use:
+# VITE_API_URL=http://localhost:3000
 # Example: if backend runs on port 3002
 # VITE_API_URL=http://localhost:3002
-
-# API URL for production deployment
-# VITE_API_URL=https://semakin.databenuanta.id

--- a/web/README.md
+++ b/web/README.md
@@ -33,17 +33,17 @@ web/
    npm install
    ```
 2. **Konfigurasi variabel lingkungan**
-   File `.env` default mengarah ke backend container (`http://localhost:3002`).
+   File `.env` default mengarah ke endpoint API produksi (`https://semakin.databenuanta.id`).
    Untuk menjalankan frontend di luar Docker dengan backend lokal (`http://localhost:3000`), gunakan `.env.development`.
    Sebaliknya, konfigurasi `.env.docker` disediakan untuk lingkungan Docker.
 
    Variabel yang digunakan:
 
-   | Nama          | Contoh nilai                 | Deskripsi                        |
-   |---------------|------------------------------|----------------------------------|
-   | `VITE_API_URL`| `http://localhost:3000`      | URL base API backend             |
+   | Nama          | Contoh nilai                    | Deskripsi                         |
+   |---------------|---------------------------------|-----------------------------------|
+   | `VITE_API_URL`| `https://api.example.com`       | URL base API backend              |
 
-   Catatan: Sesuaikan `VITE_API_URL` bila backend berjalan pada port lain.
+   Catatan: Untuk development lokal sesuaikan `VITE_API_URL` bila backend berjalan pada port lain, sementara di produksi pastikan menggunakan URL HTTPS.
 
 3. **Menjalankan server development**
    ```bash

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -15,7 +15,7 @@ import camelizeKeys from "./utils/camelizeKeys.js";
 import { HelmetProvider } from "react-helmet-async";
 
 axios.defaults.baseURL =
-  import.meta.env.VITE_API_URL || window.location.origin;
+  import.meta.env.VITE_API_URL ?? `${window.location.origin}`;
 axios.defaults.withCredentials = true;
 
 axios.interceptors.response.use((response) => {


### PR DESCRIPTION
## Summary
- use `window.location.origin` as the fallback API base URL with nullish coalescing
- document HTTPS production API endpoint in README
- set `.env.example` to point to an HTTPS API by default

## Testing
- `npm test` *(fails: 5 failed, 12 passed)*
- `npm run lint` *(fails: ESLint reported 4 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68bc53ba574c8332b0a717243f45c53a