### PR TITLE
Increase MySQL healthcheck tolerance

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,10 +13,10 @@ services:
       - ./docker/mysql/semakin_6502.sql:/docker-entrypoint-initdb.d/semakin_6502.sql:ro
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 10s
+      interval: 15s
       timeout: 5s
-      retries: 5
-      start_period: 20s
+      retries: 10
+      start_period: 90s
 
   redis:
     image: redis:7-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,10 @@ services:
       - ./docker/mysql/semakin_6502.sql:/docker-entrypoint-initdb.d/semakin_6502.sql:ro
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 10s
+      interval: 15s
       timeout: 5s
-      retries: 5
-      start_period: 20s
+      retries: 10
+      start_period: 90s
 
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
## Summary
- increase the MySQL healthcheck start period to 90 seconds and retries to 10 in both compose configurations
- lengthen the healthcheck interval to 15 seconds so the retry window covers InnoDB startup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0193ce1f48326b24b4f4f994a7cab