### PR TITLE
Handle paginated users response

### DIFF
--- a/web/src/pages/users/UsersPage.jsx
+++ b/web/src/pages/users/UsersPage.jsx
@@ -51,10 +51,17 @@ export default function UsersPage() {
     try {
       setLoading(true);
       const res = await axios.get("/users");
-      if (Array.isArray(res.data)) {
-        setUsers(res.data);
+      const payload = res.data;
+      const usersData = Array.isArray(payload)
+        ? payload
+        : Array.isArray(payload?.data)
+          ? payload.data
+          : null;
+
+      if (Array.isArray(usersData)) {
+        setUsers(usersData);
       } else {
-        console.warn("Unexpected users response", res.data);
+        console.warn("Unexpected users response", payload);
         setUsers([]);
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- support paginated responses in the users page by reading data from a payload wrapper
- retain the existing array fallback and warning logging when the response is unexpected

## Testing
- npm run lint --prefix web *(fails: missing eslint-plugin-react-hooks dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc3ca5d3083268fabef9a3345f6e6