### PR TITLE
Handle unexpected payload shape in daily reports fetch

### DIFF
--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -92,7 +92,14 @@ export default function LaporanHarianPage() {
         params.tambahan = true;
       }
       const res = await axios.get(url, { params });
-      setLaporan(res.data);
+      const data = res.data;
+      if (Array.isArray(data)) {
+        setLaporan(data);
+      } else {
+        console.warn("Unexpected payload shape:", data);
+        showWarning("Peringatan", "Format data laporan tidak valid");
+        setLaporan([]);
+      }
     } catch (err) {
       handleAxiosError(err, "Gagal mengambil laporan");
     } finally {


### PR DESCRIPTION
## Summary
- guard LaporanHarianPage against non-array responses and warn when payload is unexpected

## Testing
- `npm test` (fails: Test Suites: 5 failed, 12 passed)
- `npm run lint` (fails: 4 errors, 12 warnings)


------
https://chatgpt.com/codex/tasks/task_b_68bce4b4865c83329d5f3b1ed10a7c78