### PR TITLE
Handle varied team responses in MasterKegiatanPage

### DIFF
--- a/web/src/pages/master/MasterKegiatanPage.jsx
+++ b/web/src/pages/master/MasterKegiatanPage.jsx
@@ -122,10 +122,20 @@ export default function MasterKegiatanPage() {
   const fetchTeams = useCallback(async () => {
     try {
       let res = await axios.get("/teams");
-      if (Array.isArray(res.data) && res.data.length === 0) {
+      let teamsData = Array.isArray(res.data)
+        ? res.data
+        : Array.isArray(res.data?.data)
+          ? res.data.data
+          : [];
+      if (teamsData.length === 0) {
         res = await axios.get("/teams/member");
+        teamsData = Array.isArray(res.data)
+          ? res.data
+          : Array.isArray(res.data?.data)
+            ? res.data.data
+            : [];
       }
-      setTeams(res.data);
+      setTeams(teamsData);
     } catch (err) {
       handleAxiosError(err, "Gagal mengambil tim");
     }


### PR DESCRIPTION
## Summary
- Robustly parse team fetch responses supporting both array and object formats

## Testing
- `npm test --workspace web` *(fails: 5 failed, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68bce4ba1ac883328c471ac5e8a50f62