### PR TITLE
Sanitize user queries to omit sensitive fields

### DIFF
--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -9,16 +9,30 @@ import { UpdateUserDto } from "./update-user.dto";
 @Injectable()
 export class UsersService {
   constructor(private prisma: PrismaService) {}
+
+  private readonly userSelect: Prisma.UserSelect = {
+    id: true,
+    nama: true,
+    username: true,
+    email: true,
+    phone: true,
+    role: true,
+  };
+
   findAll() {
     return this.prisma.user.findMany({
-      include: {
+      select: {
+        ...this.userSelect,
         members: { include: { team: true } },
       },
     });
   }
 
   async findOne(id: string) {
-    const user = await this.prisma.user.findUnique({ where: { id } });
+    const user = await this.prisma.user.findUnique({
+      where: { id },
+      select: this.userSelect,
+    });
     if (!user) throw new NotFoundException("not found");
     return user;
   }
@@ -127,6 +141,9 @@ export class UsersService {
   }
 
   remove(id: string) {
-    return this.prisma.user.delete({ where: { id } });
+    return this.prisma.user.delete({
+      where: { id },
+      select: this.userSelect,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- exclude password from user listings and lookups using a shared select definition
- ensure user deletions also omit sensitive fields

## Testing
- `npm test` (fails: MonitoringService aggregated test, PenugasanService assign test, MonitoringController lastUpdate test)
- `npm run lint` (fails: @typescript-eslint/no-explicit-any errors)


------
https://chatgpt.com/codex/tasks/task_b_68bd9bfc82748332aa2fb8ed901a1dfe