### PR TITLE
Adjust pimpinan views for assignments

### DIFF
--- a/web/src/pages/penugasan/PenugasanPage.jsx
+++ b/web/src/pages/penugasan/PenugasanPage.jsx
@@ -188,11 +188,14 @@ export default function PenugasanPage() {
       if (filterMinggu) params.minggu = filterMinggu;
       if (viewTab === "dariSaya") params.creator = user?.id;
       const penugasanReq = axios.get("/penugasan", { params });
-      const teamsReq = axios.get("/teams").then(async (res) => {
-        if (Array.isArray(res.data) && res.data.length === 0)
-          return axios.get("/teams/member");
-        return res;
-      });
+      const teamsReq =
+        user?.role === ROLES.PIMPINAN
+          ? axios.get("/teams/all")
+          : axios.get("/teams").then(async (res) => {
+              if (Array.isArray(res.data) && res.data.length === 0)
+                return axios.get("/teams/member");
+              return res;
+            });
       const [pRes, tRes] = await Promise.all([penugasanReq, teamsReq]);
 
       let usersData;

--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -225,10 +225,6 @@ export default function TugasTambahanPage() {
     }
   };
 
-  const openDetail = (id) => {
-    navigate(`/tugas-tambahan/${id}`);
-  };
-
   const filteredItems = useMemo(() => {
     return items.filter((item) => {
       const text = `${item.nama} ${
@@ -258,33 +254,63 @@ export default function TugasTambahanPage() {
 
   // No manual pagination; pass full filteredItems to DataTable
 
-  const columns = useMemo(
-    () => [
+  const columns = useMemo(() => {
+    const base = [
       {
         Header: "No",
         accessor: (_row, i) => i + 1,
         disableFilters: true,
       },
       { Header: "Kegiatan", accessor: "nama", disableFilters: true },
-      { Header: "Deskripsi", accessor: (row) => row.deskripsi || "-", disableFilters: true },
-      { Header: "Tim", accessor: (row) => row.kegiatan.team?.namaTim || "-", disableFilters: true },
-      { Header: "Minggu", accessor: (row) => getWeekOfMonth(new Date(row.tanggal)), disableFilters: true },
-      { Header: "Bulan", accessor: (row) => {
+      {
+        Header: "Deskripsi",
+        accessor: (row) => row.deskripsi || "-",
+        disableFilters: true,
+      },
+    ];
+
+    if (user?.role === ROLES.PIMPINAN) {
+      base.push({
+        Header: "Pegawai",
+        accessor: (row) => row.user?.nama || "-",
+        disableFilters: true,
+      });
+    }
+
+    base.push(
+      {
+        Header: "Tim",
+        accessor: (row) => row.kegiatan.team?.namaTim || "-",
+        disableFilters: true,
+      },
+      {
+        Header: "Minggu",
+        accessor: (row) => getWeekOfMonth(new Date(row.tanggal)),
+        disableFilters: true,
+      },
+      {
+        Header: "Bulan",
+        accessor: (row) => {
           const d = new Date(row.tanggal);
           return `${months[d.getMonth()]} ${d.getFullYear()}`;
-        }, disableFilters: true },
+        },
+        disableFilters: true,
+      },
       {
         Header: "Status",
         accessor: "status",
         Cell: ({ row }) => <StatusBadge status={row.original.status} />,
         disableFilters: true,
-      },
-      {
+      }
+    );
+
+    if (user?.role !== ROLES.PIMPINAN) {
+      base.push({
         Header: "Aksi",
         accessor: "id",
         Cell: ({ row }) => (
           <Button
-            onClick={() => openDetail(row.original.id)}
+            onClick={() => navigate(`/tugas-tambahan/${row.original.id}`)}
             variant="icon"
             icon
             aria-label="Detail"
@@ -293,10 +319,11 @@ export default function TugasTambahanPage() {
           </Button>
         ),
         disableFilters: true,
-      },
-    ],
-    [user?.role]
-  );
+      });
+    }
+
+    return base;
+  }, [navigate, user?.role]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- fetch full team list for pimpinan users so the Tugas Mingguan team filter includes all teams
- show Pegawai information and hide the action column for pimpinan on the Tugas Tambahan table

## Testing
- npm run lint --workspace web *(fails: missing eslint dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f11e1a6083269d10bcf950d3323b