### PR TITLE
Add BPS Provinsi user to Prisma seed data

### DIFF
--- a/api/dist/prisma/seed.js
+++ b/api/dist/prisma/seed.js
@@ -28,6 +28,14 @@ const baseUsers = [
         role: "Pimpinan",
     },
     {
+        nama: "BPS Provinsi",
+        email: "bpsprovinsi@bps.go.id",
+        username: "bpsprovinsi",
+        password: "password",
+        team: "Pimpinan",
+        role: "Pimpinan",
+    },
+    {
         nama: "Warsidi",
         email: "warsidi2@bps.go.id",
         username: "warsidi2",

--- a/api/dist/prisma/user-phones.json
+++ b/api/dist/prisma/user-phones.json
@@ -1,5 +1,6 @@
 {
     "Yuda Agus Irianto": "6281253949680",
+    "BPS Provinsi": "6281255550000",
     "Warsidi": "6281253216991",
     "Muhamadsyah": "6285294404060",
     "Dwi Prasetyono": "6282331466449",

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -29,6 +29,14 @@ const baseUsers = [
     role: "Pimpinan",
   },
   {
+    nama: "BPS Provinsi",
+    email: "bpsprovinsi@bps.go.id",
+    username: "bpsprovinsi",
+    password: "password",
+    team: "Pimpinan",
+    role: "Pimpinan",
+  },
+  {
     nama: "Warsidi",
     email: "warsidi2@bps.go.id",
     username: "warsidi2",

--- a/api/prisma/user-phones.json
+++ b/api/prisma/user-phones.json
@@ -1,5 +1,6 @@
 {
   "Yuda Agus Irianto": "6281253949680",
+  "BPS Provinsi": "6281255550000",
   "Warsidi": "6281253216991",
   "Muhamadsyah": "6285294404060",
   "Dwi Prasetyono": "6282331466449",


### PR DESCRIPTION
## Summary
- add a BPS Provinsi record to the base user seed list with Pimpinan privileges
- register the corresponding BPS Provinsi phone number alongside existing seed data

## Testing
- npm run build --workspace api
- npm run seed --workspace api *(fails: Can't reach database server at `mysql:3306`)*

------
https://chatgpt.com/codex/tasks/task_e_68d5faeee3f48326af9dba0777d09e81