### PR TITLE
feat: add teams proxy

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -14,6 +14,11 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
   }
+  location /teams/ {
+    proxy_pass http://backend:3000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+  }
   location / {
     try_files $uri /index.html;
   }


### PR DESCRIPTION
## Summary
- proxy `/teams/` path to backend

## Testing
- `npm test` (fails: Cannot read properties of undefined (reading 'Cell'); Found multiple elements with role "button"; Not implemented: HTMLCanvasElement.prototype.getContext; etc.)
- `docker build -t semakin6502-frontend web` (fails: Cannot connect to the Docker daemon)


------
https://chatgpt.com/codex/tasks/task_b_68be1bd751f08332bf9618eb463f2238