### PR TITLE
Ensure monitoring roster fills daily and weekly matrices

### DIFF
--- a/web/src/pages/monitoring/MonitoringPage.jsx
+++ b/web/src/pages/monitoring/MonitoringPage.jsx
@@ -119,6 +119,7 @@ export default function MonitoringPage() {
               weekStarts={weekStarts}
               year={year}
               teamId={teamId}
+              teams={teams}
               monthlyMode={monthlyMode}
               onMonthlyModeChange={setMonthlyMode}
               contentRef={contentRef}


### PR DESCRIPTION
## Summary
- inject the monitoring team roster into TabContent so daily and weekly views always know each member
- seed daily results with zero-count detail rows for roster members missing from the API response
- extend the weekly baseline map with roster entries so weekly summaries keep zeroed rows when the backend omits users

## Testing
- npm run lint *(fails: registry returned 403 for eslint-plugin-react-hooks, preventing installation)*

------
https://chatgpt.com/codex/tasks/task_e_68ca753f5b48832683bc593ce1cead08