### PR TITLE
feat: ensure DataTable receives array data

### DIFF
--- a/web/src/components/ui/DataTable.jsx
+++ b/web/src/components/ui/DataTable.jsx
@@ -55,7 +55,7 @@ export function SelectColumnFilter({ column, options }) {
 
 export default function DataTable({
   columns,
-  data,
+  data = [],
   initialPageSize = 10,
   showGlobalFilter = true,
   initialSorting = [],


### PR DESCRIPTION
## Summary
- default `data` prop in `DataTable` to an empty array so react-table always receives an array
- verified parent components either supply array data or rely on the default

## Testing
- `npm test --workspace web` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module './ValidateAndApplyPropertyDescriptor')*


------
https://chatgpt.com/codex/tasks/task_b_68bc57b223688332b6244ef475970a32