### PR TITLE
chore: set default API URL for frontend build

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-ARG VITE_API_URL
+ARG VITE_API_URL=https://semakin.databenuanta.id
 ENV VITE_API_URL=${VITE_API_URL}
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- default frontend build ARG `VITE_API_URL` to https://semakin.databenuanta.id

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined, Unable to find element...)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `docker build -t frontend-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_b_68be040184ec8332a6706e1952bbef4b