### PR TITLE
Validate laporan fetch response type

### DIFF
--- a/web/src/pages/laporan/LaporanHarianPage.jsx
+++ b/web/src/pages/laporan/LaporanHarianPage.jsx
@@ -92,6 +92,16 @@ export default function LaporanHarianPage() {
         params.tambahan = true;
       }
       const res = await axios.get(url, { params });
+      const contentType = res.headers["content-type"];
+      if (!contentType || !contentType.includes("application/json")) {
+        if (res.status === 401) {
+          window.location.href = "/login";
+        } else {
+          handleAxiosError(new Error(), "Respon server tidak valid");
+        }
+        setLaporan([]);
+        return;
+      }
       const data = res.data;
       if (Array.isArray(data)) {
         setLaporan(data);


### PR DESCRIPTION
## Summary
- ensure LaporanHarian fetch verifies JSON content type and handles non-JSON responses

## Testing
- `npm run lint` (fails: react-hooks/exhaustive-deps warnings)
- `npm test` (fails: multiple tests not passing)


------
https://chatgpt.com/codex/tasks/task_b_68bcecfbb0948332bc05a9614c6fdea5