### PR TITLE
Guard UsersPage against non-array API responses

### DIFF
--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -49,11 +49,12 @@ export default function UsersPage() {
     try {
       setLoading(true);
       const res = await axios.get("/users");
-      const data = Array.isArray(res.data) ? res.data : [];
-      if (!Array.isArray(res.data)) {
+      if (Array.isArray(res.data)) {
+        setUsers(res.data);
+      } else {
         console.warn("Unexpected users response", res.data);
+        setUsers([]);
       }
-      setUsers(data);
     } catch (err) {
       handleAxiosError(err, "Gagal mengambil pengguna");
     } finally {


### PR DESCRIPTION
## Summary
- prevent UsersPage crash if /users returns non-array by warning and defaulting to empty list

## Testing
- `npm test` *(fails: TypeError in TugasTambahanPage.test.jsx and others)*
- `npm run lint` *(fails: no-undef and no-unused-vars errors)*

------
https://chatgpt.com/codex/tasks/task_b_68bc53bb0ff08332adea58a2edc4ff56