### PR TITLE
feat(api): add pagination for users list

### DIFF
--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -8,8 +8,9 @@ import {
   Body,
   UseGuards,
   Req,
+  Query,
 } from "@nestjs/common";
-import { ApiTags } from "@nestjs/swagger";
+import { ApiQuery, ApiTags } from "@nestjs/swagger";
 import { UsersService } from "./users.service";
 import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
@@ -28,8 +29,25 @@ export class UsersController {
 
   @Get()
   @Roles(ROLES.ADMIN, ROLES.KETUA)
-  findAll() {
-    return this.usersService.findAll();
+  @ApiQuery({
+    name: "page",
+    required: false,
+    type: Number,
+    description: "Page number (default: 1)",
+  })
+  @ApiQuery({
+    name: "pageSize",
+    required: false,
+    type: Number,
+    description: "Items per page (default: 10)",
+  })
+  findAll(
+    @Query("page") page?: string,
+    @Query("pageSize") pageSize?: string,
+  ) {
+    const p = page ? parseInt(page, 10) : undefined;
+    const ps = pageSize ? parseInt(pageSize, 10) : undefined;
+    return this.usersService.findAll(p, ps);
   }
 
   @Get(":id")

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -9,8 +9,12 @@ import { UpdateUserDto } from "./update-user.dto";
 @Injectable()
 export class UsersService {
   constructor(private prisma: PrismaService) {}
-  findAll() {
+  findAll(page = 1, pageSize = 10) {
+    const p = page > 0 ? page : 1;
+    const ps = pageSize > 0 ? pageSize : 10;
     return this.prisma.user.findMany({
+      skip: (p - 1) * ps,
+      take: ps,
       include: {
         members: { include: { team: true } },
       },


### PR DESCRIPTION
## Summary
- support pagination in users service with page and pageSize
- expose page and pageSize query params in users controller and document defaults

## Testing
- `npm test` *(fails: PenugasanService assign sends WhatsApp message when pegawai has phone, MonitoringService aggregated, MonitoringController lastUpdate)*
- `npm run lint` *(fails: Unexpected any in multiple test files)*

------
https://chatgpt.com/codex/tasks/task_b_68bd9bfd19748332ad58785c7d57d930