### PR TITLE
Enforce case-insensitive uniqueness for team names

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Berkas `semakin_6502.sql` berisi struktur dan data awal aplikasi. Berkas ini bis
 
 File dump tetap tersedia di folder root untuk referensi.
 
+## Pembersihan Data Tim Duplikat
+
+Sebelum menjalankan migrasi yang menambahkan constraint unik _case-insensitive_ pada kolom `nama_tim`, bersihkan terlebih dahulu data lama yang mungkin sudah memiliki duplikasi. Jalankan kueri pada berkas [`docs/cleanup-duplicate-teams.sql`](docs/cleanup-duplicate-teams.sql) terhadap database produksi maupun pengembangan:
+
+1. Periksa terlebih dahulu apakah ada duplikasi nama tim (diabaikan kapitalisasinya).
+2. Jika terdeteksi, hapus entri duplikat dan pertahankan baris dengan ULID terendah.
+
+Setelah memastikan data bersih, lanjutkan proses migrasi Prisma seperti biasa.
+
 ## Deployment
 
 1. Pastikan server sudah login ke registry yang menyimpan image, misalnya: `docker login ghcr.io`.

--- a/api/dist/src/teams/teams.service.js
+++ b/api/dist/src/teams/teams.service.js
@@ -49,10 +49,33 @@ let TeamsService = class TeamsService {
             throw new common_1.NotFoundException("not found");
         return team;
     }
-    create(data) {
+    async create(data) {
+        const namaTim = data?.namaTim;
+        if (namaTim) {
+            const existing = await this.prisma.team.findFirst({
+                where: {
+                    namaTim,
+                },
+            });
+            if (existing) {
+                throw new common_1.ConflictException("Nama tim sudah ada");
+            }
+        }
         return this.prisma.team.create({ data: { id: (0, ulid_1.ulid)(), ...data } });
     }
-    update(id, data) {
+    async update(id, data) {
+        const namaTim = data?.namaTim;
+        if (namaTim) {
+            const existing = await this.prisma.team.findFirst({
+                where: {
+                    namaTim,
+                    id: { not: id },
+                },
+            });
+            if (existing) {
+                throw new common_1.ConflictException("Nama tim sudah ada");
+            }
+        }
         return this.prisma.team.update({ where: { id }, data });
     }
     remove(id) {

--- a/api/dist/teams/teams.service.js
+++ b/api/dist/teams/teams.service.js
@@ -49,10 +49,33 @@ let TeamsService = class TeamsService {
             throw new common_1.NotFoundException("not found");
         return team;
     }
-    create(data) {
+    async create(data) {
+        const namaTim = data?.namaTim;
+        if (namaTim) {
+            const existing = await this.prisma.team.findFirst({
+                where: {
+                    namaTim,
+                },
+            });
+            if (existing) {
+                throw new common_1.ConflictException("Nama tim sudah ada");
+            }
+        }
         return this.prisma.team.create({ data: { id: (0, ulid_1.ulid)(), ...data } });
     }
-    update(id, data) {
+    async update(id, data) {
+        const namaTim = data?.namaTim;
+        if (namaTim) {
+            const existing = await this.prisma.team.findFirst({
+                where: {
+                    namaTim,
+                    id: { not: id },
+                },
+            });
+            if (existing) {
+                throw new common_1.ConflictException("Nama tim sudah ada");
+            }
+        }
         return this.prisma.team.update({ where: { id }, data });
     }
     remove(id) {

--- a/api/prisma/migrations/20250901000000_add_team_namatim_unique_ci/migration.sql
+++ b/api/prisma/migrations/20250901000000_add_team_namatim_unique_ci/migration.sql
@@ -1,0 +1,5 @@
+-- Ensure namaTim uses a case-insensitive collation and add a unique constraint
+ALTER TABLE `Team`
+  MODIFY `namaTim` VARCHAR(191) NOT NULL COLLATE utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX `Team_namaTim_key` ON `Team`(`namaTim`);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -30,6 +30,8 @@ model Team {
   members          Member[]
   masterKegiatan   MasterKegiatan[]
   kegiatanTambahan KegiatanTambahan[]
+
+  @@unique([namaTim], map: "Team_namaTim_key")
 }
 
 model Member {

--- a/api/src/modules/teams/teams.service.ts
+++ b/api/src/modules/teams/teams.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from "@nestjs/common";
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
 import { ulid } from "ulid";
 import { PrismaService } from "@core/database/prisma.service";
 
@@ -41,11 +45,36 @@ export class TeamsService {
     return team;
   }
 
-  create(data: any) {
+  async create(data: any) {
+    const namaTim = data?.namaTim;
+    if (namaTim) {
+      const existing = await this.prisma.team.findFirst({
+        where: {
+          namaTim,
+        },
+      });
+      if (existing) {
+        throw new ConflictException("Nama tim sudah ada");
+      }
+    }
+
     return this.prisma.team.create({ data: { id: ulid(), ...data } });
   }
 
-  update(id: string, data: any) {
+  async update(id: string, data: any) {
+    const namaTim = data?.namaTim;
+    if (namaTim) {
+      const existing = await this.prisma.team.findFirst({
+        where: {
+          namaTim,
+          id: { not: id },
+        },
+      });
+      if (existing) {
+        throw new ConflictException("Nama tim sudah ada");
+      }
+    }
+
     return this.prisma.team.update({ where: { id }, data });
   }
 

--- a/docs/cleanup-duplicate-teams.sql
+++ b/docs/cleanup-duplicate-teams.sql
@@ -1,0 +1,16 @@
+-- Detect duplicate team names ignoring case before applying the unique constraint
+SELECT LOWER(nama_tim) AS normalized_name,
+       COUNT(*) AS duplicate_count,
+       GROUP_CONCAT(id ORDER BY id) AS team_ids
+FROM Team
+GROUP BY LOWER(nama_tim)
+HAVING COUNT(*) > 1;
+
+-- Remove duplicated teams while keeping the lowest ULID for each normalized name
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY LOWER(nama_tim) ORDER BY id) AS rn
+  FROM Team
+)
+DELETE FROM Team
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);

--- a/web/src/pages/teams/TeamsPage.jsx
+++ b/web/src/pages/teams/TeamsPage.jsx
@@ -94,6 +94,11 @@ export default function TeamsPage() {
       fetchTeams();
       showSuccess("Berhasil", "Tim disimpan");
     } catch (err) {
+      if (axios.isAxiosError(err) && err.response?.status === 409) {
+        const message = err.response?.data?.message || "Nama tim sudah ada";
+        showWarning("Nama tim sudah ada", message);
+        return;
+      }
       handleAxiosError(err, "Gagal menyimpan tim");
     }
   };


### PR DESCRIPTION
## Summary
- add a case-insensitive unique constraint on `Team.namaTim`, ship a Prisma migration, and provide a SQL helper to clean duplicate legacy rows
- guard the team service against duplicate names so API responses return HTTP 409 conflicts and surface a friendly alert in the team management form
- document the duplicate-cleanup workflow so deployments can tidy existing data before applying the migration

## Testing
- npm run build (api)
- npm --workspace web run build *(fails: vite not found in PATH in this environment)*
- DATABASE_URL="mysql://root@127.0.0.1:3307/semakin_6502" npx prisma migrate deploy *(fails: database unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccaa81433083268a5253a920e44bb8