### PR TITLE
Compose database URL from individual env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
 MYSQL_ROOT_PASSWORD=
 MYSQL_DATABASE=
+# Optional overrides when running the backend outside docker compose
+DATABASE_HOST=localhost
+DATABASE_PORT=3306
+DATABASE_USER=root
+DATABASE_PASSWORD=
+DATABASE_NAME=
 JWT_SECRET=
 PORT=3000
 BACKEND_PORT=3002 # Host port mapping for container port 3000

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SEMAKIN 6502 (Sistem Monitoring Kinerja) adalah aplikasi internal untuk mencata
 
 ## Instalasi
 
-1. Salin berkas contoh `.env` (misalnya dari `api/.env.example`) ke direktori root sebagai `.env`. Minimal isilah `MYSQL_ROOT_PASSWORD` dan `MYSQL_DATABASE`; `docker compose` akan menyusun `DATABASE_URL` backend secara otomatis dari dua nilai tersebut. Atur juga variabel lain seperti `PORT` (port dalam kontainer, bawaan 3000) dan `BACKEND_PORT` (port host yang memetakan port 3000, bawaan 3002) jika diperlukan.
+1. Salin berkas contoh `.env` (misalnya dari `api/.env.example`) ke direktori root sebagai `.env`. Minimal isilah `MYSQL_ROOT_PASSWORD` dan `MYSQL_DATABASE`. `docker compose` akan meneruskan host, port, pengguna, sandi, dan nama database ke backend sehingga URL koneksi dibangun otomatis saat runtime. Jika Anda menjalankan backend tanpa Compose, atur variabel `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER`, `DATABASE_PASSWORD`, dan `DATABASE_NAME` (atau langsung isi `DATABASE_URL`). Atur juga variabel lain seperti `PORT` (port dalam kontainer, bawaan 3000) dan `BACKEND_PORT` (port host yang memetakan port 3000, bawaan 3002) jika diperlukan.
 2. Jalankan `docker-compose up` untuk membangun dan menjalankan seluruh layanan.
 3. Setelah kontainer berjalan, API dapat diakses di `http://localhost:${BACKEND_PORT}` (default `http://localhost:3002`) dan antarmuka web di `http://localhost:5173`. Layanan MySQL hanya dipetakan ke `127.0.0.1:3307`, sehingga tidak dapat diakses dari luar host kecuali Anda mengubah pemetaan port secara eksplisit.
 
@@ -55,7 +55,8 @@ Sistem hanya mengenali keempat peran di atas.
 Beberapa pengaturan aplikasi dibaca dari berkas `.env`.
 
 - `WEB_URL` – URL dasar frontend yang digunakan backend untuk membentuk tautan pada notifikasi.
-- `DATABASE_URL` hanya perlu diisi manual jika backend dijalankan di luar `docker compose`; saat menggunakan Compose, nilainya otomatis dibentuk dari `MYSQL_ROOT_PASSWORD` dan `MYSQL_DATABASE`.
+- `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER`, `DATABASE_PASSWORD`, `DATABASE_NAME` – potongan kredensial database. `docker compose` mengisi nilai ini dari layanan MySQL; saat menjalankan backend secara manual, isi variabel tersebut untuk membentuk koneksi yang sama.
+- `DATABASE_URL` – opsional untuk menimpa seluruh koneksi database (misalnya menggunakan DSN lain). Bila diisi, nilai ini akan mengesampingkan potongan kredensial di atas.
 
 ## Alur Penggunaan Umum
 

--- a/api/src/core/database/prisma.service.ts
+++ b/api/src/core/database/prisma.service.ts
@@ -6,11 +6,49 @@ export class PrismaService
   extends PrismaClient
   implements OnModuleInit, OnModuleDestroy
 {
+  constructor() {
+    const databaseUrl =
+      process.env.DATABASE_URL ?? PrismaService.composeDatabaseUrl();
+
+    if (!process.env.DATABASE_URL) {
+      process.env.DATABASE_URL = databaseUrl;
+    }
+
+    super({
+      datasources: {
+        db: {
+          url: databaseUrl,
+        },
+      },
+    });
+  }
+
   async onModuleInit() {
     await this.$connect();
   }
 
   async onModuleDestroy() {
     await this.$disconnect();
+  }
+
+  private static composeDatabaseUrl(): string {
+    const host = process.env.DATABASE_HOST;
+    const port = process.env.DATABASE_PORT ?? "3306";
+    const user = process.env.DATABASE_USER;
+    const database = process.env.DATABASE_NAME;
+
+    if (!host || !user || !database) {
+      throw new Error(
+        "DATABASE_URL is not set and database connection pieces are incomplete.",
+      );
+    }
+
+    const rawPassword = process.env.DATABASE_PASSWORD ?? "";
+    const passwordSegment = rawPassword
+      ? `:${encodeURIComponent(rawPassword)}`
+      : "";
+    const portSegment = port ? `:${port}` : "";
+
+    return `mysql://${user}${passwordSegment}@${host}${portSegment}/${database}`;
   }
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,7 +28,11 @@ services:
   backend:
     image: ${REGISTRY_USERNAME}/semakin6502-backend:latest
     environment:
-      DATABASE_URL: mysql://root:${MYSQL_ROOT_PASSWORD}@mysql:3306/${MYSQL_DATABASE}
+      DATABASE_HOST: mysql
+      DATABASE_PORT: 3306
+      DATABASE_USER: root
+      DATABASE_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      DATABASE_NAME: ${MYSQL_DATABASE}
       JWT_SECRET: ${JWT_SECRET}
       PORT: ${PORT}
       CORS_ORIGIN: ${CORS_ORIGIN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,11 @@ services:
     build: ./api
     image: semakin6502-backend
     environment:
-      DATABASE_URL: mysql://root:${MYSQL_ROOT_PASSWORD}@mysql:3306/${MYSQL_DATABASE}
+      DATABASE_HOST: mysql
+      DATABASE_PORT: 3306
+      DATABASE_USER: root
+      DATABASE_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      DATABASE_NAME: ${MYSQL_DATABASE}
       JWT_SECRET: ${JWT_SECRET}
       PORT: ${PORT}
       CORS_ORIGIN: ${CORS_ORIGIN}


### PR DESCRIPTION
## Summary
- pass individual MySQL connection environment variables to the backend service in both compose files
- construct the Prisma connection string at runtime from those variables, URL-encoding the password as needed
- document the new database environment variables and how to override the connection when running outside Compose

## Testing
- npm run build
- npm run lint *(fails: existing lint issues in repository)*
- MYSQL_ROOT_PASSWORD='pa@ss:word!' docker compose up *(fails: docker CLI not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5fd214d48326914f9a81118a731a