### PR TITLE
refactor: guard team responses before filtering

### DIFF
--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -223,11 +223,15 @@ export default function PenugasanPage() {
         kRes = { data: { data: [] } };
       }
       setPenugasan(sortPenugasan(pRes.data, user?.teamId));
-      setTeams(
-        tRes.data.filter(
-          (t) => t.namaTim !== "Admin" && t.namaTim !== "Pimpinan"
-        )
-      );
+      if (Array.isArray(tRes.data)) {
+        setTeams(
+          tRes.data.filter(
+            (t) => t.namaTim !== "Admin" && t.namaTim !== "Pimpinan"
+          )
+        );
+      } else {
+        setTeams([]);
+      }
       setUsers([...usersData].sort((a, b) => a.nama.localeCompare(b.nama)));
       const kData = kRes.data.data || kRes.data;
       setKegiatan(

--- a/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanDetailPage.jsx
@@ -144,11 +144,15 @@ export default function TugasTambahanDetailPage() {
     const fetchTeams = async () => {
       try {
         const res = await axios.get("/teams/all");
-        setTeams(
-          res.data.filter(
-            (t) => t.namaTim !== "Admin" && t.namaTim !== "Pimpinan"
-          )
-        );
+        if (Array.isArray(res.data)) {
+          setTeams(
+            res.data.filter(
+              (t) => t.namaTim !== "Admin" && t.namaTim !== "Pimpinan"
+            )
+          );
+        } else {
+          setTeams([]);
+        }
       } catch (err) {
         handleAxiosError(err, "Gagal mengambil tim");
       }

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -134,11 +134,15 @@ export default function TugasTambahanPage() {
       ]);
       setItems(sortTambahan(tRes.data, user?.teamId));
       setKegiatan(kRes.data.data || kRes.data);
-      setTeams(
-        teamRes.data.filter(
-          (t) => t.namaTim !== "Admin" && t.namaTim !== "Pimpinan"
-        )
-      );
+      if (Array.isArray(teamRes.data)) {
+        setTeams(
+          teamRes.data.filter(
+            (t) => t.namaTim !== "Admin" && t.namaTim !== "Pimpinan"
+          )
+        );
+      } else {
+        setTeams([]);
+      }
     } catch (err) {
       handleAxiosError(err, "Gagal mengambil data");
     } finally {


### PR DESCRIPTION
## Summary
- safeguard array filtering for teams in additional-task, assignment, and detail pages

## Testing
- `npm test` *(fails: 4 failed, 13 passed)*
- `npm run lint` *(fails: 4 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68be0416d2d08332b040667aeeaedd1b