### PR TITLE
Add development nginx config without TLS requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SEMAKIN 6502 (Sistem Monitoring Kinerja) adalah aplikasi internal untuk mencata
 1. Salin berkas contoh `.env` (misalnya dari `api/.env.example`) ke direktori root sebagai `.env`. Minimal isilah `MYSQL_ROOT_PASSWORD` dan `MYSQL_DATABASE`. `docker compose` akan meneruskan host, port, pengguna, sandi, dan nama database ke backend sehingga URL koneksi dibangun otomatis saat runtime. Jika Anda menjalankan backend tanpa Compose, atur variabel `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER`, `DATABASE_PASSWORD`, dan `DATABASE_NAME` (atau langsung isi `DATABASE_URL`). Atur juga variabel lain seperti `PORT` (port dalam kontainer, bawaan 3000) dan `BACKEND_PORT` (port host yang memetakan port 3000, bawaan 3002) jika diperlukan.
 2. Jalankan `docker-compose up` untuk membangun dan menjalankan seluruh layanan.
 3. Setelah kontainer berjalan, API dapat diakses di `http://localhost:${BACKEND_PORT}` (default `http://localhost:3002`) dan antarmuka web di `http://localhost:5173`. Layanan MySQL hanya dipetakan ke `127.0.0.1:3307`, sehingga tidak dapat diakses dari luar host kecuali Anda mengubah pemetaan port secara eksplisit.
+   > **Catatan pengembangan lokal:** Layanan frontend sekarang memuat templat Nginx `web/nginx.dev.conf` yang hanya membuka HTTP pada port 80. Anda tidak perlu lagi menyiapkan pasangan sertifikat `tls.crt`/`tls.key` agar perintah `docker compose up frontend` berjalan.
 
 ## Menggunakan dump SQL untuk seeding
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ services:
       - "5173:80"
     environment:
       - BACKEND_PORT=${BACKEND_PORT:-3002}
+    volumes:
+      - ./web/nginx.dev.conf:/etc/nginx/templates/default.conf.template:ro
     depends_on:
       - backend
 

--- a/web/nginx.dev.conf
+++ b/web/nginx.dev.conf
@@ -1,0 +1,46 @@
+server {
+  listen 80 default_server;
+  listen [::]:80 default_server;
+  server_name _;
+  root /usr/share/nginx/html;
+
+  location /api {
+    proxy_pass http://backend:$BACKEND_PORT;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /auth/ {
+    proxy_pass http://backend:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /users/ {
+    proxy_pass http://backend:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /teams/ {
+    proxy_pass http://backend:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location / {
+    try_files $uri /index.html;
+  }
+}


### PR DESCRIPTION
## Summary
- add an HTTP-only nginx template dedicated for local development
- mount the development template in docker-compose so the frontend can run without local TLS certificates
- document the new nginx.dev.conf behavior in the installation guide

## Testing
- `docker compose up frontend` *(fails in CI: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca54e74c883268d8f5a3a5b27e3db