### PR TITLE
Log Axios errors to console

### DIFF
--- a/web/src/utils/alerts.js
+++ b/web/src/utils/alerts.js
@@ -33,6 +33,7 @@ export const handleAxiosError = (error, defaultMessage = "Terjadi kesalahan") =>
         (error?.request
           ? "Tidak dapat terhubung ke server. Coba lagi nanti."
           : defaultMessage);
+  console.error(error);
   showError("Error", message);
 };
 


### PR DESCRIPTION
## Summary
- log unexpected Axios errors to the browser console

## Testing
- `npm test --workspace web` *(fails: 4 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68bda8811de08332abafdac7e54e40df