### PR TITLE
Move Team unique index creation into cleanup migration

### DIFF
--- a/api/prisma/migrations/20250901000000_add_team_namatim_unique_ci/migration.sql
+++ b/api/prisma/migrations/20250901000000_add_team_namatim_unique_ci/migration.sql
@@ -1,5 +1,3 @@
 -- Ensure namaTim uses a case-insensitive collation and add a unique constraint
 ALTER TABLE `Team`
   MODIFY `namaTim` VARCHAR(191) NOT NULL COLLATE utf8mb4_unicode_ci;
-
-CREATE UNIQUE INDEX `Team_namaTim_key` ON `Team`(`namaTim`);


### PR DESCRIPTION
## Summary
- remove the CREATE UNIQUE INDEX statement from the 20250901000000_add_team_namatim_unique_ci migration
- rely on the cleanup migration that drops duplicates to recreate the Team_namaTim_key index after the data is deduplicated

## Testing
- DATABASE_URL="mysql://root:root@localhost:3307/semakin_6502" npx prisma migrate deploy *(fails: MySQL not running in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb6091e748326b786d40859dc83ff