### PR TITLE
docs: specify Fonnte send endpoint

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -21,7 +21,7 @@ REDIS_URL=redis://localhost:6379
 
 # WhatsApp integration
 # Base URL for the WhatsApp API
-WHATSAPP_API_URL=https://fonnte.com/api
+WHATSAPP_API_URL=https://fonnte.com/api/send # path must include /send
 # Fonnte API token (use this if sending via Fonnte)
 FONNTE_TOKEN=your_fonnte_token_here
 # Generic WhatsApp API token (alternative provider)


### PR DESCRIPTION
## Summary
- update WhatsApp API URL example to use Fonnte `/send` endpoint

## Testing
- `npm test` *(fails: MonitoringService aggregated categorizes users by last report date and excludes admin/pimpinan; PenugasanService assign sends WhatsApp message when pegawai has phone; MonitoringController lastUpdate returns ISO string)*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_b_68bdb2662b108332be753ac19854b005