### PR TITLE
Adjust tugas tambahan columns order

### DIFF
--- a/web/src/pages/tambahan/TugasTambahanPage.jsx
+++ b/web/src/pages/tambahan/TugasTambahanPage.jsx
@@ -261,15 +261,9 @@ export default function TugasTambahanPage() {
         accessor: (_row, i) => i + 1,
         disableFilters: true,
       },
-      { Header: "Kegiatan", accessor: "nama", disableFilters: true },
-      {
-        Header: "Deskripsi",
-        accessor: (row) => row.deskripsi || "-",
-        disableFilters: true,
-      },
     ];
 
-    if (user?.role === ROLES.PIMPINAN) {
+    if ([ROLES.ADMIN, ROLES.PIMPINAN].includes(user?.role)) {
       base.push({
         Header: "Pegawai",
         accessor: (row) => row.user?.nama || "-",
@@ -278,6 +272,12 @@ export default function TugasTambahanPage() {
     }
 
     base.push(
+      { Header: "Kegiatan", accessor: "nama", disableFilters: true },
+      {
+        Header: "Deskripsi",
+        accessor: (row) => row.deskripsi || "-",
+        disableFilters: true,
+      },
       {
         Header: "Tim",
         accessor: (row) => row.kegiatan.team?.namaTim || "-",


### PR DESCRIPTION
## Summary
- insert the Pegawai column immediately after the No column for admin and pimpinan views
- reorder the remaining tugas tambahan table columns to keep Kegiatan through Status together and leave actions last

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d5e34f4dfc832691b98145ea482c68