### PR TITLE
Fix monitoring completion percentages

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -1,5 +1,11 @@
+const { pathsToModuleNameMapper } = require('ts-jest');
+const { compilerOptions } = require('./tsconfig.json');
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/test/**/*.spec.ts', '**/src/**/__tests__/**/*.spec.ts']
+  testMatch: ['**/test/**/*.spec.ts', '**/src/**/__tests__/**/*.spec.ts'],
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths || {}, {
+    prefix: '<rootDir>/src/',
+  }),
 };

--- a/api/src/modules/monitoring/__tests__/monitoring.service.spec.ts
+++ b/api/src/modules/monitoring/__tests__/monitoring.service.spec.ts
@@ -1,16 +1,24 @@
+import { STATUS } from '../../../shared/constants/status.constants';
 import { MonitoringService } from '../monitoring.service';
 
-describe('MonitoringService month boundary', () => {
+describe('MonitoringService', () => {
   const prisma = {
     laporanHarian: { findMany: jest.fn() },
     penugasan: { findMany: jest.fn() },
+    user: { findMany: jest.fn() },
   } as any;
-  const service = new MonitoringService(prisma);
+  const cache = { get: jest.fn(), set: jest.fn() } as any;
+
+  let service: MonitoringService;
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
     prisma.laporanHarian.findMany.mockResolvedValue([]);
     prisma.penugasan.findMany.mockResolvedValue([]);
+    prisma.user.findMany.mockResolvedValue([]);
+    cache.get.mockResolvedValue(null);
+    cache.set.mockResolvedValue(undefined);
+    service = new MonitoringService(prisma, cache);
   });
 
   it('uses original date month and week when spanning months', async () => {
@@ -22,5 +30,52 @@ describe('MonitoringService month boundary', () => {
     expect(res.bulan).toBe('Juni');
     expect(res.bulan).not.toBe('Juli');
     expect(res.minggu).toBe(1);
+  });
+
+  it('calculates daily completion percentage based on selesai vs total', async () => {
+    prisma.laporanHarian.findMany.mockResolvedValue([
+      {
+        tanggal: new Date('2024-06-03T00:00:00.000Z'),
+        status: STATUS.SELESAI_DIKERJAKAN,
+      },
+      {
+        tanggal: new Date('2024-06-03T00:00:00.000Z'),
+        status: STATUS.BELUM,
+      },
+      {
+        tanggal: new Date('2024-06-04T00:00:00.000Z'),
+        status: STATUS.SELESAI_DIKERJAKAN,
+      },
+    ]);
+
+    const res = await service.mingguan('2024-06-05T00:00:00.000Z');
+    const detail = res.detail as Array<{ hari: string; persen: number }>;
+    const monday = detail.find((d) => d.hari === 'Senin');
+    const tuesday = detail.find((d) => d.hari === 'Selasa');
+    expect(monday?.persen).toBe(50);
+    expect(tuesday?.persen).toBe(100);
+  });
+
+  it('derives weekly completion percentage for each user', async () => {
+    prisma.user.findMany.mockResolvedValue([
+      { id: 'u1', nama: 'User 1' },
+    ]);
+    prisma.laporanHarian.findMany.mockResolvedValue([
+      {
+        pegawaiId: 'u1',
+        tanggal: new Date('2024-06-03T00:00:00.000Z'),
+        status: STATUS.SELESAI_DIKERJAKAN,
+      },
+      {
+        pegawaiId: 'u1',
+        tanggal: new Date('2024-06-04T00:00:00.000Z'),
+        status: STATUS.BELUM,
+      },
+    ]);
+
+    const res = await service.mingguanBulan('2024-06-15T00:00:00.000Z');
+    expect(res[0].weeks[1].total).toBe(2);
+    expect(res[0].weeks[1].selesai).toBe(1);
+    expect(res[0].weeks[1].persen).toBe(50);
   });
 });

--- a/api/src/modules/monitoring/monitoring.service.ts
+++ b/api/src/modules/monitoring/monitoring.service.ts
@@ -147,7 +147,9 @@ export class MonitoringService {
       d.setUTCDate(start.getUTCDate() + i);
       const dateStr = d.toISOString();
       const data = perDay[dateStr] || { selesai: 0, total: 0 };
-      const persen = data.total > 0 ? 100 : 0;
+      const persen = data.total
+        ? Math.round((data.selesai / data.total) * 100)
+        : 0;
       detail.push({
         hari: hari[d.getUTCDay()],
         tanggal: dateStr,
@@ -541,7 +543,9 @@ export class MonitoringService {
       .map(([id, v]) => {
         const weeks = weekStarts.map((_, i) => {
           const w = v.perWeek[i] || { selesai: 0, total: 0 };
-          const persen = w.total > 0 ? 100 : 0;
+          const persen = w.total
+            ? Math.round((w.selesai / w.total) * 100)
+            : 0;
           return { selesai: w.selesai, total: w.total, persen };
         });
         return { userId: id, nama: v.nama, weeks };


### PR DESCRIPTION
## Summary
- calculate weekly detail percentages in the monitoring service using completed vs total counts
- apply the same percentage fix for the monthly weekly breakdown
- configure Jest path aliases and expand monitoring service tests to cover the corrected logic

## Testing
- npm test -- src/modules/monitoring/__tests__/monitoring.service.spec.ts --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c9426555b88326bb1183c020fbbd09