### PR TITLE
Fix API proxy pass path forwarding

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -21,7 +21,7 @@ server {
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
   location /api {
-    proxy_pass http://backend:3000;
+    proxy_pass http://backend:3000/;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/web/nginx.dev.conf
+++ b/web/nginx.dev.conf
@@ -5,7 +5,7 @@ server {
   root /usr/share/nginx/html;
 
   location /api {
-    proxy_pass http://backend:3000;
+    proxy_pass http://backend:3000/;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- ensure the nginx API proxy forwards nested paths by using a trailing slash on the backend upstream
- apply the same proxy adjustment to the development nginx template

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d02628399c8326a4452e2431fb8943